### PR TITLE
feat: TableDataProvider starter

### DIFF
--- a/frontend/app/project/[...slug]/page.tsx
+++ b/frontend/app/project/[...slug]/page.tsx
@@ -2,7 +2,7 @@ import { notFound } from "next/navigation";
 import { PlasmicComponent } from "@plasmicapp/loader-nextjs";
 import { PLASMIC } from "../../../plasmic-init";
 import { PlasmicClientRootProvider } from "../../../plasmic-init-client";
-import { cachedGetProjectBySlug } from "../../../lib/cached-queries";
+import { cachedGetProjectsBySlugs } from "../../../lib/cached-queries";
 import { logger } from "../../../lib/logger";
 import { catchallPathToString } from "../../../lib/paths";
 
@@ -25,16 +25,16 @@ type ProjectPageProps = {
 
 export default async function ProjectPage(props: ProjectPageProps) {
   const { params, searchParams } = props;
-  const slug = catchallPathToString(params.slug);
+  const slugs = [catchallPathToString(params.slug)];
   if (!params.slug || !Array.isArray(params.slug) || params.slug.length < 1) {
     logger.warn("Invalid project page path", params);
     notFound();
   }
 
   // Get project metadata from the database
-  const { project: projectArray } = await cachedGetProjectBySlug({ slug });
+  const { project: projectArray } = await cachedGetProjectsBySlugs({ slugs });
   if (!Array.isArray(projectArray) || projectArray.length < 1) {
-    logger.warn(`Cannot find project (slug=${slug})`);
+    logger.warn(`Cannot find project (slugs=${slugs})`);
     notFound();
   }
   const project = projectArray[0];

--- a/frontend/components/dataprovider/event-data-provider.tsx
+++ b/frontend/components/dataprovider/event-data-provider.tsx
@@ -13,7 +13,11 @@ import {
   GET_EVENTS_MONTHLY_TO_PROJECT,
   GET_PROJECTS_BY_IDS,
 } from "../../lib/graphql/queries";
-import { DataProviderView } from "./provider-view";
+import { RegistrationProps } from "../../lib/types";
+import {
+  DataProviderView,
+  CommonDataProviderRegistration,
+} from "./provider-view";
 import type { CommonDataProviderProps } from "./provider-view";
 
 // TO FIX BUILDS WE ARE HARDCODING THE EVENT TYPES FOR NOW. THIS SHOULD INSTEAD
@@ -95,6 +99,41 @@ type EventDataProviderProps = CommonDataProviderProps & {
   startDate?: string;
   endDate?: string;
 };
+
+const EventDataProviderRegistration: RegistrationProps<EventDataProviderProps> =
+  {
+    ...CommonDataProviderRegistration,
+    chartType: {
+      type: "choice",
+      helpText: "Pair this with the component in 'children'",
+      options: ["areaChart", "barList"],
+    },
+    xAxis: {
+      type: "choice",
+      helpText: "What is the x-axis?",
+      options: ["eventTime", "entity", "eventType"],
+    },
+    entityType: {
+      type: "choice",
+      options: ["project", "artifact"],
+    },
+    ids: {
+      type: "array",
+      defaultValue: [],
+    },
+    eventTypes: {
+      type: "array",
+      defaultValue: [],
+    },
+    startDate: {
+      type: "string",
+      helpText: "YYYY-MM-DD",
+    },
+    endDate: {
+      type: "string",
+      helpText: "YYYY-MM-DD",
+    },
+  };
 
 /**
  * Convert the event time to a date label
@@ -495,6 +534,7 @@ function EventDataProvider(props: EventDataProviderProps) {
 
 export {
   EventDataProvider,
+  EventDataProviderRegistration,
   ProjectEventDataProvider,
   ArtifactEventDataProvider,
 };

--- a/frontend/components/dataprovider/provider-view.tsx
+++ b/frontend/components/dataprovider/provider-view.tsx
@@ -1,5 +1,6 @@
 import { DataProvider } from "@plasmicapp/loader-nextjs";
 import { ReactNode } from "react";
+import { RegistrationProps } from "../../lib/types";
 
 // The name used to pass data into the Plasmic DataProvider
 const DEFAULT_VARIABLE_NAME = "eventData";
@@ -22,50 +23,50 @@ type DataProviderViewProps = CommonDataProviderProps & {
   error?: Error;
 };
 
-const CommonDataProviderRegistration = {
-  //// CommonDataProviderRegistration
-  // Data variable
-  variableName: {
-    type: "string",
-    helpText: "Name to use in Plasmic data picker. Must be unique per query.",
-  },
-  // Plasmic elements
-  children: "slot",
-  loadingChildren: {
-    type: "slot",
-    defaultValue: {
-      type: "text",
-      value: "Placeholder",
+const CommonDataProviderRegistration: RegistrationProps<CommonDataProviderProps> =
+  {
+    // Data variable
+    variableName: {
+      type: "string",
+      helpText: "Name to use in Plasmic data picker. Must be unique per query.",
     },
-  },
-  ignoreLoading: {
-    type: "boolean",
-    helpText: "Don't show 'loadingChildren' even if we're still loading data",
-    advanced: true,
-  },
-  errorChildren: {
-    type: "slot",
-    defaultValue: {
-      type: "text",
-      value: "Placeholder",
+    // Plasmic elements
+    children: "slot",
+    loadingChildren: {
+      type: "slot",
+      defaultValue: {
+        type: "text",
+        value: "Placeholder",
+      },
     },
-  },
-  ignoreError: {
-    type: "boolean",
-    helpText: "Don't show 'errorChildren' even if we get an error",
-    advanced: true,
-  },
-  useTestData: {
-    type: "boolean",
-    helpText: "Render with test data",
-    editOnly: true,
-    advanced: true,
-  },
-  testData: {
-    type: "object",
-    advanced: true,
-  },
-};
+    ignoreLoading: {
+      type: "boolean",
+      helpText: "Don't show 'loadingChildren' even if we're still loading data",
+      advanced: true,
+    },
+    errorChildren: {
+      type: "slot",
+      defaultValue: {
+        type: "text",
+        value: "Placeholder",
+      },
+    },
+    ignoreError: {
+      type: "boolean",
+      helpText: "Don't show 'errorChildren' even if we get an error",
+      advanced: true,
+    },
+    useTestData: {
+      type: "boolean",
+      helpText: "Render with test data",
+      editOnly: true,
+      advanced: true,
+    },
+    testData: {
+      type: "object",
+      advanced: true,
+    },
+  };
 
 /**
  * Common view logic for EventDataProviders

--- a/frontend/components/dataprovider/supabase-query.tsx
+++ b/frontend/components/dataprovider/supabase-query.tsx
@@ -1,7 +1,12 @@
 import React from "react";
 import useSWR from "swr";
 import { SupabaseQueryArgs, supabaseQuery } from "../../lib/clients/supabase";
-import { CommonDataProviderProps, DataProviderView } from "./provider-view";
+import {
+  CommonDataProviderProps,
+  CommonDataProviderRegistration,
+  DataProviderView,
+} from "./provider-view";
+import { RegistrationProps } from "../../lib/types";
 
 // The name used to pass data into the Plasmic DataProvider
 const KEY_PREFIX = "db";
@@ -31,10 +36,38 @@ const genKey = (props: SupabaseQueryProps) => {
  * Current limitations:
  * - Does not support authentication or RLS. Make sure data is readable by unauthenticated users
  */
-export type SupabaseQueryProps = Partial<SupabaseQueryArgs> &
-  CommonDataProviderProps;
+type SupabaseQueryProps = Partial<SupabaseQueryArgs> & CommonDataProviderProps;
 
-export function SupabaseQuery(props: SupabaseQueryProps) {
+const SupabaseQueryRegistration: RegistrationProps<SupabaseQueryProps> = {
+  ...CommonDataProviderRegistration,
+  tableName: {
+    type: "string",
+    helpText: "Supabase table name",
+  },
+  columns: {
+    type: "string",
+    helpText: "Comma-separated list of columns",
+  },
+  filters: {
+    type: "object",
+    defaultValue: [],
+    helpText: "e.g. [['id', 'lt', 10], ['name', 'eq', 'foobar']]",
+  },
+  limit: {
+    type: "number",
+    helpText: "Number of rows to return",
+  },
+  orderBy: {
+    type: "string",
+    helpText: "Name of column to order by",
+  },
+  orderAscending: {
+    type: "boolean",
+    helpText: "True if ascending, false if descending",
+  },
+};
+
+function SupabaseQuery(props: SupabaseQueryProps) {
   // These props are set in the Plasmic Studio
   const { variableName, tableName, useTestData, testData } = props;
   const key = variableName ?? genKey(props);
@@ -61,3 +94,6 @@ export function SupabaseQuery(props: SupabaseQueryProps) {
     />
   );
 }
+
+export { SupabaseQueryRegistration, SupabaseQuery };
+export type { SupabaseQueryProps };

--- a/frontend/components/dataprovider/table-data-provider.tsx
+++ b/frontend/components/dataprovider/table-data-provider.tsx
@@ -1,6 +1,14 @@
+import { useQuery } from "@apollo/experimental-nextjs-app-support/ssr";
 import React from "react";
 import { DataProviderView } from "./provider-view";
 import type { CommonDataProviderProps } from "./provider-view";
+import {
+  GET_PROJECTS_BY_SLUGS,
+  GET_PROJECTS_BY_COLLECTION_SLUGS,
+} from "../../lib/graphql/queries";
+
+// Default start time
+const DEFAULT_START_DATE = 0;
 
 /**
  * Query component focused on providing data to our data tables
@@ -9,8 +17,8 @@ import type { CommonDataProviderProps } from "./provider-view";
  * - Does not support authentication or RLS. Make sure data is readable by unauthenticated users
  */
 type TableDataProviderProps = CommonDataProviderProps & {
-  collectionSlugs: string[]; // Collections to include
-  projectSlugs: string[]; // Projects to include
+  collectionSlugs?: string[]; // Collections to include
+  projectSlugs?: string[]; // Projects to include
   eventTypes?: string[];
   startDate?: string;
   endDate?: string;
@@ -22,19 +30,42 @@ type TableDataProviderProps = CommonDataProviderProps & {
  * @returns
  */
 function TableDataProvider(props: TableDataProviderProps) {
-  /**
   const {
-    data: rawData,
-    error,
-    loading,
-  } = useQuery(
-    GET_EVENTS_DAILY_BY_ARTIFACT,
-    { 
-      variables: {
+    collectionSlugs,
+    projectSlugs,
+    eventTypes,
+    startDate: rawStartDate,
+    endDate,
+  } = props;
+  const startDate = rawStartDate ?? DEFAULT_START_DATE;
 
-      },
-    }
-  );
+  // Get the project metadata
+  const {
+    data: projectsByCollectionData,
+    error: projectsByCollectionError,
+    loading: projectsByCollectionLoading,
+  } = useQuery(GET_PROJECTS_BY_COLLECTION_SLUGS, {
+    variables: {
+      slugs: collectionSlugs ?? [],
+    },
+  });
+  const {
+    data: projectsBySlugData,
+    error: projectsBySlugError,
+    loading: projectsBySlugLoading,
+  } = useQuery(GET_PROJECTS_BY_SLUGS, {
+    variables: {
+      slugs: projectSlugs ?? [],
+    },
+  });
+  const projects = [
+    ...(projectsByCollectionData?.project ?? []),
+    ...(projectsBySlugData?.project ?? []),
+  ];
+  console.log(startDate, endDate, eventTypes);
+
+  // Get the aggregate event data
+  /**
   const normalizedData: EventData[] = (
     rawData?.events_daily_by_artifact ?? []
   ).map((x) => ({
@@ -45,13 +76,15 @@ function TableDataProvider(props: TableDataProviderProps) {
   }));
   console.log(props.ids, rawData, formattedData);
   */
-  const formattedData = {};
+  const formattedData = {
+    projects,
+  };
   return (
     <DataProviderView
       {...props}
       formattedData={formattedData}
-      loading={false}
-      error={undefined}
+      loading={projectsByCollectionLoading || projectsBySlugLoading}
+      error={projectsByCollectionError ?? projectsBySlugError}
     />
   );
 }

--- a/frontend/lib/cached-queries.ts
+++ b/frontend/lib/cached-queries.ts
@@ -4,7 +4,7 @@ import {
   GET_ALL_ARTIFACTS,
   GET_ARTIFACT_BY_NAME,
   GET_ALL_PROJECTS,
-  GET_PROJECT_BY_SLUG,
+  GET_PROJECTS_BY_SLUGS,
 } from "./graphql/queries";
 import { logger } from "./logger";
 
@@ -48,21 +48,23 @@ const cachedGetAllProjects = cache(async () => {
   return data;
 });
 
-const cachedGetProjectBySlug = cache(async (variables: { slug: string }) => {
-  const { data, error } = await getApolloClient().query({
-    query: GET_PROJECT_BY_SLUG,
-    variables,
-  });
-  if (error) {
-    logger.error(error);
-    throw error;
-  }
-  return data;
-});
+const cachedGetProjectsBySlugs = cache(
+  async (variables: { slugs: string[] }) => {
+    const { data, error } = await getApolloClient().query({
+      query: GET_PROJECTS_BY_SLUGS,
+      variables,
+    });
+    if (error) {
+      logger.error(error);
+      throw error;
+    }
+    return data;
+  },
+);
 
 export {
   cachedGetAllArtifacts,
   cachedGetArtifactByName,
   cachedGetAllProjects,
-  cachedGetProjectBySlug,
+  cachedGetProjectsBySlugs,
 };

--- a/frontend/lib/graphql/queries.ts
+++ b/frontend/lib/graphql/queries.ts
@@ -1,23 +1,15 @@
 import { gql } from "../__generated__/gql";
 
+/**********************
+ * ARTIFACT
+ **********************/
+
 const GET_ALL_ARTIFACTS = gql(`
   query Artifacts {
     artifact {
       id
       name
       namespace
-      url
-      type
-    }
-  }
-`);
-
-const GET_ALL_PROJECTS = gql(`
-  query Projects {
-    project {
-      id
-      name
-      slug
     }
   }
 `);
@@ -28,8 +20,6 @@ const GET_ARTIFACTS_BY_IDS = gql(`
       id
       name
       namespace
-      type
-      url
     }
   }
 `);
@@ -46,29 +36,93 @@ const GET_ARTIFACT_BY_NAME = gql(`
   }
 `);
 
+/**********************
+ * PROJECT
+ **********************/
+
+const GET_ALL_PROJECTS = gql(`
+  query Projects {
+    project {
+      id
+      name
+      slug
+    }
+  }
+`);
+
 const GET_PROJECTS_BY_IDS = gql(`
   query ProjectsByIds($projectIds: [Int!]) {
     project(where: { id: { _in: $projectIds } }) {
       id
       name
       slug
-      verified
-      description
     }
   }
 `);
 
-const GET_PROJECT_BY_SLUG = gql(`
-  query ProjectBySlug($slug: String!) {
-    project(where: { slug: { _eq: $slug } }) {
+const GET_PROJECTS_BY_SLUGS = gql(`
+  query ProjectsBySlug($slugs: [String!]) {
+    project(where: { slug: { _in: $slugs } }) {
       id
       name
       slug
-      verified
       description
+      verified
     }
   }
 `);
+
+const GET_PROJECTS_BY_COLLECTION_SLUGS = gql(`
+  query ProjectsByCollectionSlugs($slugs: [String!]) {
+    project(where: {collection_projects_projects: {collection: {slug: {_in: $slugs}}}}) {
+      id
+      name
+      slug
+      description
+      verified
+    }
+  }
+`);
+
+/**********************
+ * COLLECTION
+ **********************/
+
+const GET_ALL_COLLECTIONS = gql(`
+  query Collections {
+    collection {
+      id
+      name
+      slug
+    }
+  }
+`);
+
+const GET_COLLECTIONS_BY_IDS = gql(`
+  query CollectionsByIds($collectionIds: [Int!]) {
+    collection(where: { id: { _in: $collectionIds } }) {
+      id
+      name
+      slug
+    }
+  }
+`);
+
+const GET_COLLECTIONS_BY_SLUGS = gql(`
+  query CollectionsBySlug($slugs: [String!]) {
+    collection(where: { slug: { _in: $slugs } }) {
+      id
+      name
+      slug
+      description
+      verified
+    }
+  }
+`);
+
+/**********************
+ * EVENTS
+ **********************/
 
 const GET_EVENTS_DAILY_TO_ARTIFACT = gql(`
   query EventsDailyToArtifact(
@@ -190,17 +244,44 @@ const GET_EVENTS_MONTHLY_TO_PROJECT = gql(`
   }
 `);
 
+const GET_EVENT_SUM = gql(`
+  query AggregateSum (
+    $projectIds: [Int!],
+    $typeIds: [Int!],
+    $startDate: timestamptz!,
+    $endDate: timestamptz!, 
+  ) {
+    events_daily_to_project_aggregate(
+      where: {
+        projectId: {_in: $projectIds},
+        typeId: {_in: $typeIds},
+        bucketDaily: {_gte: $startDate, _lte: $endDate}}
+    ) {
+      aggregate {
+        sum {
+          amount
+        }
+      }
+    }
+  }
+`);
+
 export {
   GET_ALL_ARTIFACTS,
   GET_ARTIFACTS_BY_IDS,
   GET_ARTIFACT_BY_NAME,
-  GET_PROJECTS_BY_IDS,
   GET_ALL_PROJECTS,
-  GET_PROJECT_BY_SLUG,
+  GET_PROJECTS_BY_IDS,
+  GET_PROJECTS_BY_SLUGS,
+  GET_PROJECTS_BY_COLLECTION_SLUGS,
+  GET_ALL_COLLECTIONS,
+  GET_COLLECTIONS_BY_IDS,
+  GET_COLLECTIONS_BY_SLUGS,
   GET_EVENTS_DAILY_TO_ARTIFACT,
   GET_EVENTS_WEEKLY_TO_ARTIFACT,
   GET_EVENTS_MONTHLY_TO_ARTIFACT,
   GET_EVENTS_DAILY_TO_PROJECT,
   GET_EVENTS_WEEKLY_TO_PROJECT,
   GET_EVENTS_MONTHLY_TO_PROJECT,
+  GET_EVENT_SUM,
 };

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -1,0 +1,5 @@
+import { PropType } from "@plasmicapp/loader-nextjs";
+
+export type RegistrationProps<P> = {
+  [prop: string]: PropType<P>;
+};

--- a/frontend/plasmic-init-client.tsx
+++ b/frontend/plasmic-init-client.tsx
@@ -8,9 +8,13 @@ import { AlgoliaSearchBox } from "./components/widgets/algolia";
 import { FeedbackWrapper } from "./components/widgets/feedback-farm";
 import { ProjectsClientProvider } from "./components/project-browser/project-client-provider";
 import { ProjectBrowser } from "./components/project-browser/project-browser";
-import { SupabaseQuery } from "./components/dataprovider/supabase-query";
+import {
+  SupabaseQuery,
+  SupabaseQueryRegistration,
+} from "./components/dataprovider/supabase-query";
 import {
   EventDataProvider,
+  EventDataProviderRegistration,
   ProjectEventDataProvider,
   ArtifactEventDataProvider,
 } from "./components/dataprovider/event-data-provider";
@@ -141,392 +145,28 @@ PLASMIC.registerComponent(ProjectBrowser, {
 
 PLASMIC.registerComponent(SupabaseQuery, {
   name: "SupabaseQuery",
-  props: {
-    variableName: {
-      type: "string",
-      helpText: "Name to use in Plasmic data picker. Must be unique per query.",
-    },
-
-    // SupabaseQueryArgs
-    tableName: {
-      type: "string",
-      helpText: "Supabase table name",
-    },
-    columns: {
-      type: "string",
-      helpText: "Comma-separated list of columns",
-    },
-    filters: {
-      type: "object",
-      defaultValue: [],
-      helpText: "e.g. [['id', 'lt', 10], ['name', 'eq', 'foobar']]",
-    },
-    limit: {
-      type: "number",
-      helpText: "Number of rows to return",
-    },
-    orderBy: {
-      type: "string",
-      helpText: "Name of column to order by",
-    },
-    orderAscending: {
-      type: "boolean",
-      helpText: "True if ascending, false if descending",
-    },
-
-    // Plasmic elements
-    children: "slot",
-    loadingChildren: {
-      type: "slot",
-      defaultValue: {
-        type: "text",
-        value: "Placeholder",
-      },
-    },
-    ignoreLoading: {
-      type: "boolean",
-      helpText: "Don't show 'loadingChildren' even if we're still loading data",
-      advanced: true,
-    },
-    errorChildren: {
-      type: "slot",
-      defaultValue: {
-        type: "text",
-        value: "Placeholder",
-      },
-    },
-    ignoreError: {
-      type: "boolean",
-      helpText: "Don't show 'errorChildren' even if we get an error",
-      advanced: true,
-    },
-    useTestData: {
-      type: "boolean",
-      helpText: "Render with test data",
-      editOnly: true,
-      advanced: true,
-    },
-    testData: {
-      type: "object",
-      advanced: true,
-    },
-  },
+  props: { ...SupabaseQueryRegistration },
   providesData: true,
   importPath: "./components/dataprovider/supabase-query",
 });
 
 PLASMIC.registerComponent(EventDataProvider, {
   name: "EventDataProvider",
-  props: {
-    //// CommonDataProviderRegistration
-    // Data variable
-    variableName: {
-      type: "string",
-      helpText: "Name to use in Plasmic data picker. Must be unique per query.",
-    },
-    // Plasmic elements
-    children: "slot",
-    loadingChildren: {
-      type: "slot",
-      defaultValue: {
-        type: "text",
-        value: "Placeholder",
-      },
-    },
-    ignoreLoading: {
-      type: "boolean",
-      helpText: "Don't show 'loadingChildren' even if we're still loading data",
-      advanced: true,
-    },
-    errorChildren: {
-      type: "slot",
-      defaultValue: {
-        type: "text",
-        value: "Placeholder",
-      },
-    },
-    ignoreError: {
-      type: "boolean",
-      helpText: "Don't show 'errorChildren' even if we get an error",
-      advanced: true,
-    },
-    useTestData: {
-      type: "boolean",
-      helpText: "Render with test data",
-      editOnly: true,
-      advanced: true,
-    },
-    testData: {
-      type: "object",
-      advanced: true,
-    },
-    // Data options
-    chartType: {
-      type: "choice",
-      helpText: "Pair this with the component in 'children'",
-      options: ["areaChart", "barList"],
-    },
-    xAxis: {
-      type: "choice",
-      helpText: "What is the x-axis?",
-      options: ["eventTime", "entity", "eventType"],
-    },
-    entityType: {
-      type: "choice",
-      options: ["project", "artifact"],
-    },
-    ids: {
-      type: "array",
-      defaultValue: [],
-    },
-    eventTypes: {
-      type: "array",
-      defaultValue: [],
-    },
-    startDate: {
-      type: "string",
-      helpText: "YYYY-MM-DD",
-    },
-    endDate: {
-      type: "string",
-      helpText: "YYYY-MM-DD",
-    },
-  },
-  providesData: true,
-  importPath: "./components/dataprovider/event-data-provider",
-});
-
-PLASMIC.registerComponent(EventDataProvider, {
-  name: "EventDataProvider",
-  props: {
-    //// CommonDataProviderRegistration
-    // Data variable
-    variableName: {
-      type: "string",
-      helpText: "Name to use in Plasmic data picker. Must be unique per query.",
-    },
-    // Plasmic elements
-    children: "slot",
-    loadingChildren: {
-      type: "slot",
-      defaultValue: {
-        type: "text",
-        value: "Placeholder",
-      },
-    },
-    ignoreLoading: {
-      type: "boolean",
-      helpText: "Don't show 'loadingChildren' even if we're still loading data",
-      advanced: true,
-    },
-    errorChildren: {
-      type: "slot",
-      defaultValue: {
-        type: "text",
-        value: "Placeholder",
-      },
-    },
-    ignoreError: {
-      type: "boolean",
-      helpText: "Don't show 'errorChildren' even if we get an error",
-      advanced: true,
-    },
-    useTestData: {
-      type: "boolean",
-      helpText: "Render with test data",
-      editOnly: true,
-      advanced: true,
-    },
-    testData: {
-      type: "object",
-      advanced: true,
-    },
-    // Data options
-    chartType: {
-      type: "choice",
-      helpText: "Pair this with the component in 'children'",
-      options: ["areaChart", "barList"],
-    },
-    xAxis: {
-      type: "choice",
-      helpText: "What is the x-axis?",
-      options: ["eventTime", "entity", "eventType"],
-    },
-    entityType: {
-      type: "choice",
-      options: ["project", "artifact"],
-    },
-    ids: {
-      type: "array",
-      defaultValue: [],
-    },
-    eventTypes: {
-      type: "array",
-      defaultValue: [],
-    },
-    startDate: {
-      type: "string",
-      helpText: "YYYY-MM-DD",
-    },
-    endDate: {
-      type: "string",
-      helpText: "YYYY-MM-DD",
-    },
-  },
+  props: { ...EventDataProviderRegistration },
   providesData: true,
   importPath: "./components/dataprovider/event-data-provider",
 });
 
 PLASMIC.registerComponent(ProjectEventDataProvider, {
   name: "ProjectEventDataProvider",
-  props: {
-    //// CommonDataProviderRegistration
-    // Data variable
-    variableName: {
-      type: "string",
-      helpText: "Name to use in Plasmic data picker. Must be unique per query.",
-    },
-    // Plasmic elements
-    children: "slot",
-    loadingChildren: {
-      type: "slot",
-      defaultValue: {
-        type: "text",
-        value: "Placeholder",
-      },
-    },
-    ignoreLoading: {
-      type: "boolean",
-      helpText: "Don't show 'loadingChildren' even if we're still loading data",
-      advanced: true,
-    },
-    errorChildren: {
-      type: "slot",
-      defaultValue: {
-        type: "text",
-        value: "Placeholder",
-      },
-    },
-    ignoreError: {
-      type: "boolean",
-      helpText: "Don't show 'errorChildren' even if we get an error",
-      advanced: true,
-    },
-    useTestData: {
-      type: "boolean",
-      helpText: "Render with test data",
-      editOnly: true,
-      advanced: true,
-    },
-    testData: {
-      type: "object",
-      advanced: true,
-    },
-    // Data options
-    chartType: {
-      type: "choice",
-      helpText: "Pair this with the component in 'children'",
-      options: ["areaChart", "barList"],
-    },
-    xAxis: {
-      type: "choice",
-      helpText: "What is the x-axis?",
-      options: ["eventTime", "entity", "eventType"],
-    },
-    ids: {
-      type: "array",
-      defaultValue: [],
-    },
-    eventTypes: {
-      type: "array",
-      defaultValue: [],
-    },
-    startDate: {
-      type: "string",
-      helpText: "YYYY-MM-DD",
-    },
-    endDate: {
-      type: "string",
-      helpText: "YYYY-MM-DD",
-    },
-  },
+  props: { ...EventDataProviderRegistration },
   providesData: true,
   importPath: "./components/dataprovider/event-data-provider",
 });
 
 PLASMIC.registerComponent(ArtifactEventDataProvider, {
   name: "ArtifactEventDataProvider",
-  props: {
-    //// CommonDataProviderRegistration
-    // Data variable
-    variableName: {
-      type: "string",
-      helpText: "Name to use in Plasmic data picker. Must be unique per query.",
-    },
-    // Plasmic elements
-    children: "slot",
-    loadingChildren: {
-      type: "slot",
-      defaultValue: {
-        type: "text",
-        value: "Placeholder",
-      },
-    },
-    ignoreLoading: {
-      type: "boolean",
-      helpText: "Don't show 'loadingChildren' even if we're still loading data",
-      advanced: true,
-    },
-    errorChildren: {
-      type: "slot",
-      defaultValue: {
-        type: "text",
-        value: "Placeholder",
-      },
-    },
-    ignoreError: {
-      type: "boolean",
-      helpText: "Don't show 'errorChildren' even if we get an error",
-      advanced: true,
-    },
-    useTestData: {
-      type: "boolean",
-      helpText: "Render with test data",
-      editOnly: true,
-      advanced: true,
-    },
-    testData: {
-      type: "object",
-      advanced: true,
-    },
-    // Data options
-    chartType: {
-      type: "choice",
-      helpText: "Pair this with the component in 'children'",
-      options: ["areaChart", "barList"],
-    },
-    xAxis: {
-      type: "choice",
-      helpText: "What is the x-axis?",
-      options: ["eventTime", "entity", "eventType"],
-    },
-    ids: {
-      type: "array",
-      defaultValue: [],
-    },
-    eventTypes: {
-      type: "array",
-      defaultValue: [],
-    },
-    startDate: {
-      type: "string",
-      helpText: "YYYY-MM-DD",
-    },
-    endDate: {
-      type: "string",
-      helpText: "YYYY-MM-DD",
-    },
-  },
+  props: { ...EventDataProviderRegistration },
   providesData: true,
   importPath: "./components/dataprovider/event-data-provider",
 });


### PR DESCRIPTION
    feat: TableDataProvider shell

    * Abstracting out the Plasmic code component registration props into
      reusable snippets
    * GraphQL to get projects by collection slugs
    * GraphQL to get event sum aggregates