### PR TITLE
Event index should be unique by type X sourceId

### DIFF
--- a/indexer/src/db/migration/1696805280733-fix-event-source-id-index.ts
+++ b/indexer/src/db/migration/1696805280733-fix-event-source-id-index.ts
@@ -1,0 +1,23 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class FixEventSourceIdIndex1696805280733 implements MigrationInterface {
+  name = "FixEventSourceIdIndex1696805280733";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_8eb34e6d33033e17e91776c1c2"`,
+    );
+    await queryRunner.query(
+      `CREATE UNIQUE INDEX "IDX_7ea8a55b1ae8ec8d4a5e0af3e5" ON "event" ("type", "sourceId", "time") `,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_7ea8a55b1ae8ec8d4a5e0af3e5"`,
+    );
+    await queryRunner.query(
+      `CREATE UNIQUE INDEX "IDX_8eb34e6d33033e17e91776c1c2" ON "event" ("sourceId", "time") `,
+    );
+  }
+}

--- a/indexer/src/db/orm-entities.ts
+++ b/indexer/src/db/orm-entities.ts
@@ -184,7 +184,7 @@ export class Artifact extends Base<"ArtifactId"> {
 @Entity()
 @Index(["time"])
 @Index(["id", "time"], { unique: true })
-@Index(["sourceId", "time"], { unique: true })
+@Index(["type", "sourceId", "time"], { unique: true })
 export class Event {
   @PrimaryColumn("integer", { generated: "increment" })
   id: Brand<number, "EventId">;

--- a/indexer/src/recorder/recorder.ts
+++ b/indexer/src/recorder/recorder.ts
@@ -587,7 +587,6 @@ export class BatchEventRecorder implements IEventRecorder {
     // Write all the new artifacts
     await asyncBatch(newArtifacts, this.options.maxBatchSize, async (batch) => {
       logger.debug("writing new artifacts");
-      //console.log(batch);
       const artifacts = Artifact.create(batch);
       return this.artifactRepository.insert(artifacts);
     });
@@ -620,7 +619,7 @@ export class BatchEventRecorder implements IEventRecorder {
         } catch (err) {
           if (err instanceof QueryFailedError) {
             if (err.message.indexOf("duplicate") !== -1) {
-              logger.debug("attempted to write a duplicate event. skipping");
+              logger.debug("attempted to insert a duplicate event. skipping");
             }
           }
           this.notifyFailure(eventTypeStorage, events);
@@ -643,7 +642,9 @@ export class BatchEventRecorder implements IEventRecorder {
         } catch (err) {
           if (err instanceof QueryFailedError) {
             if (err.message.indexOf("duplicate") !== -1) {
-              logger.debug("attempted to write a duplicate event. skipping");
+              logger.debug(
+                "attempted to update but have duplicated event. skipping",
+              );
             }
           }
           this.notifyFailure(eventTypeStorage, events);


### PR DESCRIPTION
As designed, a single `sourceId` of an event can potentially create multiple event types. This could prove useful in the future, to use as some kind of relationship but for now this is just how it works for issues. 