### PR TITLE
feat: EventDataProvider can accept either artifact or project IDs

### DIFF
--- a/frontend/app/artifact/[namespace]/[...name]/page.tsx
+++ b/frontend/app/artifact/[namespace]/[...name]/page.tsx
@@ -66,7 +66,6 @@ export default async function ArtifactPage(props: ArtifactPageProps) {
       <PlasmicComponent
         component={compMeta.displayName}
         componentProps={{
-          id: artifact.id,
           metadata: artifact,
         }}
       />

--- a/frontend/app/project/[...slug]/page.tsx
+++ b/frontend/app/project/[...slug]/page.tsx
@@ -52,10 +52,7 @@ export default async function ProjectPage(props: ProjectPageProps) {
       <PlasmicComponent
         component={compMeta.displayName}
         componentProps={{
-          id: project.id,
           metadata: project,
-          artifacts: [],
-          collections: [],
         }}
       />
     </PlasmicClientRootProvider>

--- a/frontend/components/dataprovider/event-data-provider.tsx
+++ b/frontend/components/dataprovider/event-data-provider.tsx
@@ -3,47 +3,41 @@ import dayjs from "dayjs";
 import _ from "lodash";
 import React, { ReactNode } from "react";
 import { useQuery } from "@apollo/experimental-nextjs-app-support/ssr";
-import { GET_EVENTS_DAILY_BY_ARTIFACT } from "../../lib/graphql/queries";
-import { assertNever } from "../../lib/common";
+import {
+  GET_EVENTS_DAILY_BY_ARTIFACT,
+  GET_EVENTS_DAILY_BY_PROJECT,
+} from "../../lib/graphql/queries";
+import { assertNever, ensure, uncheckedCast } from "../../lib/common";
 
 // The name used to pass data into the Plasmic DataProvider
 const DEFAULT_VARIABLE_NAME = "eventData";
 
-type EventData = Partial<{
-  toId: number;
-  amount: any;
-  bucketDaily: any;
-  type: any;
-}>;
+type EventData = {
+  type: string;
+  id: number;
+  date: string;
+  amount: number;
+};
 
-const eventToValue = (e: EventData) => Math.max(e.amount, 1);
+const eventTimeToLabel = (t: any) => dayjs(t).format("YYYY-MM-DD");
+const eventTypeToLabel = (t: string) => _.capitalize(t.replace(/_/g, " "));
 
-const formatDataToKpiCard = (data?: EventData[]) => {
-  if (!data) {
-    return { data: 0 };
-  }
-  const result = _.sumBy(data, eventToValue);
+const formatDataToKpiCard = (data: EventData[]) => {
+  const result = _.sumBy(data, (x) => x.amount);
   return {
     data: result,
   };
 };
 
-const formatDataToAreaChart = (data?: EventData[]) => {
-  if (!data) {
-    return {
-      data: [],
-      categories: [],
-      xAxis: "date",
-    };
-  }
+const formatDataToAreaChart = (data: EventData[]) => {
   // Store the categories for the Tremor area chart
   const categories = new Set<string>();
   const simpleDates = data.map((x: EventData) => ({
     ...x,
     // Pull out the date
-    date: dayjs(x.bucketDaily).format("YYYY-MM-DD"),
+    date: eventTimeToLabel(x.date),
     // Get the value we want to plot
-    value: eventToValue(x),
+    value: x.amount,
   }));
   //console.log(simpleDates);
   const groupedByDate = _.groupBy(simpleDates, (x) => x.date);
@@ -54,9 +48,8 @@ const formatDataToAreaChart = (data?: EventData[]) => {
     _.reduce(
       x,
       (accum, curr) => {
-        const category = `${curr.toId} ${_.capitalize(
-          curr.type.replace(/_/g, " "),
-        )}`;
+        //const category = `${curr.toId} ${eventTypeToLabel(curr.type)}`;
+        const category = `${eventTypeToLabel(curr.type)}`;
         categories.add(category);
         return {
           ...accum,
@@ -82,22 +75,26 @@ const formatDataToAreaChart = (data?: EventData[]) => {
   };
 };
 
-const formatDataToBarList = (xAxis: XAxis, data?: EventData[]) => {
-  if (!data) {
-    return { data: [] };
-  }
+const formatDataToBarList = (xAxis: XAxis, data: EventData[]) => {
   const grouped = _.groupBy(data, (x) =>
     xAxis === "eventTime"
-      ? dayjs(x.bucketDaily).format("YYYY-MM-DD")
+      ? x.date
       : xAxis === "artifact"
-      ? x.toId
+      ? x.id
       : xAxis === "eventType"
       ? x.type
       : assertNever(xAxis),
   );
-  const summed = _.mapValues(grouped, (x) => _.sumBy(x, eventToValue));
+  const summed = _.mapValues(grouped, (x) => _.sumBy(x, (x) => x.amount));
   const result = _.toPairs(summed).map((x) => ({
-    name: x[0],
+    name:
+      xAxis === "eventTime"
+        ? eventTimeToLabel(x[0])
+        : xAxis === "artifact"
+        ? x[0]
+        : xAxis === "eventType"
+        ? eventTypeToLabel(x[0])
+        : assertNever(xAxis),
     value: x[1],
   }));
   return {
@@ -107,7 +104,7 @@ const formatDataToBarList = (xAxis: XAxis, data?: EventData[]) => {
 
 type ChartType = "kpiCard" | "areaChart" | "barList";
 type XAxis = "eventTime" | "artifact" | "eventType";
-type EntityType = "collection" | "project" | "artifact";
+type EntityType = "project" | "artifact";
 
 /**
  * Query component focused on providing data to visualiation components
@@ -115,7 +112,7 @@ type EntityType = "collection" | "project" | "artifact";
  * Current limitations:
  * - Does not support authentication or RLS. Make sure data is readable by unauthenticated users
  */
-export type EventDataProviderProps = {
+type EventDataProviderProps = {
   className?: string; // Plasmic CSS class
   variableName?: string; // Name to use in Plasmic data picker
   children?: ReactNode; // Show this
@@ -134,72 +131,122 @@ export type EventDataProviderProps = {
   endDate?: string;
 };
 
-export function EventDataProvider(props: EventDataProviderProps) {
+const createVariables = (props: EventDataProviderProps) => ({
+  ids:
+    props.ids?.map((id) => parseInt(id)).filter((id) => !!id && !isNaN(id)) ??
+    [],
+  types: props.eventTypes ?? [],
+  startDate: eventTimeToLabel(props.startDate ?? 0),
+  endDate: eventTimeToLabel(props.endDate),
+});
+
+const formatData = (props: EventDataProviderProps, rawData: EventData[]) => {
+  //const checkedData = rawData as unknown as EventData[];
+  // Short-circuit if test data
+  const data = props.useTestData
+    ? uncheckedCast<EventData[]>(props.testData)
+    : rawData;
+
+  const formattedData =
+    props.chartType === "kpiCard"
+      ? formatDataToKpiCard(data)
+      : props.chartType === "areaChart"
+      ? formatDataToAreaChart(data)
+      : props.chartType === "barList"
+      ? formatDataToBarList(props.xAxis ?? "artifact", data)
+      : assertNever(props.chartType);
+  return formattedData;
+};
+
+function ArtifactEventDataProvider(props: EventDataProviderProps) {
   // These props are set in the Plasmic Studio
-  const {
-    className,
-    variableName,
-    children,
-    loadingChildren,
-    ignoreLoading,
-    errorChildren,
-    ignoreError,
-    useTestData,
-    testData,
-    chartType,
-    xAxis,
-    ids,
-    eventTypes,
-    startDate,
-    endDate,
-  } = props;
-  const startDateObj = dayjs(startDate ?? 0);
-  const endDateObj = endDate ? dayjs(endDate) : dayjs();
-  const key = variableName ?? DEFAULT_VARIABLE_NAME;
+  const key = props.variableName ?? DEFAULT_VARIABLE_NAME;
+  const variables = createVariables(props);
   const {
     data: rawData,
     error,
     loading,
-  } = useQuery(GET_EVENTS_DAILY_BY_ARTIFACT, {
-    variables: {
-      ids:
-        ids?.map((id) => parseInt(id)).filter((id) => !!id && !isNaN(id)) ?? [],
-      types: eventTypes ?? [],
-      startDate: startDateObj.format("YYYY-MM-DD"),
-      endDate: endDateObj.format("YYYY-MM-DD"),
-    },
-  });
+  } = useQuery(GET_EVENTS_DAILY_BY_ARTIFACT, { variables });
+  const normalizedData: EventData[] = (
+    rawData?.events_daily_by_artifact ?? []
+  ).map((x) => ({
+    type: ensure<string>(x.type, "Data missing 'type'"),
+    id: ensure<number>(x.toId, "Data missing 'projectId'"),
+    date: ensure<string>(x.bucketDaily, "Data missing 'bucketDaily'"),
+    amount: ensure<number>(x.amount, "Data missing 'number'"),
+  }));
+  const formattedData = formatData(props, normalizedData);
+  console.log(props.ids, rawData, formattedData);
 
   // Show when loading or error
-  if (loading && !ignoreLoading && !!loadingChildren) {
-    return <div className={className}> {loadingChildren} </div>;
-  } else if (error && !ignoreError && !!errorChildren) {
+  if (loading && !props.ignoreLoading && !!props.loadingChildren) {
+    return <div className={props.className}> {props.loadingChildren} </div>;
+  } else if (error && !props.ignoreError && !!props.errorChildren) {
     return (
-      <div className={className}>
+      <div className={props.className}>
         <DataProvider name={key} data={error}>
-          {errorChildren}
+          {props.errorChildren}
         </DataProvider>
       </div>
     );
   }
-
-  //const checkedData = rawData as unknown as EventData[];
-  // Short-circuit if test data
-  const data = useTestData ? testData : rawData?.events_daily_by_artifact;
-  const formattedData =
-    chartType === "kpiCard"
-      ? formatDataToKpiCard(data)
-      : chartType === "areaChart"
-      ? formatDataToAreaChart(data)
-      : chartType === "barList"
-      ? formatDataToBarList(xAxis ?? "artifact", data)
-      : assertNever(chartType);
-
   return (
-    <div className={className}>
+    <div className={props.className}>
       <DataProvider name={key} data={formattedData}>
-        {children}
+        {props.children}
       </DataProvider>
     </div>
   );
 }
+
+function ProjectEventDataProvider(props: EventDataProviderProps) {
+  // These props are set in the Plasmic Studio
+  const key = props.variableName ?? DEFAULT_VARIABLE_NAME;
+  const variables = createVariables(props);
+  const {
+    data: rawData,
+    error,
+    loading,
+  } = useQuery(GET_EVENTS_DAILY_BY_PROJECT, { variables });
+  const normalizedData: EventData[] = (
+    rawData?.events_daily_by_project ?? []
+  ).map((x) => ({
+    type: ensure<string>(x.type, "Data missing 'type'"),
+    id: ensure<number>(x.projectId, "Data missing 'projectId'"),
+    date: ensure<string>(x.bucketDaily, "Data missing 'bucketDaily'"),
+    amount: ensure<number>(x.amount, "Data missing 'number'"),
+  }));
+  const formattedData = formatData(props, normalizedData);
+  console.log(props.ids, rawData, formattedData);
+
+  // Show when loading or error
+  if (loading && !props.ignoreLoading && !!props.loadingChildren) {
+    return <div className={props.className}> {props.loadingChildren} </div>;
+  } else if (error && !props.ignoreError && !!props.errorChildren) {
+    return (
+      <div className={props.className}>
+        <DataProvider name={key} data={error}>
+          {props.errorChildren}
+        </DataProvider>
+      </div>
+    );
+  }
+  return (
+    <div className={props.className}>
+      <DataProvider name={key} data={formattedData}>
+        {props.children}
+      </DataProvider>
+    </div>
+  );
+}
+
+function EventDataProvider(props: EventDataProviderProps) {
+  return props.entityType === "project" ? (
+    <ProjectEventDataProvider {...props} />
+  ) : (
+    <ArtifactEventDataProvider {...props} />
+  );
+}
+
+export { EventDataProvider };
+export type { EventDataProviderProps };

--- a/frontend/components/widgets/algolia.tsx
+++ b/frontend/components/widgets/algolia.tsx
@@ -79,7 +79,6 @@ function AlgoliaSearchBox() {
         placeholder={"Search projects..."}
         onSubmit={(event) => {
           event.preventDefault();
-          console.log(event);
           setAnchorEl(event.currentTarget);
         }}
       />

--- a/frontend/lib/common.ts
+++ b/frontend/lib/common.ts
@@ -1,3 +1,4 @@
+import { NullOrUndefinedValueError } from "./errors";
 /**
  * Explicitly marks a promise as something we won't await
  * @param _promise
@@ -27,4 +28,22 @@ export function uncheckedCast<T>(x: any): T {
  */
 export function assertNever(_x: never): never {
   throw new Error("unexpected branch taken");
+}
+
+/**
+ * Asserts that a value is not null or undefined.
+ * @param x
+ * @param msg
+ * @returns
+ */
+export function ensure<T>(x: T | null | undefined, msg: string): T {
+  if (x === null || x === undefined) {
+    // eslint-disable-next-line no-debugger
+    debugger;
+    throw new NullOrUndefinedValueError(
+      `Value must not be undefined or null${msg ? `- ${msg}` : ""}`,
+    );
+  } else {
+    return x;
+  }
 }

--- a/frontend/lib/errors.ts
+++ b/frontend/lib/errors.ts
@@ -9,3 +9,4 @@ export class NotImplementedError extends Error {
 
 export class HttpError extends Error {}
 export class MissingDataError extends Error {}
+export class NullOrUndefinedValueError extends Error {}

--- a/frontend/lib/graphql/queries.ts
+++ b/frontend/lib/graphql/queries.ts
@@ -58,10 +58,10 @@ const GET_EVENTS_DAILY_BY_ARTIFACT = gql(`
       type: {_in: $types},
       bucketDaily: {_gte: $startDate, _lte: $endDate}
     }) {
-      toId
-      amount
-      bucketDaily
       type
+      toId
+      bucketDaily
+      amount
     }
   }
 `);
@@ -78,10 +78,10 @@ const GET_EVENTS_DAILY_BY_PROJECT = gql(`
       type: {_in: $types},
       bucketDaily: {_gte: $startDate, _lte: $endDate}
     }) {
-      amount
-      bucketDaily
-      projectId
       type
+      projectId
+      bucketDaily
+      amount
     }
   }
 `);


### PR DESCRIPTION
* Add a new `entityType` to choose between artifact or projects
* Add separate components for doing different graph queries
* Clean up the event data parsing and normalization