### PR TITLE
feat: barlist colors set to light mode

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -19,7 +19,7 @@ module.exports = {
     "**/utilities/**",
     //"**/next.config.js",
     "**/postcss.config.js",
-    "**/tailwind.config.js",
+    //"**/tailwind.config.js",
     "**/.env"
   ],
   "parser": "@typescript-eslint/parser",

--- a/frontend/components/widgets/tremor.tsx
+++ b/frontend/components/widgets/tremor.tsx
@@ -1,0 +1,12 @@
+import { BarList as BarListTremor, BarListProps } from "@tremor/react";
+
+function BarList(props: BarListProps) {
+  return (
+    <BarListTremor
+      {...props}
+      valueFormatter={(value: number) => value.toLocaleString()}
+    />
+  );
+}
+
+export { BarList };

--- a/frontend/plasmic-init-client.tsx
+++ b/frontend/plasmic-init-client.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import CircularProgress from "@mui/material/CircularProgress";
-import { AreaChart, BarList } from "@tremor/react";
+import { AreaChart } from "@tremor/react";
 import { PlasmicRootProvider } from "@plasmicapp/loader-nextjs";
 import { PLASMIC } from "./plasmic-init";
 import { AlgoliaSearchBox } from "./components/widgets/algolia";
@@ -20,6 +20,7 @@ import {
 } from "./components/dataprovider/event-data-provider";
 import { FormField, FormError } from "./components/forms/form-elements";
 import { VisualizationContext } from "./components/forms/visualization-context";
+import { BarList } from "./components/widgets/tremor";
 
 /**
  * Plasmic component registration
@@ -90,7 +91,7 @@ PLASMIC.registerComponent(BarList, {
     color: "string",
     showAnimation: "boolean",
   },
-  importPath: "@tremor/react",
+  importPath: "./components/widgets/tremor",
 });
 
 PLASMIC.registerComponent(AlgoliaSearchBox, {

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
+  darkMode: "class",
   content: [
     "./app/**/*.{js,ts,jsx,tsx,mdx}",
     "./pages/**/*.{js,ts,jsx,tsx,mdx}",

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -26,6 +26,7 @@
     "**/*.ts",
     "**/*.tsx",
     "next.config.js",
+    "tailwind.config.js",
     ".next/types/**/*.ts"
   ],
   "exclude": ["node_modules"]


### PR DESCRIPTION
* Currently the barlist will use your system settings for light vs dark mode by default. But when you specify a color, it will go to lightmode for the background. If the system settings are dark mode, the text also shows up light, which is ugly.
* This just hardcodes everything to light mode unless we explicitly set dark mode
* I also add a hard-coded value formatter to use toLocaleString() on values