### PR TITLE
Add additional fields to events

### DIFF
--- a/indexer/src/db/migration/1697236370397-event-add-size-and-details.ts
+++ b/indexer/src/db/migration/1697236370397-event-add-size-and-details.ts
@@ -1,0 +1,19 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class EventAddSizeAndDetails1697236370397 implements MigrationInterface {
+  name = "EventAddSizeAndDetails1697236370397";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "event" ADD "size" bigint NOT NULL DEFAULT '0'`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "event" ADD "details" jsonb NOT NULL DEFAULT '{}'`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "event" DROP COLUMN "details"`);
+    await queryRunner.query(`ALTER TABLE "event" DROP COLUMN "size"`);
+  }
+}

--- a/indexer/src/db/orm-entities.ts
+++ b/indexer/src/db/orm-entities.ts
@@ -209,6 +209,12 @@ export class Event {
 
   @Column("float")
   amount: number;
+
+  @Column("bigint", { default: 0 })
+  size: string;
+
+  @Column("jsonb", { default: {} })
+  details: Record<string, any>;
 }
 
 @Entity()


### PR DESCRIPTION
Arrived at this to pragmatically add the contract call count _and_ the gas totals. The `size` field is a bigint so it can fit gwei measurements. We can rename the field later but this is very much pragmatic. Dune data is imminently being loaded. 