### PR TITLE
Adds Execution Summaries for each job

### DIFF
--- a/indexer/src/actions/dune/index.ts
+++ b/indexer/src/actions/dune/index.ts
@@ -13,7 +13,11 @@ import {
   DailyContractUsageRow,
   DailyContractUsageResponse,
 } from "./daily-contract-usage/client.js";
-import { IArtifactGroup, ICollector } from "../../scheduler/types.js";
+import {
+  IArtifactGroup,
+  IArtifactGroupCommitmentProducer,
+  ICollector,
+} from "../../scheduler/types.js";
 import _ from "lodash";
 import { Range } from "../../utils/ranges.js";
 import {
@@ -145,7 +149,7 @@ export class DailyContractUsageCollector implements ICollector {
   async collect(
     group: IArtifactGroup,
     range: Range,
-    commitArtifact: (artifact: Artifact) => Promise<void>,
+    committer: IArtifactGroupCommitmentProducer,
   ): Promise<void> {
     logger.info("loading contract usage data");
     const knownUserAddresses = await this.loadKnownUserAddresses(range);
@@ -191,7 +195,7 @@ export class DailyContractUsageCollector implements ICollector {
           await Promise.all(eventPromises);
           logger.debug(`events for ${contract.name} recorded`);
 
-          await commitArtifact(contract);
+          committer.commit(contract);
         },
       );
 

--- a/indexer/src/actions/github/fetch/common.ts
+++ b/indexer/src/actions/github/fetch/common.ts
@@ -6,7 +6,11 @@ import {
   ArtifactType,
   ArtifactNamespace,
 } from "../../../db/orm-entities.js";
-import { IArtifactGroup, CollectResponse } from "../../../scheduler/types.js";
+import {
+  IArtifactGroup,
+  CollectResponse,
+  IArtifactGroupCommitmentProducer,
+} from "../../../scheduler/types.js";
 import { Range } from "../../../utils/ranges.js";
 import { GenericError } from "../../../common/errors.js";
 import { IEventRecorder } from "../../../recorder/types.js";
@@ -110,7 +114,7 @@ export class GithubByProjectBaseCollector extends ProjectArtifactsCollector {
   collect(
     _group: IArtifactGroup<Project>,
     _range: Range,
-    _commitArtifact: (artifact: Artifact | Artifact[]) => Promise<void>,
+    _committer: IArtifactGroupCommitmentProducer,
   ): Promise<CollectResponse> {
     throw new Error("Not implemented");
   }

--- a/indexer/src/actions/github/fetch/repo-followers.ts
+++ b/indexer/src/actions/github/fetch/repo-followers.ts
@@ -26,7 +26,10 @@ import {
 import { Repository } from "typeorm";
 import { TimeSeriesCacheWrapper } from "../../../cacher/time-series.js";
 import _ from "lodash";
-import { IArtifactGroup } from "../../../scheduler/types.js";
+import {
+  IArtifactGroup,
+  IArtifactGroupCommitmentProducer,
+} from "../../../scheduler/types.js";
 import {
   Range,
   doRangesIntersect,
@@ -208,7 +211,7 @@ export class GithubFollowingCollector extends GithubByProjectBaseCollector {
   async collect(
     group: IArtifactGroup<Project>,
     range: Range,
-    commitArtifact: (artifact: Artifact | Artifact[]) => Promise<void>,
+    committer: IArtifactGroupCommitmentProducer,
   ): Promise<void> {
     const project = await group.meta();
     const artifacts = await group.artifacts();
@@ -245,7 +248,7 @@ export class GithubFollowingCollector extends GithubByProjectBaseCollector {
           ...(await this.recordStarHistoryForRepo(repo, locator, range)),
         );
       }
-      await Promise.all([...recordPromises, commitArtifact(repo)]);
+      committer.commit(repo).withPromises(recordPromises);
     }
   }
 

--- a/indexer/src/cli.ts
+++ b/indexer/src/cli.ts
@@ -185,10 +185,23 @@ const cli = yargs(hideBin(process.argv))
           async (args) => {
             const scheduler = await configure(args);
 
-            await scheduler.executeForRange(args.collector, {
-              startDate: args.startDate,
-              endDate: args.endDate,
-            });
+            const execSummary = await scheduler.executeForRange(
+              args.collector,
+              {
+                startDate: args.startDate,
+                endDate: args.endDate,
+              },
+            );
+
+            logger.info(`--------------Completed manual run---------------`);
+            logger.info("   Collection Stats:");
+            logger.info(`       ${execSummary.errors.length} errors`);
+            logger.info(
+              `       ${execSummary.artifactSummaries.length} artifacts committed`,
+            );
+            if (execSummary.errors.length > 0) {
+              process.exit(1);
+            }
           },
         )
         .command<SchedulerWorkerArgs>(
@@ -208,11 +221,17 @@ const cli = yargs(hideBin(process.argv))
           },
           async (args) => {
             const scheduler = await configure(args);
-            const errors = await scheduler.runWorker(
+            const execSummary = await scheduler.runWorker(
               args.group,
               args.resumeWithLock,
             );
-            if (errors.length > 0) {
+            logger.info(`--------------Completed job---------------`);
+            logger.info("   Collection Stats:");
+            logger.info(`       ${execSummary.errors.length} errors`);
+            logger.info(
+              `       ${execSummary.artifactSummaries.length} artifacts committed`,
+            );
+            if (execSummary.errors.length > 0) {
               process.exit(1);
             }
           },

--- a/indexer/src/db/events.test.ts
+++ b/indexer/src/db/events.test.ts
@@ -94,8 +94,6 @@ withDbDescribe("EventRepository", () => {
       }),
     );
 
-    console.log("updating");
-
     const updatePartials: BulkUpdateBySourceIDEvent[] = [
       {
         time: createPartials[0].time,

--- a/indexer/src/recorder/group.ts
+++ b/indexer/src/recorder/group.ts
@@ -1,0 +1,125 @@
+import { EventEmitter } from "node:events";
+import {
+  IEventRecorder,
+  IEventGroupRecorder,
+  IncompleteEvent,
+  RecordResponse,
+  EventGroupRecorderCallback,
+  IncompleteArtifact,
+} from "./types.js";
+import { AsyncResults } from "../utils/async-results.js";
+import { collectAsyncResults } from "../utils/async-results.js";
+
+export type EventGrouperFn<T> = (event: IncompleteEvent) => T;
+export type GroupObjToStrFn<T> = (group: T) => string;
+
+/**
+ * Allows for organizing a large set of pending events for specific groups
+ * (usually artifacts)
+ */
+export class EventGroupRecorder<T> implements IEventGroupRecorder<T> {
+  private groupRecordPromises: Record<string, Promise<RecordResponse>[]>;
+  private grouperFn: EventGrouperFn<T>;
+  private groupToStrFn: GroupObjToStrFn<T>;
+  private emitter: EventEmitter;
+  private recorder: IEventRecorder;
+  private committed: boolean;
+  private listeningIds: Record<string, boolean>;
+
+  constructor(
+    recorder: IEventRecorder,
+    grouperFn: EventGrouperFn<T>,
+    groupObjToStrFn: GroupObjToStrFn<T>,
+  ) {
+    this.groupRecordPromises = {};
+    this.grouperFn = grouperFn;
+    this.groupToStrFn = groupObjToStrFn;
+    this.emitter = new EventEmitter();
+    this.recorder = recorder;
+    this.listeningIds = {};
+
+    this.committed = false;
+  }
+
+  commit(): void {
+    if (this.committed) {
+      return;
+    }
+    // This should only run once.
+    this.committed = true;
+
+    setImmediate(() => {
+      for (const groupId in this.groupRecordPromises) {
+        // Catch errors so we can record all of them
+        this.commitId(groupId);
+      }
+    });
+  }
+
+  async wait(group: T): Promise<AsyncResults<string>> {
+    return new Promise((resolve) => {
+      const cb: EventGroupRecorderCallback<string> = (results) => {
+        resolve(results);
+        this.removeGroupCallback(group, cb);
+      };
+      this.addGroupCallback(group, cb);
+    });
+  }
+
+  record(event: IncompleteEvent): void {
+    const group = this.grouperFn(event);
+    const promises = this.getGroupRecordPromises(group);
+    promises.push(this.recorder.record(event));
+  }
+
+  private commitId(id: string): void {
+    const promises = this.groupRecordPromises[id] || [];
+    collectAsyncResults(promises)
+      .then((result) => {
+        this.emitter.emit(id, result);
+      })
+      .catch((err) => {
+        // This is a final catch all here just in case. This shouldn't
+        // actually have to happen unless something is really wrong.
+        this.emitter.emit(id, {
+          errors: [err],
+          success: [],
+        });
+      });
+  }
+
+  private getGroupRecordPromises(group: T): Promise<RecordResponse>[] {
+    const id = this.groupToStrFn(group);
+    if (!this.groupRecordPromises[id]) {
+      this.groupRecordPromises[id] = [];
+    }
+    return this.groupRecordPromises[id];
+  }
+
+  private addGroupCallback(
+    group: T,
+    cb: EventGroupRecorderCallback<string>,
+  ): void {
+    const id = this.groupToStrFn(group);
+    this.listeningIds[id] = true;
+    this.emitter.addListener(id, cb);
+  }
+
+  private removeGroupCallback(
+    group: T,
+    cb: EventGroupRecorderCallback<string>,
+  ): void {
+    const id = this.groupToStrFn(group);
+    delete this.listeningIds[id];
+    this.emitter.removeListener(id, cb);
+  }
+}
+
+export class ArtifactGroupRecorder extends EventGroupRecorder<IncompleteArtifact> {
+  constructor(recorder: IEventRecorder) {
+    const artifactToString = (a: IncompleteArtifact) => {
+      return `${a.name}:${a.namespace}:${a.type}`;
+    };
+    super(recorder, (event) => event.to, artifactToString);
+  }
+}

--- a/indexer/src/recorder/recorder.ts
+++ b/indexer/src/recorder/recorder.ts
@@ -32,13 +32,12 @@ import { EventEmitter } from "node:events";
 import { randomUUID } from "node:crypto";
 import { DateTime } from "luxon";
 import { EventRepository } from "../db/events.js";
+import { RecordResponse } from "./types.js";
 
 export interface BatchEventRecorderOptions {
   maxBatchSize: number;
   timeoutMs: number;
 }
-
-export type RecordResponse = string;
 
 class EventTypeStorage<T> {
   private queue: UniqueArray<IncompleteEvent>;

--- a/indexer/src/scheduler/common.ts
+++ b/indexer/src/scheduler/common.ts
@@ -1,7 +1,12 @@
 import { FindOptionsWhere, Repository } from "typeorm";
 import { Artifact, Project } from "../db/orm-entities.js";
 import { Range } from "../utils/ranges.js";
-import { CollectResponse, IArtifactGroup, ICollector } from "./types.js";
+import {
+  CollectResponse,
+  IArtifactGroupCommitmentProducer,
+  IArtifactGroup,
+  ICollector,
+} from "./types.js";
 import { TimeSeriesCacheWrapper } from "../cacher/time-series.js";
 import { IEventRecorder } from "../recorder/types.js";
 
@@ -80,7 +85,7 @@ export class ProjectArtifactsCollector implements ICollector {
   collect(
     _group: IArtifactGroup<Project>,
     _range: Range,
-    _commitArtifact: (artifact: Artifact | Artifact[]) => Promise<void>,
+    _committer: IArtifactGroupCommitmentProducer,
   ): Promise<CollectResponse> {
     throw new Error("Not implemented");
   }

--- a/indexer/src/scheduler/pointers.test.ts
+++ b/indexer/src/scheduler/pointers.test.ts
@@ -63,11 +63,9 @@ withDbDescribe("EventPointerManager", () => {
       const expectedMatches = expectedPointerIndexes.map(
         (n) => eventPointers[n],
       );
-      const result = await manager.getAllEventPointersForRange(
-        range,
-        [artifact0],
-        "test",
-      );
+      const result = await manager.getAllEventPointersForRange("test", range, [
+        artifact0,
+      ]);
       expect(result.length).toBe(expectedMatches.length);
       const sortedResultIds = result.map((e) => e.id.valueOf());
       const sortedExpectedIds = expectedMatches.map((e) => e.id.valueOf());
@@ -121,20 +119,18 @@ withDbDescribe("EventPointerManager", () => {
 
   it("should merge pointers together", async () => {
     const range = rangeFromISO("2022-01-15T00:00:00Z", "2023-03-02T00:00:00Z");
-    await manager.commitArtifactForRange(range, artifact0, "test");
+    await manager.commitArtifactForRange("test", range, artifact0);
 
     // Check that there's only a single pointer left
-    const result = await manager.getAllEventPointersForRange(
-      range,
-      [artifact0],
-      "test",
-    );
+    const result = await manager.getAllEventPointersForRange("test", range, [
+      artifact0,
+    ]);
     expect(result.length).toBe(1);
   });
 
   it("should merge pointers together when they do not intersect", async () => {
     const range = rangeFromISO("2022-04-01T00:00:00Z", "2023-05-01T00:00:00Z");
-    await manager.commitArtifactForRange(range, artifact0, "test");
+    await manager.commitArtifactForRange("test", range, artifact0);
 
     // Check that there's only a single pointer left
     const totalRange = rangeFromISO(
@@ -142,9 +138,9 @@ withDbDescribe("EventPointerManager", () => {
       "2023-05-01T00:00:00Z",
     );
     const result = await manager.getAllEventPointersForRange(
+      "test",
       totalRange,
       [artifact0],
-      "test",
     );
     expect(result.length).toBe(1);
   });

--- a/indexer/src/scheduler/pointers.ts
+++ b/indexer/src/scheduler/pointers.ts
@@ -16,8 +16,21 @@ export const DefaultEventPointerManagerOptions = {
   batchSize: 5000,
 };
 
+export interface IEventPointerManager {
+  getAllEventPointersForRange(
+    collectorName: string,
+    range: Range,
+    artifacts: Artifact[],
+  ): Promise<EventPointer[]>;
+  commitArtifactForRange(
+    collectorName: string,
+    range: Range,
+    artifact: Artifact,
+  ): Promise<void>;
+}
+
 // Event pointer management
-export class EventPointerManager {
+export class EventPointerManager implements IEventPointerManager {
   private eventPointerRepository: IEventPointerRepository;
   private options: EventPointerManagerOptions;
   private dataSource: DataSource;
@@ -35,9 +48,9 @@ export class EventPointerManager {
   // Find all matching event pointers for the given artifacts and the collector
   // name
   async getAllEventPointersForRange(
+    collector: string,
     range: Range,
     artifacts: Artifact[],
-    collector: string,
   ): Promise<EventPointer[]> {
     const batches = await asyncBatch(
       artifacts,
@@ -63,17 +76,17 @@ export class EventPointerManager {
   }
 
   async commitArtifactForRange(
+    collector: string,
     range: Range,
     artifact: Artifact,
-    collector: string,
   ) {
     logger.debug(`committing this artifact[${artifact.id}]`);
 
     // Find any old event pointer that's connectable to this one if it exists. Update it.
     const intersectingPointers = await this.getAllEventPointersForRange(
+      collector,
       range,
       [artifact],
-      collector,
     );
 
     if (intersectingPointers.length === 0) {

--- a/indexer/src/utils/async-results.test.ts
+++ b/indexer/src/utils/async-results.test.ts
@@ -1,0 +1,19 @@
+import { collectAsyncResults } from "./async-results.js";
+
+describe("reducePromises", () => {
+  it("should reduce promises", async () => {
+    const err2 = new Error("two");
+    const err4 = new Error("four");
+    const results = await collectAsyncResults<string>([
+      Promise.resolve("one"),
+      Promise.reject(err2),
+      Promise.resolve("three"),
+      Promise.reject(err4),
+    ]);
+
+    expect(results.errors.length).toEqual(2);
+    expect(results.success.length).toEqual(2);
+    expect(results.success).toEqual(["one", "three"]);
+    expect(results.errors).toEqual([err2, err4]);
+  });
+});

--- a/indexer/src/utils/async-results.ts
+++ b/indexer/src/utils/async-results.ts
@@ -1,0 +1,41 @@
+// Tools for dealing with async coordination
+
+export type PossiblyError = unknown | undefined | null;
+export type AsyncResults<T> = {
+  success: T[];
+  errors: PossiblyError[];
+};
+
+export function collectAsyncResults<T>(
+  promises: Promise<T>[],
+): Promise<AsyncResults<T>> {
+  const caughtPromises: Promise<AsyncResults<T>>[] = promises.map((p) => {
+    return p
+      .then((s: T) => {
+        return {
+          success: [s],
+          errors: [],
+        };
+      })
+      .catch((err) => {
+        return {
+          success: [],
+          errors: [err],
+        };
+      });
+  });
+
+  return Promise.all(caughtPromises).then((results) => {
+    return results.reduce<AsyncResults<T>>(
+      (acc, result) => {
+        acc.errors.push(...result.errors);
+        acc.success.push(...result.success);
+        return acc;
+      },
+      {
+        errors: [],
+        success: [],
+      },
+    );
+  });
+}


### PR DESCRIPTION
This is a fairly big one: 

* Adds higher granularity responses for each job
    * Attempts to structure so we can report failures at finer grained points.
* Adds grouping of recordings
    * This is useful when the events are streamed in a way that is unordered and ungrouped. So we can commit a single artifact at the end of the `collect` step, but only if all of it's dependent events are properly recorded.
* Fixes `github-followers` collector. Now runs to completion
* Fixes `github-issues` collector. Now runs to completion