### PR TITLE
Recorder speed improvements and stability

### DIFF
--- a/indexer/package.json
+++ b/indexer/package.json
@@ -59,6 +59,7 @@
     "@octokit/plugin-paginate-graphql": "^4.0.0",
     "@octokit/plugin-throttling": "^8.0.0",
     "@octokit/types": "^11.1.0",
+    "async-mutex": "^0.4.0",
     "chalk": "^5.3.0",
     "class-validator": "^0.14.0",
     "dayjs": "^1.11.9",

--- a/indexer/src/actions/github/fetch/common.ts
+++ b/indexer/src/actions/github/fetch/common.ts
@@ -15,7 +15,7 @@ import { Range } from "../../../utils/ranges.js";
 import { GenericError } from "../../../common/errors.js";
 import { IEventRecorder } from "../../../recorder/types.js";
 import { TimeSeriesCacheWrapper } from "../../../cacher/time-series.js";
-import { RequestDocument, Variables } from "graphql-request";
+import { ClientError, RequestDocument, Variables } from "graphql-request";
 import { graphQLClient } from "../../../events/github/graphQLClient.js";
 import { DateTime } from "luxon";
 import { logger } from "../../../utils/logger.js";
@@ -23,6 +23,7 @@ import {
   ProjectArtifactGroup,
   ProjectArtifactsCollector,
 } from "../../../scheduler/common.js";
+import { Mutex } from "async-mutex";
 
 export class IncompleteRepoName extends GenericError {}
 export type GithubRepoLocator = { owner: string; repo: string };
@@ -76,6 +77,7 @@ export class GithubByProjectBaseCollector extends ProjectArtifactsCollector {
   protected cache: TimeSeriesCacheWrapper;
   protected options: GithubBaseCollectorOptions;
   protected resetTime: DateTime | null;
+  private requestMutex: Mutex;
 
   constructor(
     projectRepository: Repository<Project>,
@@ -90,6 +92,7 @@ export class GithubByProjectBaseCollector extends ProjectArtifactsCollector {
 
     this.options = options;
     this.resetTime = null;
+    this.requestMutex = new Mutex();
   }
 
   async *groupedArtifacts(): AsyncGenerator<IArtifactGroup<Project>> {
@@ -140,29 +143,50 @@ export class GithubByProjectBaseCollector extends ProjectArtifactsCollector {
 
   protected async rateLimitedGraphQLRequest<
     R extends GithubGraphQLResponse<object>,
-  >(query: RequestDocument, variables: Variables) {
-    if (this.resetTime) {
-      const now = DateTime.now();
-      const diffMs = this.resetTime.toMillis() - now.toMillis();
-      if (diffMs > 0) {
-        if (diffMs > 200) {
-          logger.debug(
-            `encountered rate limit on github. waiting for ${diffMs}ms`,
-          );
+  >(query: RequestDocument, variables: Variables): Promise<R> {
+    for (let i = 0; i < 10; i++) {
+      if (this.resetTime) {
+        const now = DateTime.now();
+        const diffMs = this.resetTime.toMillis() - now.toMillis();
+        if (diffMs > 0) {
+          if (diffMs > 200) {
+            logger.debug(
+              `encountered rate limit on github. waiting for ${diffMs}ms`,
+            );
+          }
+          await sleep(diffMs);
         }
-        await sleep(diffMs);
+      }
+
+      const release = await this.requestMutex.acquire();
+      // Hacky retry loop for 5XX errors
+      try {
+        const response = await graphQLClient.request<R>(query, variables);
+        const rateLimit = response.rateLimit;
+        if (
+          rateLimit.remaining == 0 ||
+          rateLimit.remaining - rateLimit.cost <= 0
+        ) {
+          this.resetTime = DateTime.fromISO(rateLimit.resetAt);
+        } else {
+          // Artificially rate limit to 5reqs/second
+          this.resetTime = DateTime.now().plus(500);
+        }
+        release();
+        return response;
+      } catch (err) {
+        if (err instanceof ClientError) {
+          // Retry up
+          if (err.response.status >= 500 && err.response.status < 600) {
+            logger.error("hit a github 500 error. waiting for some period");
+            this.resetTime = DateTime.now().plus({ milliseconds: 5000 });
+            continue;
+          }
+        }
+        release();
+        throw err;
       }
     }
-
-    const response = await graphQLClient.request<R>(query, variables);
-    const rateLimit = response.rateLimit;
-
-    if (rateLimit.remaining == 0 || rateLimit.remaining - rateLimit.cost <= 0) {
-      this.resetTime = DateTime.fromISO(rateLimit.resetAt);
-    } else {
-      // Artificially rate limit to 5reqs/second
-      this.resetTime = DateTime.now().plus(200);
-    }
-    return response;
+    throw new Error("too many retries for graphql request");
   }
 }

--- a/indexer/src/cli.ts
+++ b/indexer/src/cli.ts
@@ -154,6 +154,10 @@ const cli = yargs(hideBin(process.argv))
         type: "boolean",
         default: false,
       });
+      yags.option("recorder-timeout-ms", {
+        type: "number",
+        default: 600000,
+      });
       const dateConverter = (input: string) => {
         const date = DateTime.fromISO(input).toUTC();
         if (!date.isValid) {

--- a/indexer/src/db/events.test.ts
+++ b/indexer/src/db/events.test.ts
@@ -5,10 +5,8 @@ import {
   Artifact,
   ArtifactNamespace,
   ArtifactType,
-  Event,
   EventType,
 } from "./orm-entities.js";
-import { DeepPartial } from "typeorm";
 
 withDbDescribe("EventRepository", () => {
   let artifact0: Artifact;
@@ -35,7 +33,7 @@ withDbDescribe("EventRepository", () => {
 
   it("should update the events based on sourceId", async () => {
     // Setup some events
-    const createPartials: DeepPartial<Event>[] = [
+    const createPartials: BulkUpdateBySourceIDEvent[] = [
       {
         time: new Date(),
         sourceId: "0",

--- a/indexer/src/db/events.ts
+++ b/indexer/src/db/events.ts
@@ -1,8 +1,16 @@
-import { DeepPartial } from "typeorm";
+import {
+  And,
+  DeepPartial,
+  In,
+  LessThanOrEqual,
+  MoreThanOrEqual,
+} from "typeorm";
 import { normalizeToObject } from "../utils/common.js";
 import { AppDataSource } from "./data-source.js";
 import type { Brand } from "utility-types";
-import { EventPointer, Event } from "./orm-entities.js";
+import { EventPointer, Event, EventType } from "./orm-entities.js";
+import { Range } from "../utils/ranges.js";
+import { DateTime } from "luxon";
 
 export const EventPointerRepository = AppDataSource.getRepository(
   EventPointer,
@@ -31,29 +39,75 @@ export const EventPointerRepository = AppDataSource.getRepository(
 });
 
 export type BulkUpdateBySourceIDEvent = DeepPartial<Event> &
-  Pick<Event, "type" | "sourceId">;
+  Pick<Event, "time" | "type" | "sourceId">;
 
 export type EventRef = Pick<Event, "id" | "type" | "sourceId">;
 
 export const EventRepository = AppDataSource.getRepository(Event).extend({
   async bulkUpdateBySourceIDAndType(events: BulkUpdateBySourceIDEvent[]) {
-    // This should likely be refactored eventually as this is likely slow.
+    // Ensure all have the same event type
+    if (events.length === 0) {
+      return [];
+    }
+
+    const summary = events.reduce<{
+      types: EventType[];
+      sourceIds: string[];
+      range: Range;
+    }>(
+      (summ, event) => {
+        const time = DateTime.fromJSDate(event.time);
+        if (time < summ.range.startDate) {
+          summ.range.startDate = time;
+        }
+        if (time > summ.range.endDate) {
+          summ.range.endDate = time;
+        }
+        if (summ.types.indexOf(event.type) === -1) {
+          summ.types.push(event.type);
+        }
+        summ.sourceIds.push(event.sourceId);
+        return summ;
+      },
+      {
+        types: [],
+        sourceIds: [],
+        range: {
+          startDate: DateTime.fromJSDate(events[0].time),
+          endDate: DateTime.fromJSDate(events[0].time),
+        },
+      },
+    );
+
+    if (summary.types.length !== 1) {
+      throw new Error("bulk update requires event types have the same type");
+    }
+
+    // This should likely be refactored eventually as this is likely slow
     return this.manager.transaction(async (manager) => {
       const repo = manager.withRepository(this);
-      const results = [];
-      for (const event of events) {
-        // Add all of the event updates to the transasction
-        results.push(
-          repo.update(
-            {
-              type: event.type,
-              sourceId: event.sourceId,
-            },
-            event,
-          ),
+
+      // Delete all of the events within the specific time range and with the specific sourceIds
+      const deleteResult = await repo.delete({
+        time: And(
+          MoreThanOrEqual(summary.range.startDate.toJSDate()),
+          LessThanOrEqual(summary.range.endDate.toJSDate()),
+        ),
+        sourceId: In(summary.sourceIds),
+        type: summary.types[0],
+      });
+      if (!deleteResult.affected) {
+        throw new Error(
+          "the deletion should have effected the expected number of rows. no deletions recorded",
         );
       }
-      return await Promise.all(results);
+      if (deleteResult.affected !== summary.sourceIds.length) {
+        throw new Error(
+          "the deletion should have effected the expected number of rows",
+        );
+      }
+
+      return await repo.insert(events);
     });
   },
 });

--- a/indexer/src/recorder/group.ts
+++ b/indexer/src/recorder/group.ts
@@ -3,9 +3,9 @@ import {
   IEventRecorder,
   IEventGroupRecorder,
   IncompleteEvent,
-  RecordResponse,
   EventGroupRecorderCallback,
   IncompleteArtifact,
+  RecordHandle,
 } from "./types.js";
 import { AsyncResults } from "../utils/async-results.js";
 import { collectAsyncResults } from "../utils/async-results.js";
@@ -19,7 +19,7 @@ export type GroupObjToStrFn<T> = (group: T) => string;
  * (usually artifacts)
  */
 export class EventGroupRecorder<T> implements IEventGroupRecorder<T> {
-  private groupRecordPromises: Record<string, Promise<RecordResponse>[]>;
+  private groupRecordHandles: Record<string, RecordHandle[]>;
   private grouperFn: EventGrouperFn<T>;
   private groupToStrFn: GroupObjToStrFn<T>;
   private emitter: EventEmitter;
@@ -33,7 +33,7 @@ export class EventGroupRecorder<T> implements IEventGroupRecorder<T> {
     grouperFn: EventGrouperFn<T>,
     groupObjToStrFn: GroupObjToStrFn<T>,
   ) {
-    this.groupRecordPromises = {};
+    this.groupRecordHandles = {};
     this.grouperFn = grouperFn;
     this.groupToStrFn = groupObjToStrFn;
     this.emitter = new EventEmitter();
@@ -68,16 +68,17 @@ export class EventGroupRecorder<T> implements IEventGroupRecorder<T> {
     });
   }
 
-  record(event: IncompleteEvent): void {
+  async record(event: IncompleteEvent): Promise<void> {
     const group = this.grouperFn(event);
-    const promises = this.getGroupRecordPromises(group);
-    promises.push(this.recorder.record(event));
+    const promises = this.getGroupRecordHandles(group);
+    promises.push(await this.recorder.record(event));
   }
 
   private commitId(id: string): void {
     console.log(`commiting group ${id}`);
-    const promises = this.groupRecordPromises[id] || [];
-    collectAsyncResults(promises)
+    const recordHandles = this.groupRecordHandles[id] || [];
+    const handlesAsPromises = recordHandles.map((r) => r.wait());
+    collectAsyncResults(handlesAsPromises)
       .then((result) => {
         this.emitter.emit(id, result);
       })
@@ -91,12 +92,12 @@ export class EventGroupRecorder<T> implements IEventGroupRecorder<T> {
       });
   }
 
-  private getGroupRecordPromises(group: T): Promise<RecordResponse>[] {
+  private getGroupRecordHandles(group: T): RecordHandle[] {
     const id = this.groupToStrFn(group);
-    if (!this.groupRecordPromises[id]) {
-      this.groupRecordPromises[id] = [];
+    if (!this.groupRecordHandles[id]) {
+      this.groupRecordHandles[id] = [];
     }
-    return this.groupRecordPromises[id];
+    return this.groupRecordHandles[id];
   }
 
   private addGroupCallback(

--- a/indexer/src/recorder/group.ts
+++ b/indexer/src/recorder/group.ts
@@ -10,6 +10,7 @@ import {
 import { AsyncResults } from "../utils/async-results.js";
 import { collectAsyncResults } from "../utils/async-results.js";
 import { randomUUID } from "node:crypto";
+import { logger } from "../utils/logger.js";
 
 export type EventGrouperFn<T> = (event: IncompleteEvent) => T;
 export type GroupObjToStrFn<T> = (group: T) => string;
@@ -75,7 +76,7 @@ export class EventGroupRecorder<T> implements IEventGroupRecorder<T> {
   }
 
   private commitId(id: string): void {
-    console.log(`commiting group ${id}`);
+    logger.debug(`commiting group ${id}`);
     const recordHandles = this.groupRecordHandles[id] || [];
     const handlesAsPromises = recordHandles.map((r) => r.wait());
     collectAsyncResults(handlesAsPromises)

--- a/indexer/src/recorder/recorder.test.ts
+++ b/indexer/src/recorder/recorder.test.ts
@@ -77,16 +77,16 @@ withDbDescribe("BatchEventRecorder", () => {
       },
       sourceId: "test123",
     };
-    const record0Promise = recorder.record(testEvent);
+    const record0Handle = await recorder.record(testEvent);
     const record0Wait = recorder.wait(EventType.COMMIT_CODE);
     flusher.flush();
     await record0Wait;
-    await record0Promise;
+    await record0Handle.wait();
 
     // No errors should be thrown if we attempt to write twice
-    const record1 = recorder.record(testEvent);
+    const record1 = await recorder.record(testEvent);
     flusher.flush();
-    await record1;
+    await record1.wait();
 
     // Check that the values are correct
     const results = await EventRepository.find({
@@ -131,11 +131,11 @@ withDbDescribe("BatchEventRecorder", () => {
       recorder.addListener("error", reject);
     });
 
-    const record2 = recorder.record(outOfScopeEvent);
+    const record2 = await recorder.record(outOfScopeEvent);
     flusher.flush();
 
     await expect(async () => {
-      return record2;
+      return record2.wait();
     }).rejects.toThrow();
 
     await expect(errorHandler).rejects.toThrow();

--- a/indexer/src/recorder/recorder.ts
+++ b/indexer/src/recorder/recorder.ts
@@ -312,7 +312,7 @@ export class BatchEventRecorder implements IEventRecorder {
           clearTimeout(timeout);
           resolve();
         } else {
-          console.log("queue full. blocking");
+          logger.debug("recorder queue full. applying backpressure");
           this.emitter.once("flush", checkQueue);
         }
       };
@@ -682,7 +682,7 @@ export class BatchEventRecorder implements IEventRecorder {
             `completed writing batch of ${result.identifiers.length}`,
           );
         } catch (err) {
-          console.log("encountered an error writing to the database");
+          logger.error("encountered an error writing to the database");
           if (err instanceof QueryFailedError) {
             if (err.message.indexOf("duplicate") !== -1) {
               logger.debug("attempted to insert a duplicate event. skipping");

--- a/indexer/src/recorder/recorder.ts
+++ b/indexer/src/recorder/recorder.ts
@@ -13,6 +13,7 @@ import {
   IncompleteArtifact,
   RecorderError,
   EventRecorderOptions,
+  RecordHandle,
 } from "./types.js";
 import {
   In,
@@ -103,7 +104,9 @@ class EventTypeStorage<T> {
 
 const defaultBatchEventRecorderOptions: BatchEventRecorderOptions = {
   maxBatchSize: 5000,
-  // ten minute timeout seems sane for completing any db writes
+
+  // ten minute timeout seems sane for completing any db writes (in a normal
+  // case). When backfilling this should be made much bigger.
   timeoutMs: 600000,
 };
 
@@ -249,13 +252,14 @@ export class BatchEventRecorder implements IEventRecorder {
   private emitter: EventEmitter;
   private closing: boolean;
   private recorderOptions: EventRecorderOptions;
+  private queueSize: number;
   private lastActorUpdatedAt: DateTime;
 
   constructor(
     eventRepository: typeof EventRepository,
     artifactRepository: Repository<Artifact>,
     flusher: IFlusher,
-    options?: BatchEventRecorderOptions,
+    options?: Partial<BatchEventRecorderOptions>,
   ) {
     this.eventRepository = eventRepository;
     this.artifactRepository = artifactRepository;
@@ -267,6 +271,7 @@ export class BatchEventRecorder implements IEventRecorder {
     this.types = [];
     this.actorsLoaded = false;
     this.flusher = flusher;
+    this.queueSize = 0;
     this.pubsub = new PromisePubSub({
       timeoutMs: this.options.timeoutMs,
     });
@@ -293,6 +298,30 @@ export class BatchEventRecorder implements IEventRecorder {
         this.emitter.emit("error", err);
       }
     });
+  }
+
+  private async waitTillAvailable(): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        reject(new Error("timed out waiting for recorder to become available"));
+      }, this.options.timeoutMs);
+
+      const checkQueue = () => {
+        // Start event waiting loop for flushes
+        if (!this.isQueueFull()) {
+          clearTimeout(timeout);
+          resolve();
+        } else {
+          console.log("queue full. blocking");
+          this.emitter.once("flush", checkQueue);
+        }
+      };
+      checkQueue();
+    });
+  }
+
+  private isQueueFull() {
+    return this.queueSize >= this.options.maxBatchSize;
   }
 
   setActorScope(namespaces: ArtifactNamespace[], types: ArtifactType[]) {
@@ -433,17 +462,26 @@ export class BatchEventRecorder implements IEventRecorder {
     this.eventTypeStrategies[eventType.toString()] = strategy;
   }
 
-  record(event: IncompleteEvent): Promise<RecordResponse> {
+  async record(event: IncompleteEvent): Promise<RecordHandle> {
     if (this.closing) {
       throw new RecorderError("recorder is closing. should be more writes");
     }
+
+    await this.waitTillAvailable();
+
     // Queue an event for writing
     const queue = this.getEventTypeStorage(event.type);
     const promise = queue.pushAndWait(event);
+    this.queueSize += 1;
 
     // Upon the first "record" begin the flush sequence
     this.scheduleFlush(1);
-    return promise;
+
+    return {
+      wait: () => {
+        return promise;
+      },
+    };
   }
 
   addListener(listener: string, callback: (...args: any) => void) {
@@ -477,6 +515,7 @@ export class BatchEventRecorder implements IEventRecorder {
         this.emitter.emit("error", err);
       }
     }
+    this.queueSize = 0;
   }
 
   async close(): Promise<void> {
@@ -656,26 +695,30 @@ export class BatchEventRecorder implements IEventRecorder {
     );
 
     // Update any events
-    await asyncBatch(updateEvents, 100, async (batch, batchLength) => {
-      logger.info(`preparing to update a batch of ${batchLength} events`);
-      const events = await this.createEventsFromIncomplete(batch);
+    await asyncBatch(
+      updateEvents,
+      this.options.maxBatchSize,
+      async (batch, batchLength) => {
+        logger.info(`preparing to update a batch of ${batchLength} events`);
+        const events = await this.createEventsFromIncomplete(batch);
 
-      try {
-        await this.eventRepository.bulkUpdateBySourceIDAndType(events);
-        this.notifySuccess(eventTypeStorage, events);
-      } catch (err) {
-        console.log("encountered an error updating to the database");
-        if (err instanceof QueryFailedError) {
-          if (err.message.indexOf("duplicate") !== -1) {
-            logger.debug(
-              "attempted to update but have duplicated event. skipping",
-            );
+        try {
+          await this.eventRepository.bulkUpdateBySourceIDAndType(events);
+          this.notifySuccess(eventTypeStorage, events);
+        } catch (err) {
+          logger.error("encountered an error updating to the database");
+          if (err instanceof QueryFailedError) {
+            if (err.message.indexOf("duplicate") !== -1) {
+              logger.error(
+                "attempted to update but have duplicated event. skipping",
+              );
+            }
           }
+          this.notifyFailure(eventTypeStorage, events);
+          this.emitter.emit("error", err);
         }
-        this.notifyFailure(eventTypeStorage, events);
-        this.emitter.emit("error", err);
-      }
-    });
+      },
+    );
     logger.info(`finished flushing for ${eventType}`);
   }
 

--- a/indexer/src/recorder/types.ts
+++ b/indexer/src/recorder/types.ts
@@ -24,6 +24,10 @@ export interface EventRecorderOptions {
 
 export type RecordResponse = string;
 
+export interface RecordHandle {
+  wait(): Promise<RecordResponse>;
+}
+
 export interface IEventRecorder {
   // A generic event recorder that will automatically handle batching writes for
   // events and also resolving artifacts and contributors (and automatically
@@ -34,7 +38,7 @@ export interface IEventRecorder {
   registerEventType(eventType: EventType, strategy: IEventTypeStrategy): void;
 
   // Record a single event. These are batched
-  record(event: IncompleteEvent): Promise<RecordResponse>;
+  record(event: IncompleteEvent): Promise<RecordHandle>;
 
   setActorScope(namespaces: ArtifactNamespace[], types: ArtifactType[]): void;
 
@@ -102,7 +106,7 @@ export type IncompleteEvent = {
 export type EventGroupRecorderCallback<T> = (results: AsyncResults<T>) => void;
 
 export interface IEventGroupRecorder<G> {
-  record(event: IncompleteEvent): void;
+  record(event: IncompleteEvent): Promise<void>;
 
   wait(group: G): Promise<AsyncResults<string>>;
 

--- a/indexer/src/scheduler/index.ts
+++ b/indexer/src/scheduler/index.ts
@@ -39,6 +39,7 @@ import { JobExecutionRepository, JobsRepository } from "../db/jobs.js";
 import { NpmDownloadCollector } from "../events/npm.js";
 
 export type SchedulerArgs = CommonArgs & {
+  recorderTimeoutMs: number;
   overwriteExistingEvents: boolean;
   batchSize: number;
 };
@@ -72,6 +73,9 @@ export async function configure(args: SchedulerArgs) {
     EventRepository,
     ArtifactRepository,
     flusher,
+    {
+      timeoutMs: args.recorderTimeoutMs,
+    },
   );
   recorder.setOptions({
     overwriteExistingEvents: args.overwriteExistingEvents,

--- a/indexer/src/scheduler/types.ts
+++ b/indexer/src/scheduler/types.ts
@@ -532,7 +532,7 @@ export class BaseScheduler implements IScheduler {
       );
     } catch (err) {
       if (err instanceof JobAlreadyQueued) {
-        console.log(
+        logger.info(
           `job for ${collectorName} already queued at ${baseTime.toISO()}`,
         );
         return;

--- a/indexer/src/scheduler/types.ts
+++ b/indexer/src/scheduler/types.ts
@@ -11,6 +11,7 @@ import {
   IEventGroupRecorder,
   IEventRecorder,
   IEventTypeStrategy,
+  RecordHandle,
   RecordResponse,
 } from "../recorder/types.js";
 import {
@@ -58,7 +59,7 @@ type ArtifactCommitterFn = (results: AsyncResults<RecordResponse>) => void;
 
 export interface IArtifactCommitter {
   withResults(results: AsyncResults<RecordResponse>): void;
-  withPromises(promises: Promise<RecordResponse>[]): void;
+  withHandles(handles: RecordHandle[]): void;
   withNone(): void;
 }
 
@@ -73,8 +74,9 @@ class ArtifactCommitter implements IArtifactCommitter {
     this.cb = cb;
   }
 
-  withPromises(promises: Promise<RecordResponse>[]): void {
-    collectAsyncResults(promises)
+  withHandles(handles: RecordHandle[]): void {
+    const handlesAsPromises = handles.map((h) => h.wait());
+    collectAsyncResults(handlesAsPromises)
       .then((results) => {
         this.withResults(results);
       })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,7 +28,7 @@ importers:
         version: 3.8.5(graphql@16.7.1)(react-dom@18.2.0)(react@18.2.0)
       '@apollo/experimental-nextjs-app-support':
         specifier: ^0.4.3
-        version: 0.4.3(@apollo/client@3.8.5)(next@13.5.4)(react@18.2.0)
+        version: 0.4.3(@apollo/client@3.8.5)(next@13.4.13)(react@18.2.0)
       '@emotion/react':
         specifier: ^11.11.1
         version: 11.11.1(@types/react@18.2.17)(react@18.2.0)
@@ -49,7 +49,7 @@ importers:
         version: link:../indexer
       '@plasmicapp/loader-nextjs':
         specifier: ^1.0.302
-        version: 1.0.302(next@13.5.4)(react-dom@18.2.0)(react@18.2.0)
+        version: 1.0.302(next@13.4.13)(react-dom@18.2.0)(react@18.2.0)
       '@supabase/supabase-js':
         specifier: ^2.32.0
         version: 2.32.0
@@ -79,7 +79,7 @@ importers:
         version: 16.7.1
       next:
         specifier: latest
-        version: 13.5.4(@babel/core@7.22.10)(react-dom@18.2.0)(react@18.2.0)
+        version: 13.4.13(@babel/core@7.22.10)(react-dom@18.2.0)(react@18.2.0)
       qs:
         specifier: ^6.11.2
         version: 6.11.2
@@ -207,6 +207,9 @@ importers:
       '@octokit/types':
         specifier: ^11.1.0
         version: 11.1.0
+      async-mutex:
+        specifier: ^0.4.0
+        version: 0.4.0
       chalk:
         specifier: ^5.3.0
         version: 5.3.0
@@ -372,7 +375,7 @@ packages:
       zen-observable-ts: 1.2.5
     dev: false
 
-  /@apollo/experimental-nextjs-app-support@0.4.3(@apollo/client@3.8.5)(next@13.5.4)(react@18.2.0):
+  /@apollo/experimental-nextjs-app-support@0.4.3(@apollo/client@3.8.5)(next@13.4.13)(react@18.2.0):
     resolution: {integrity: sha512-UrgLMUIW7SFmeJyLvqh0E8KRvo6Nd/zzbUFt0ENT3BRa7z7kGsCk7I+kZEZEAn13nqlTC3M4VPS6tOfvtLFhxQ==}
     peerDependencies:
       '@apollo/client': '>=3.8.0-rc || ^3.8.0'
@@ -380,7 +383,7 @@ packages:
       react: ^18
     dependencies:
       '@apollo/client': 3.8.5(graphql@16.7.1)(react-dom@18.2.0)(react@18.2.0)
-      next: 13.5.4(@babel/core@7.22.10)(react-dom@18.2.0)(react@18.2.0)
+      next: 13.4.13(@babel/core@7.22.10)(react-dom@18.2.0)(react@18.2.0)
       react: 18.2.0
       server-only: 0.0.1
       superjson: 1.13.3
@@ -2126,8 +2129,8 @@ packages:
       react-transition-group: 4.4.5(react-dom@18.2.0)(react@18.2.0)
     dev: false
 
-  /@next/env@13.5.4:
-    resolution: {integrity: sha512-LGegJkMvRNw90WWphGJ3RMHMVplYcOfRWf2Be3td3sUa+1AaxmsYyANsA+znrGCBjXJNi4XAQlSoEfUxs/4kIQ==}
+  /@next/env@13.4.13:
+    resolution: {integrity: sha512-fwz2QgVg08v7ZL7KmbQBLF2PubR/6zQdKBgmHEl3BCyWTEDsAQEijjw2gbFhI1tcKfLdOOJUXntz5vZ4S0Polg==}
     dev: false
 
   /@next/eslint-plugin-next@13.4.12:
@@ -2136,8 +2139,8 @@ packages:
       glob: 7.1.7
     dev: true
 
-  /@next/swc-darwin-arm64@13.5.4:
-    resolution: {integrity: sha512-Df8SHuXgF1p+aonBMcDPEsaahNo2TCwuie7VXED4FVyECvdXfRT9unapm54NssV9tF3OQFKBFOdlje4T43VO0w==}
+  /@next/swc-darwin-arm64@13.4.13:
+    resolution: {integrity: sha512-ZptVhHjzUuivnXMNCJ6lER33HN7lC+rZ01z+PM10Ows21NHFYMvGhi5iXkGtBDk6VmtzsbqnAjnx4Oz5um0FjA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
@@ -2145,8 +2148,8 @@ packages:
     dev: false
     optional: true
 
-  /@next/swc-darwin-x64@13.5.4:
-    resolution: {integrity: sha512-siPuUwO45PnNRMeZnSa8n/Lye5ZX93IJom9wQRB5DEOdFrw0JjOMu1GINB8jAEdwa7Vdyn1oJ2xGNaQpdQQ9Pw==}
+  /@next/swc-darwin-x64@13.4.13:
+    resolution: {integrity: sha512-t9nTiWCLApw8W4G1kqJyYP7y6/7lyal3PftmRturIxAIBlZss9wrtVN8nci50StDHmIlIDxfguYIEGVr9DbFTg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
@@ -2154,8 +2157,8 @@ packages:
     dev: false
     optional: true
 
-  /@next/swc-linux-arm64-gnu@13.5.4:
-    resolution: {integrity: sha512-l/k/fvRP/zmB2jkFMfefmFkyZbDkYW0mRM/LB+tH5u9pB98WsHXC0WvDHlGCYp3CH/jlkJPL7gN8nkTQVrQ/2w==}
+  /@next/swc-linux-arm64-gnu@13.4.13:
+    resolution: {integrity: sha512-xEHUqC8eqR5DHe8SOmMnDU1K3ggrJ28uIKltrQAwqFSSSmzjnN/XMocZkcVhuncuxYrpbri0iMQstRyRVdQVWg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
@@ -2163,8 +2166,8 @@ packages:
     dev: false
     optional: true
 
-  /@next/swc-linux-arm64-musl@13.5.4:
-    resolution: {integrity: sha512-YYGb7SlLkI+XqfQa8VPErljb7k9nUnhhRrVaOdfJNCaQnHBcvbT7cx/UjDQLdleJcfyg1Hkn5YSSIeVfjgmkTg==}
+  /@next/swc-linux-arm64-musl@13.4.13:
+    resolution: {integrity: sha512-sNf3MnLAm8rquSSAoeD9nVcdaDeRYOeey4stOWOyWIgbBDtP+C93amSgH/LPTDoUV7gNiU6f+ghepTjTjRgIUQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
@@ -2172,8 +2175,8 @@ packages:
     dev: false
     optional: true
 
-  /@next/swc-linux-x64-gnu@13.5.4:
-    resolution: {integrity: sha512-uE61vyUSClnCH18YHjA8tE1prr/PBFlBFhxBZis4XBRJoR+txAky5d7gGNUIbQ8sZZ7LVkSVgm/5Fc7mwXmRAg==}
+  /@next/swc-linux-x64-gnu@13.4.13:
+    resolution: {integrity: sha512-WhcRaJJSHyx9OWmKjjz+OWHumiPZWRqmM/09Bt7Up4UqUJFFhGExeztR4trtv3rflvULatu9IH/nTV8fUUgaMA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
@@ -2181,8 +2184,8 @@ packages:
     dev: false
     optional: true
 
-  /@next/swc-linux-x64-musl@13.5.4:
-    resolution: {integrity: sha512-qVEKFYML/GvJSy9CfYqAdUexA6M5AklYcQCW+8JECmkQHGoPxCf04iMh7CPR7wkHyWWK+XLt4Ja7hhsPJtSnhg==}
+  /@next/swc-linux-x64-musl@13.4.13:
+    resolution: {integrity: sha512-+Y4LLhOWWZQIDKVwr2R17lq2KSN0F1c30QVgGIWfnjjHpH8nrIWHEndhqYU+iFuW8It78CiJjQKTw4f51HD7jA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
@@ -2190,8 +2193,8 @@ packages:
     dev: false
     optional: true
 
-  /@next/swc-win32-arm64-msvc@13.5.4:
-    resolution: {integrity: sha512-mDSQfqxAlfpeZOLPxLymZkX0hYF3juN57W6vFHTvwKlnHfmh12Pt7hPIRLYIShk8uYRsKPtMTth/EzpwRI+u8w==}
+  /@next/swc-win32-arm64-msvc@13.4.13:
+    resolution: {integrity: sha512-rWurdOR20uxjfqd1X9vDAgv0Jb26KjyL8akF9CBeFqX8rVaBAnW/Wf6A2gYEwyYY4Bai3T7p1kro6DFrsvBAAw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
@@ -2199,8 +2202,8 @@ packages:
     dev: false
     optional: true
 
-  /@next/swc-win32-ia32-msvc@13.5.4:
-    resolution: {integrity: sha512-aoqAT2XIekIWoriwzOmGFAvTtVY5O7JjV21giozBTP5c6uZhpvTWRbmHXbmsjZqY4HnEZQRXWkSAppsIBweKqw==}
+  /@next/swc-win32-ia32-msvc@13.4.13:
+    resolution: {integrity: sha512-E8bSPwRuY5ibJ3CzLQmJEt8qaWrPYuUTwnrwygPUEWoLzD5YRx9SD37oXRdU81TgGwDzCxpl7z5Nqlfk50xAog==}
     engines: {node: '>= 10'}
     cpu: [ia32]
     os: [win32]
@@ -2208,8 +2211,8 @@ packages:
     dev: false
     optional: true
 
-  /@next/swc-win32-x64-msvc@13.5.4:
-    resolution: {integrity: sha512-cyRvlAxwlddlqeB9xtPSfNSCRy8BOa4wtMo0IuI9P7Y0XT2qpDrpFKRyZ7kUngZis59mPVla5k8X1oOJ8RxDYg==}
+  /@next/swc-win32-x64-msvc@13.4.13:
+    resolution: {integrity: sha512-4KlyC6jWRubPnppgfYsNTPeWfGCxtWLh5vaOAW/kdzAk9widqho8Qb5S4K2vHmal1tsURi7Onk2MMCV1phvyqA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -2852,7 +2855,7 @@ packages:
       '@plasmicapp/isomorphic-unfetch': 1.0.2
     dev: false
 
-  /@plasmicapp/loader-nextjs@1.0.302(next@13.5.4)(react-dom@18.2.0)(react@18.2.0):
+  /@plasmicapp/loader-nextjs@1.0.302(next@13.4.13)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-A/P9LmJ/60yKai49pO1MJxTrDjUp/x+vC7ar/h9lMjOyXhYYsR3PSRWSrI36fhEZnbD2e8mEIrDRjpQ6hIjJeA==}
     engines: {node: '>=10'}
     peerDependencies:
@@ -2864,7 +2867,7 @@ packages:
       '@plasmicapp/loader-edge': 1.0.35
       '@plasmicapp/loader-react': 1.0.283(react-dom@18.2.0)(react@18.2.0)
       '@plasmicapp/watcher': 1.0.72
-      next: 13.5.4(@babel/core@7.22.10)(react-dom@18.2.0)(react@18.2.0)
+      next: 13.4.13(@babel/core@7.22.10)(react-dom@18.2.0)(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       server-only: 0.0.1
@@ -3117,8 +3120,8 @@ packages:
       - supports-color
     dev: false
 
-  /@swc/helpers@0.5.2:
-    resolution: {integrity: sha512-E4KcWTpoLHqwPHLxidpOqQbcrZVgi0rsmmZXUle1jXmJfuIf/UWpczUJ7MZZ5tlxytgJXyp0w4PGkkeLiuIdZw==}
+  /@swc/helpers@0.5.1:
+    resolution: {integrity: sha512-sJ902EfIzn1Fa+qYmjdQqh8tPsoxyBz+8yBKC2HKUxyezKJFwPGOn7pv4WY6QuQW//ySQi5lJjA/ZT9sNWWNTg==}
     dependencies:
       tslib: 2.6.2
     dev: false
@@ -4094,6 +4097,12 @@ packages:
     resolution: {integrity: sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==}
     engines: {node: '>=8'}
     dev: true
+
+  /async-mutex@0.4.0:
+    resolution: {integrity: sha512-eJFZ1YhRR8UN8eBLoNzcDPcy/jqjsg6I1AP+KvWQX80BqOSW1oJPJXDylPUEeMr2ZQvHgnQ//Lp6f3RQ1zI7HA==}
+    dependencies:
+      tslib: 2.6.2
+    dev: false
 
   /async@3.2.4:
     resolution: {integrity: sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ==}
@@ -8531,9 +8540,9 @@ packages:
     resolution: {integrity: sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==}
     dev: false
 
-  /next@13.5.4(@babel/core@7.22.10)(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-+93un5S779gho8y9ASQhb/bTkQF17FNQOtXLKAj3lsNgltEcF0C5PMLLncDmH+8X1EnJH1kbqAERa29nRXqhjA==}
-    engines: {node: '>=16.14.0'}
+  /next@13.4.13(@babel/core@7.22.10)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-A3YVbVDNeXLhWsZ8Nf6IkxmNlmTNz0yVg186NJ97tGZqPDdPzTrHotJ+A1cuJm2XfuWPrKOUZILl5iBQkIf8Jw==}
+    engines: {node: '>=16.8.0'}
     hasBin: true
     peerDependencies:
       '@opentelemetry/api': ^1.1.0
@@ -8546,25 +8555,26 @@ packages:
       sass:
         optional: true
     dependencies:
-      '@next/env': 13.5.4
-      '@swc/helpers': 0.5.2
+      '@next/env': 13.4.13
+      '@swc/helpers': 0.5.1
       busboy: 1.6.0
       caniuse-lite: 1.0.30001534
-      postcss: 8.4.31
+      postcss: 8.4.14
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       styled-jsx: 5.1.1(@babel/core@7.22.10)(react@18.2.0)
       watchpack: 2.4.0
+      zod: 3.21.4
     optionalDependencies:
-      '@next/swc-darwin-arm64': 13.5.4
-      '@next/swc-darwin-x64': 13.5.4
-      '@next/swc-linux-arm64-gnu': 13.5.4
-      '@next/swc-linux-arm64-musl': 13.5.4
-      '@next/swc-linux-x64-gnu': 13.5.4
-      '@next/swc-linux-x64-musl': 13.5.4
-      '@next/swc-win32-arm64-msvc': 13.5.4
-      '@next/swc-win32-ia32-msvc': 13.5.4
-      '@next/swc-win32-x64-msvc': 13.5.4
+      '@next/swc-darwin-arm64': 13.4.13
+      '@next/swc-darwin-x64': 13.4.13
+      '@next/swc-linux-arm64-gnu': 13.4.13
+      '@next/swc-linux-arm64-musl': 13.4.13
+      '@next/swc-linux-x64-gnu': 13.4.13
+      '@next/swc-linux-x64-musl': 13.4.13
+      '@next/swc-win32-arm64-msvc': 13.4.13
+      '@next/swc-win32-ia32-msvc': 13.4.13
+      '@next/swc-win32-x64-msvc': 13.4.13
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros
@@ -9175,6 +9185,15 @@ packages:
   /postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
 
+  /postcss@8.4.14:
+    resolution: {integrity: sha512-E398TUmfAYFPBSdzgeieK2Y1+1cpdxJx8yXbK/m57nRhKSmk1GB2tO4lbLBtlkfPQTDKfe4Xqv1ASWPpayPEig==}
+    engines: {node: ^10 || ^12 || >=14}
+    dependencies:
+      nanoid: 3.3.6
+      picocolors: 1.0.0
+      source-map-js: 1.0.2
+    dev: false
+
   /postcss@8.4.29:
     resolution: {integrity: sha512-cbI+jaqIeu/VGqXEarWkRCCffhjgXc0qjBtXpqJhTBohMUjUQnbBr0xqX3vEKudc4iviTewcJo5ajcec5+wdJw==}
     engines: {node: ^10 || ^12 || >=14}
@@ -9182,15 +9201,6 @@ packages:
       nanoid: 3.3.6
       picocolors: 1.0.0
       source-map-js: 1.0.2
-
-  /postcss@8.4.31:
-    resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
-    engines: {node: ^10 || ^12 || >=14}
-    dependencies:
-      nanoid: 3.3.6
-      picocolors: 1.0.0
-      source-map-js: 1.0.2
-    dev: false
 
   /postgres-array@2.0.0:
     resolution: {integrity: sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==}
@@ -11479,4 +11489,8 @@ packages:
 
   /zen-observable@0.8.15:
     resolution: {integrity: sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ==}
+    dev: false
+
+  /zod@3.21.4:
+    resolution: {integrity: sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==}
     dev: false


### PR DESCRIPTION
Found some issues reindexing the backfill for `github-issues`. This caused some timeouts. This fix will ensure that the recorder slows down collectors if necessary (assuming the collector properly `await`s the recording). 

Fixes/Features:
* Recorder backpressure
* Github GraphQL requests are only ever triggered in series. We use a mutex to guarantee that the requests are not in parallel.
* Automatic 5XX retries on GraphQL github errors still related to #180 (This should improve that further)