### PR TITLE
fix: removing trimming function in areacharts

### DIFF
--- a/frontend/components/dataprovider/event-data-provider.tsx
+++ b/frontend/components/dataprovider/event-data-provider.tsx
@@ -200,7 +200,9 @@ const formatDataToAreaChart = (
   while (j > 0 && isEmptyDataPoint(sorted[j])) {
     j--;
   }
-  const sliced = sorted.slice(i, j + 1);
+  // TODO: we are temporarily removing this trimming function to see if users like this better.
+  //const sliced = sorted.slice(i, j + 1);
+  const sliced = sorted.slice();
   //categories.results.includes("Downloads") && console.log(sliced);
 
   // Fill in any empty dates


### PR DESCRIPTION
* Previously we'd remove all preceding and trailing empty data points so that the area charts would zoom into the place with action
* Removing this for now since it can be confusing with the date picker