### PR TITLE
feat: fix the build post new materialized views

### DIFF
--- a/frontend/components/dataprovider/event-data-provider.tsx
+++ b/frontend/components/dataprovider/event-data-provider.tsx
@@ -5,8 +5,8 @@ import React from "react";
 import { assertNever, ensure, uncheckedCast } from "../../lib/common";
 import {
   GET_ARTIFACTS_BY_IDS,
-  GET_EVENTS_DAILY_BY_ARTIFACT,
-  GET_EVENTS_DAILY_BY_PROJECT,
+  GET_EVENTS_DAILY_TO_ARTIFACT,
+  GET_EVENTS_DAILY_TO_PROJECT,
   GET_PROJECTS_BY_IDS,
 } from "../../lib/graphql/queries";
 import { DataProviderView } from "./provider-view";
@@ -328,7 +328,7 @@ function ArtifactEventDataProvider(props: EventDataProviderProps) {
     data: rawEventData,
     error: eventError,
     loading: eventLoading,
-  } = useQuery(GET_EVENTS_DAILY_BY_ARTIFACT, {
+  } = useQuery(GET_EVENTS_DAILY_TO_ARTIFACT, {
     variables: {
       artifactIds: stringToIntArray(props.ids),
       typeIds: props.eventTypes?.map((n) => EVENT_TYPE_NAME_TO_ID[n]),
@@ -344,10 +344,10 @@ function ArtifactEventDataProvider(props: EventDataProviderProps) {
     variables: { artifactIds: stringToIntArray(props.ids) },
   });
   const normalizedEventData: EventData[] = (
-    rawEventData?.events_daily_by_artifact ?? []
+    rawEventData?.events_daily_to_artifact ?? []
   ).map((x) => ({
     typeId: ensure<number>(x.typeId, "Data missing 'typeId'"),
-    id: ensure<number>(x.toId, "Data missing 'projectId'"),
+    id: ensure<number>(x.artifactId, "Data missing 'projectId'"),
     date: ensure<string>(x.bucketDaily, "Data missing 'bucketDaily'"),
     amount: ensure<number>(x.amount, "Data missing 'number'"),
   }));
@@ -377,7 +377,7 @@ function ProjectEventDataProvider(props: EventDataProviderProps) {
     data: rawEventData,
     error: eventError,
     loading: eventLoading,
-  } = useQuery(GET_EVENTS_DAILY_BY_PROJECT, {
+  } = useQuery(GET_EVENTS_DAILY_TO_PROJECT, {
     variables: {
       projectIds: stringToIntArray(props.ids),
       typeIds: props.eventTypes?.map((n) => EVENT_TYPE_NAME_TO_ID[n]),
@@ -393,7 +393,7 @@ function ProjectEventDataProvider(props: EventDataProviderProps) {
     variables: { projectIds: stringToIntArray(props.ids) },
   });
   const normalizedData: EventData[] = (
-    rawEventData?.events_daily_by_project ?? []
+    rawEventData?.events_daily_to_project ?? []
   ).map((x) => ({
     typeId: ensure<number>(x.typeId, "Data missing 'type'"),
     id: ensure<number>(x.projectId, "Data missing 'projectId'"),

--- a/frontend/lib/graphql/queries.ts
+++ b/frontend/lib/graphql/queries.ts
@@ -70,34 +70,34 @@ const GET_PROJECT_BY_SLUG = gql(`
   }
 `);
 
-const GET_EVENTS_DAILY_BY_ARTIFACT = gql(`
-  query EventsDailyByArtifact(
+const GET_EVENTS_DAILY_TO_ARTIFACT = gql(`
+  query EventsDailyToArtifact(
     $artifactIds: [Int!],
     $typeIds: [Int!],
     $startDate: timestamptz!,
     $endDate: timestamptz!, 
   ) {
-    events_daily_by_artifact(where: {
-      toId: { _in: $artifactIds },
+    events_daily_to_artifact(where: {
+      artifactId: { _in: $artifactIds },
       typeId: { _in: $typeIds },
       bucketDaily: { _gte: $startDate, _lte: $endDate }
     }) {
       typeId
-      toId
+      artifactId
       bucketDaily
       amount
     }
   }
 `);
 
-const GET_EVENTS_DAILY_BY_PROJECT = gql(`
-  query EventsDailyByProject(
+const GET_EVENTS_DAILY_TO_PROJECT = gql(`
+  query EventsDailyToProject(
     $projectIds: [Int!],
     $typeIds: [Int!],
     $startDate: timestamptz!,
     $endDate: timestamptz!, 
   ) {
-    events_daily_by_project(where: {
+    events_daily_to_project(where: {
       projectId: { _in: $projectIds },
       typeId: { _in: $typeIds },
       bucketDaily: { _gte: $startDate, _lte: $endDate }
@@ -110,78 +110,6 @@ const GET_EVENTS_DAILY_BY_PROJECT = gql(`
   }
 `);
 
-const GET_AGGREGATES_BY_ARTIFACT = gql(`
-  query GetAggregatesByArtifact(
-    $artifactIds: [Int!],
-    $typeIds: [Int!],
-    $startDate: timestamptz!,
-    $endDate: timestamptz!,
-  ) {
-    event_aggregate(where: {
-      toId: { _in: $artifactIds },
-      typeId: { _in: $typeIds }, 
-      time: { _gte: $startDate, _lte: $endDate }
-    }) {
-      aggregate {
-        avg {
-          amount
-        }
-        max {
-          amount
-          time
-        }
-        min {
-          amount
-          time
-        }
-        sum {
-          amount
-        }
-        variance {
-          amount
-        }
-        count(columns: fromId, distinct: true)
-      }
-    }
-  }
-`);
-
-const GET_AGGREGATES_BY_PROJECT = gql(`
-  query GetAggregatesByProject(
-    $projectIds: [Int!],
-    $typeIds: [Int!],
-    $startDate: timestamptz!,
-    $endDate: timestamptz!,
-  ) {
-    event_aggregate(where: {
-      artifact: { project_artifacts_artifacts: { projectId: { _in: $projectIds } } },
-      typeId: { _in: $typeIds }, 
-      time: { _gte: $startDate, _lte: $endDate }
-    }) {
-      aggregate {
-        avg {
-          amount
-        }
-        max {
-          amount
-          time
-        }
-        min {
-          amount
-          time
-        }
-        sum {
-          amount
-        }
-        variance {
-          amount
-        }
-        count(columns: fromId, distinct: true)
-      }
-    }
-  }
-`);
-
 export {
   GET_ALL_ARTIFACTS,
   GET_ARTIFACTS_BY_IDS,
@@ -189,8 +117,6 @@ export {
   GET_PROJECTS_BY_IDS,
   GET_ALL_PROJECTS,
   GET_PROJECT_BY_SLUG,
-  GET_EVENTS_DAILY_BY_ARTIFACT,
-  GET_EVENTS_DAILY_BY_PROJECT,
-  GET_AGGREGATES_BY_ARTIFACT,
-  GET_AGGREGATES_BY_PROJECT,
+  GET_EVENTS_DAILY_TO_ARTIFACT,
+  GET_EVENTS_DAILY_TO_PROJECT,
 };

--- a/indexer/README.md
+++ b/indexer/README.md
@@ -18,6 +18,28 @@ For convenience, we've added a script to quickly fire up `psql` with the databas
 bash ./utilities/database/psql.sh
 ```
 
+### Refreshing the materialized views
+
+Sometimes a materialized view will be missing data
+(for example if we insert [older historical data](https://docs.timescale.com/use-timescale/latest/continuous-aggregates/troubleshooting/#continuous-aggregate-doesnt-refresh-with-newly-inserted-historical-data))
+
+To refresh a TimescaleDB continuous aggregate:
+
+```sql
+CALL refresh_continuous_aggregate('events_daily_to_project', '2021-05-01', '2021-06-01');
+```
+
+See [Timescale docs](https://docs.timescale.com/use-timescale/latest/continuous-aggregates/refresh-policies/#manually-refresh-a-continuous-aggregate) for more details.
+
+Not all materialized views are supported by Timescale (for example `FirstContribution`).
+These views are _not_ continuously updated and must always be manually refreshed by running:
+
+```sql
+REFRESH MATERIALIZED VIEW first_contribution;
+```
+
+See the [Postgres docs](https://www.postgresql.org/docs/current/rules-materializedviews.html) for more details.
+
 ## TypeScript / JavaScript
 
 ### Setup

--- a/indexer/src/db/migration/1698257133416-drop-events-by-artifact-project.ts
+++ b/indexer/src/db/migration/1698257133416-drop-events-by-artifact-project.ts
@@ -1,0 +1,81 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class DropEventsByArtifactProject1698257133416
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // Remove refresh policies
+    await queryRunner.query(
+      `SELECT remove_continuous_aggregate_policy('events_daily_by_project');`,
+    );
+    await queryRunner.query(
+      `SELECT remove_continuous_aggregate_policy('events_daily_by_artifact');`,
+    );
+
+    // Drop views
+    await queryRunner.query(
+      `DELETE FROM "typeorm_metadata" WHERE "type" = $1 AND "name" = $2 AND "schema" = $3`,
+      ["MATERIALIZED_VIEW", "events_daily_by_project", "public"],
+    );
+    await queryRunner.query(`DROP MATERIALIZED VIEW "events_daily_by_project"`);
+    await queryRunner.query(
+      `DELETE FROM "typeorm_metadata" WHERE "type" = $1 AND "name" = $2 AND "schema" = $3`,
+      ["MATERIALIZED_VIEW", "events_daily_by_artifact", "public"],
+    );
+    await queryRunner.query(
+      `DROP MATERIALIZED VIEW "events_daily_by_artifact"`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    // Add views
+    await queryRunner.query(`
+      CREATE MATERIALIZED VIEW "events_daily_by_artifact" WITH (timescaledb.continuous) AS 
+      SELECT "toId",
+        "typeId",
+        time_bucket(INTERVAL '1 day', "time") AS "bucketDaily",
+        SUM(amount) as "amount"
+      FROM "event" 
+      GROUP BY "toId", "typeId", "bucketDaily"
+      WITH NO DATA;
+    `);
+    await queryRunner.query(
+      `INSERT INTO "typeorm_metadata"("database", "schema", "table", "type", "name", "value") VALUES (DEFAULT, $1, DEFAULT, $2, $3, $4)`,
+      [
+        "public",
+        "MATERIALIZED_VIEW",
+        "events_daily_by_artifact",
+        'SELECT "toId",\n      "typeId",\n      time_bucket(INTERVAL \'1 day\', "time") AS "bucketDaily",\n      SUM(amount) as "amount"\n    FROM "event" \n    GROUP BY "toId", "typeId", "bucketDaily"\n    WITH NO DATA;',
+      ],
+    );
+    await queryRunner.query(`
+      CREATE MATERIALIZED VIEW "events_daily_by_project" WITH (timescaledb.continuous) AS 
+      SELECT "projectId",
+        "typeId",
+        time_bucket(INTERVAL '1 day', "time") AS "bucketDaily",
+        SUM(amount) as "amount"
+      FROM "event"
+      INNER JOIN "project_artifacts_artifact"
+        on "project_artifacts_artifact"."artifactId" = "event"."toId"
+      GROUP BY "projectId", "typeId", "bucketDaily"
+      WITH NO DATA;
+    `);
+    await queryRunner.query(
+      `INSERT INTO "typeorm_metadata"("database", "schema", "table", "type", "name", "value") VALUES (DEFAULT, $1, DEFAULT, $2, $3, $4)`,
+      [
+        "public",
+        "MATERIALIZED_VIEW",
+        "events_daily_by_project",
+        'SELECT "projectId",\n      "typeId",\n      time_bucket(INTERVAL \'1 day\', "time") AS "bucketDaily",\n      SUM(amount) as "amount"\n    FROM "event"\n    INNER JOIN "project_artifacts_artifact"\n      on "project_artifacts_artifact"."artifactId" = "event"."toId"\n    GROUP BY "projectId", "typeId", "bucketDaily"\n    WITH NO DATA;',
+      ],
+    );
+
+    // Add refresh policies
+    await queryRunner.query(
+      `SELECT add_continuous_aggregate_policy('events_daily_by_artifact', start_offset => INTERVAL '1 month', end_offset => INTERVAL '1 day', schedule_interval => INTERVAL '1 hour');`,
+    );
+    await queryRunner.query(
+      `SELECT add_continuous_aggregate_policy('events_daily_by_project', start_offset => INTERVAL '1 month', end_offset => INTERVAL '1 day', schedule_interval => INTERVAL '1 hour');`,
+    );
+  }
+}

--- a/indexer/src/db/migration/1698258468674-recreate-events-to-artifact-project.ts
+++ b/indexer/src/db/migration/1698258468674-recreate-events-to-artifact-project.ts
@@ -1,0 +1,194 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class RecreateEventsToArtifactProject1698258468674
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // Remove refresh policies
+    await queryRunner.query(
+      `SELECT remove_continuous_aggregate_policy('events_daily_to_project');`,
+    );
+
+    // Drop views
+    await queryRunner.query(
+      `DELETE FROM "typeorm_metadata" WHERE "type" = $1 AND "name" = $2 AND "schema" = $3`,
+      ["MATERIALIZED_VIEW", "events_monthly_to_project", "public"],
+    );
+    await queryRunner.query(
+      `DROP MATERIALIZED VIEW "events_monthly_to_project"`,
+    );
+    await queryRunner.query(
+      `DELETE FROM "typeorm_metadata" WHERE "type" = $1 AND "name" = $2 AND "schema" = $3`,
+      ["MATERIALIZED_VIEW", "events_weekly_to_project", "public"],
+    );
+    await queryRunner.query(
+      `DROP MATERIALIZED VIEW "events_weekly_to_project"`,
+    );
+    await queryRunner.query(
+      `DELETE FROM "typeorm_metadata" WHERE "type" = $1 AND "name" = $2 AND "schema" = $3`,
+      ["MATERIALIZED_VIEW", "events_daily_to_project", "public"],
+    );
+    await queryRunner.query(`DROP MATERIALIZED VIEW "events_daily_to_project"`);
+    await queryRunner.query(
+      `DELETE FROM "typeorm_metadata" WHERE "type" = $1 AND "name" = $2 AND "schema" = $3`,
+      ["MATERIALIZED_VIEW", "events_monthly_to_artifact", "public"],
+    );
+    await queryRunner.query(
+      `DROP MATERIALIZED VIEW "events_monthly_to_artifact"`,
+    );
+    await queryRunner.query(
+      `DELETE FROM "typeorm_metadata" WHERE "type" = $1 AND "name" = $2 AND "schema" = $3`,
+      ["MATERIALIZED_VIEW", "events_weekly_to_artifact", "public"],
+    );
+    await queryRunner.query(
+      `DROP MATERIALIZED VIEW "events_weekly_to_artifact"`,
+    );
+    await queryRunner.query(
+      `DELETE FROM "typeorm_metadata" WHERE "type" = $1 AND "name" = $2 AND "schema" = $3`,
+      ["MATERIALIZED_VIEW", "events_daily_to_artifact", "public"],
+    );
+    await queryRunner.query(
+      `DROP MATERIALIZED VIEW "events_daily_to_artifact"`,
+    );
+
+    // Add views
+    await queryRunner.query(`CREATE MATERIALIZED VIEW "events_daily_to_artifact"
+      WITH (timescaledb.continuous)
+      AS SELECT "toId" AS "artifactId",
+        "typeId",
+        time_bucket(INTERVAL '1 day', "time") AS "bucketDaily",
+        SUM(amount) as "amount"
+      FROM "event" 
+      GROUP BY "artifactId", "typeId", "bucketDaily"
+      WITH NO DATA;
+    `);
+    await queryRunner.query(
+      `INSERT INTO "typeorm_metadata"("database", "schema", "table", "type", "name", "value") VALUES (DEFAULT, $1, DEFAULT, $2, $3, $4)`,
+      [
+        "public",
+        "MATERIALIZED_VIEW",
+        "events_daily_to_artifact",
+        'SELECT "toId" AS "artifactId",\n      "typeId",\n      time_bucket(INTERVAL \'1 day\', "time") AS "bucketDaily",\n      SUM(amount) as "amount"\n    FROM "event" \n    GROUP BY "artifactId", "typeId", "bucketDaily"\n    WITH NO DATA;',
+      ],
+    );
+    await queryRunner.query(`CREATE MATERIALIZED VIEW "events_weekly_to_artifact"
+      WITH (timescaledb.continuous)
+      AS SELECT "artifactId",
+        "typeId",
+        time_bucket(INTERVAL '1 week', "bucketDaily") AS "bucketWeekly",
+        SUM(amount) as "amount"
+      FROM "events_daily_to_artifact" 
+      GROUP BY "artifactId", "typeId", "bucketWeekly"
+      WITH NO DATA;
+    `);
+    await queryRunner.query(
+      `INSERT INTO "typeorm_metadata"("database", "schema", "table", "type", "name", "value") VALUES (DEFAULT, $1, DEFAULT, $2, $3, $4)`,
+      [
+        "public",
+        "MATERIALIZED_VIEW",
+        "events_weekly_to_artifact",
+        'SELECT "artifactId",\n      "typeId",\n      time_bucket(INTERVAL \'1 week\', "bucketDaily") AS "bucketWeekly",\n      SUM(amount) as "amount"\n    FROM "events_daily_to_artifact" \n    GROUP BY "artifactId", "typeId", "bucketWeekly"\n    WITH NO DATA;',
+      ],
+    );
+    await queryRunner.query(`CREATE MATERIALIZED VIEW "events_monthly_to_artifact"
+      WITH (timescaledb.continuous)
+      AS SELECT "artifactId",
+        "typeId",
+        time_bucket(INTERVAL '1 month', "bucketDaily") AS "bucketMonthly",
+        SUM(amount) as "amount"
+      FROM "events_daily_to_artifact" 
+      GROUP BY "artifactId", "typeId", "bucketMonthly"
+      WITH NO DATA;
+    `);
+    await queryRunner.query(
+      `INSERT INTO "typeorm_metadata"("database", "schema", "table", "type", "name", "value") VALUES (DEFAULT, $1, DEFAULT, $2, $3, $4)`,
+      [
+        "public",
+        "MATERIALIZED_VIEW",
+        "events_monthly_to_artifact",
+        'SELECT "artifactId",\n      "typeId",\n      time_bucket(INTERVAL \'1 month\', "bucketDaily") AS "bucketMonthly",\n      SUM(amount) as "amount"\n    FROM "events_daily_to_artifact" \n    GROUP BY "artifactId", "typeId", "bucketMonthly"\n    WITH NO DATA;',
+      ],
+    );
+    await queryRunner.query(`CREATE MATERIALIZED VIEW "events_daily_to_project"
+      WITH (timescaledb.continuous)
+      AS SELECT "projectId",
+        "typeId",
+        time_bucket(INTERVAL '1 day', "time") AS "bucketDaily",
+        SUM(amount) as "amount"
+      FROM "event"
+      INNER JOIN "project_artifacts_artifact"
+        on "project_artifacts_artifact"."artifactId" = "event"."toId"
+      GROUP BY "projectId", "typeId", "bucketDaily"
+      WITH NO DATA;
+    `);
+    await queryRunner.query(
+      `INSERT INTO "typeorm_metadata"("database", "schema", "table", "type", "name", "value") VALUES (DEFAULT, $1, DEFAULT, $2, $3, $4)`,
+      [
+        "public",
+        "MATERIALIZED_VIEW",
+        "events_daily_to_project",
+        'SELECT "projectId",\n      "typeId",\n      time_bucket(INTERVAL \'1 day\', "time") AS "bucketDaily",\n      SUM(amount) as "amount"\n    FROM "event"\n    INNER JOIN "project_artifacts_artifact"\n      on "project_artifacts_artifact"."artifactId" = "event"."toId"\n    GROUP BY "projectId", "typeId", "bucketDaily"\n    WITH NO DATA;',
+      ],
+    );
+    await queryRunner.query(`CREATE MATERIALIZED VIEW "events_weekly_to_project"
+      WITH (timescaledb.continuous)
+      AS SELECT "projectId",
+        "typeId",
+        time_bucket(INTERVAL '1 week', "bucketDaily") AS "bucketWeekly",
+        SUM(amount) as "amount"
+      FROM "events_daily_to_project" 
+      GROUP BY "projectId", "typeId", "bucketWeekly"
+      WITH NO DATA;
+    `);
+    await queryRunner.query(
+      `INSERT INTO "typeorm_metadata"("database", "schema", "table", "type", "name", "value") VALUES (DEFAULT, $1, DEFAULT, $2, $3, $4)`,
+      [
+        "public",
+        "MATERIALIZED_VIEW",
+        "events_weekly_to_project",
+        'SELECT "projectId",\n      "typeId",\n      time_bucket(INTERVAL \'1 week\', "bucketDaily") AS "bucketWeekly",\n      SUM(amount) as "amount"\n    FROM "events_daily_to_project" \n    GROUP BY "projectId", "typeId", "bucketWeekly"\n    WITH NO DATA;',
+      ],
+    );
+    await queryRunner.query(`CREATE MATERIALIZED VIEW "events_monthly_to_project"
+      WITH (timescaledb.continuous)
+      AS SELECT "projectId",
+        "typeId",
+        time_bucket(INTERVAL '1 month', "bucketDaily") AS "bucketMonthly",
+        SUM(amount) as "amount"
+      FROM "events_daily_to_project" 
+      GROUP BY "projectId", "typeId", "bucketMonthly"
+      WITH NO DATA;
+    `);
+    await queryRunner.query(
+      `INSERT INTO "typeorm_metadata"("database", "schema", "table", "type", "name", "value") VALUES (DEFAULT, $1, DEFAULT, $2, $3, $4)`,
+      [
+        "public",
+        "MATERIALIZED_VIEW",
+        "events_monthly_to_project",
+        'SELECT "projectId",\n      "typeId",\n      time_bucket(INTERVAL \'1 month\', "bucketDaily") AS "bucketMonthly",\n      SUM(amount) as "amount"\n    FROM "events_daily_to_project" \n    GROUP BY "projectId", "typeId", "bucketMonthly"\n    WITH NO DATA;',
+      ],
+    );
+
+    // Add refresh policies
+    await queryRunner.query(
+      `SELECT add_continuous_aggregate_policy('events_daily_to_artifact', start_offset => INTERVAL '1 month', end_offset => INTERVAL '1 day', schedule_interval => INTERVAL '1 hour');`,
+    );
+    await queryRunner.query(
+      `SELECT add_continuous_aggregate_policy('events_weekly_to_artifact', start_offset => INTERVAL '6 month', end_offset => INTERVAL '1 week', schedule_interval => INTERVAL '1 day');`,
+    );
+    await queryRunner.query(
+      `SELECT add_continuous_aggregate_policy('events_monthly_to_artifact', start_offset => INTERVAL '1 year', end_offset => INTERVAL '1 month', schedule_interval => INTERVAL '1 week');`,
+    );
+    await queryRunner.query(
+      `SELECT add_continuous_aggregate_policy('events_daily_to_project', start_offset => INTERVAL '1 month', end_offset => INTERVAL '1 day', schedule_interval => INTERVAL '1 hour');`,
+    );
+    await queryRunner.query(
+      `SELECT add_continuous_aggregate_policy('events_weekly_to_project', start_offset => INTERVAL '6 month', end_offset => INTERVAL '1 week', schedule_interval => INTERVAL '1 day');`,
+    );
+    await queryRunner.query(
+      `SELECT add_continuous_aggregate_policy('events_monthly_to_project', start_offset => INTERVAL '1 year', end_offset => INTERVAL '1 month', schedule_interval => INTERVAL '1 week');`,
+    );
+  }
+
+  public async down(_queryRunner: QueryRunner): Promise<void> {}
+}

--- a/indexer/src/db/orm-entities.ts
+++ b/indexer/src/db/orm-entities.ts
@@ -359,6 +359,7 @@ export class Log extends Base<"LogId"> {
 
 /******************************
  * MATERIALIZED VIEWS
+ * Not all views are possible via TimescaleDB continuous aggregates (e.g. DISTINCT)
  ******************************/
 
 /**


### PR DESCRIPTION
* There were a few manual steps that happened in between. (1) I manually refreshed all of our continuous aggregates and materialized views
(2) I manually tracked the materialized views in Hasura and added anonymous SELECT and aggregation permissions
* added instructions in README on how to do this refresh
* fixed the GraphQL queries in the frontend to use the new materialzed views
* Migration to drop the old EventsDailyByArtifact/Project views
* Migration to drop and recreate the new materialized views. For some reason they didn't get registered as continuous aggregates by TimescaleDB