### PR TITLE
Recorder: Don't treat dupes as errors for now

### DIFF
--- a/indexer/src/recorder/recorder.test.ts
+++ b/indexer/src/recorder/recorder.test.ts
@@ -239,7 +239,9 @@ withDbDescribe("BatchEventRecorder", () => {
       await recorder.close();
     });
 
-    it("should fail when trying to write a duplicate event", async () => {
+    // In the current iteration of the recorder, dupes aren't errors. skipping
+    // for now.
+    it.skip("should fail when trying to write a duplicate event", async () => {
       const dupeRepo = AppDataSource.getRepository(RecorderTempDuplicateEvent);
 
       const dupes = await dupeRepo.find();
@@ -277,7 +279,9 @@ withDbDescribe("BatchEventRecorder", () => {
       expect(eventCount).toEqual(eventCountToWrite + 1);
     }, 90000);
 
-    it("should record errors when we write some duplicates over multiple batches", async () => {
+    // In the current iteration of the recorder, dupes aren't errors. skipping
+    // for now.
+    it.skip("should record errors when we write some duplicates over multiple batches", async () => {
       const events = randomCommitEventsGenerator(10);
 
       const errs: unknown[] = [];

--- a/indexer/src/recorder/recorder.ts
+++ b/indexer/src/recorder/recorder.ts
@@ -40,7 +40,7 @@ export interface BatchEventRecorderOptions {
 }
 
 const defaultBatchEventRecorderOptions: BatchEventRecorderOptions = {
-  maxBatchSize: 10000,
+  maxBatchSize: 5000,
 
   // ten minute timeout seems sane for completing any db writes (in a normal
   // case). When backfilling this should be made much bigger.

--- a/indexer/src/recorder/recorder.ts
+++ b/indexer/src/recorder/recorder.ts
@@ -40,7 +40,7 @@ export interface BatchEventRecorderOptions {
 }
 
 const defaultBatchEventRecorderOptions: BatchEventRecorderOptions = {
-  maxBatchSize: 3000,
+  maxBatchSize: 10000,
 
   // ten minute timeout seems sane for completing any db writes (in a normal
   // case). When backfilling this should be made much bigger.
@@ -933,42 +933,16 @@ export class BatchEventRecorder implements IEventRecorder {
     };
 
     try {
-      const [commitedResponse, writeCount] = await this.retryDbCall(
-        eventsWrite,
-        3,
-      );
+      const response = await this.retryDbCall(eventsWrite, 3);
+      const writeCount = response[1];
       if (writeCount !== newEvents.length) {
-        logger.debug(`some data wasn't written`);
-        const commitedEventRefs: {
-          sourceId: string;
-          type: IRecorderEventType;
-        }[] = commitedResponse.map((r) => {
-          const eventType = this.eventTypeIdMap[r.typeId];
-          return {
-            sourceId: r.sourceId,
-            type: new RecorderEventType(eventType.name, eventType.version),
-          };
-        });
-        const uncommitedEvents = _.differenceBy(
-          newEvents,
-          commitedEventRefs,
-          eventUniqueId,
+        // For now duplicates are not treated as errors. This likely needs to
+        // change in the future depending on _when_ the duplicate is encounter
+        logger.debug(
+          `some data wasn't written. it's assumed they are duplicates`,
         );
-        const commitedEvents = _.differenceBy(
-          newEvents,
-          uncommitedEvents,
-          eventUniqueId,
-        );
-        this.notifyFailure(
-          uncommitedEvents,
-          new RecorderError(
-            "did not record. likely duplicated events generated during the collection",
-          ),
-        );
-        this.notifySuccess(commitedEvents);
-      } else {
-        this.notifySuccess(newEvents);
       }
+      this.notifySuccess(newEvents);
     } catch (err) {
       this.notifyFailure(newEvents, err);
     }

--- a/indexer/src/scheduler/types.ts
+++ b/indexer/src/scheduler/types.ts
@@ -968,7 +968,9 @@ export class BaseScheduler implements IScheduler {
     if (range.startDate >= range.endDate) {
       throw new Error(`invalid input range ${rangeToString(range)}`);
     }
-    logger.debug(`starting ${collectorName} in ${mode}`);
+    logger.debug(
+      `starting ${collectorName} in ${mode} for range ${rangeToString(range)}`,
+    );
     const reg = this.eventCollectors[collectorName];
     if (mode === "all-at-once") {
       return this.executeForRange(reg, range, reindex);


### PR DESCRIPTION
This was causing some issues. It's not bad to just swallow the errors for now, but we can create some utilities to check for errors after things have completed. 