### PR TITLE
Massive recorder speed improvements

### DIFF
--- a/indexer/src/collectors/dune-daily-contract-usage.ts
+++ b/indexer/src/collectors/dune-daily-contract-usage.ts
@@ -19,7 +19,7 @@ import {
 import _ from "lodash";
 import { Range } from "../utils/ranges.js";
 import {
-  IEventRecorder,
+  IEventRecorderClient,
   IncompleteArtifact,
   IncompleteEvent,
   RecordHandle,
@@ -112,7 +112,7 @@ export const DefaultDailyContractUsageSyncerOptions: DailyContractUsageSyncerOpt
 export class DailyContractUsageCollector extends BaseEventCollector<object> {
   private client: IDailyContractUsageClientV2;
   private artifactRepository: typeof ArtifactRepository;
-  private recorder: IEventRecorder;
+  private recorder: IEventRecorderClient;
   private cache: TimeSeriesCacheWrapper;
   private options: DailyContractUsageSyncerOptions;
   private rowsProcessed: number;
@@ -120,7 +120,7 @@ export class DailyContractUsageCollector extends BaseEventCollector<object> {
   constructor(
     client: IDailyContractUsageClientV2,
     artifactRepository: typeof ArtifactRepository,
-    recorder: IEventRecorder,
+    recorder: IEventRecorderClient,
     cache: TimeSeriesCacheWrapper,
     options: Partial<DailyContractUsageSyncerOptions> = DefaultDailyContractUsageSyncerOptions,
   ) {
@@ -241,7 +241,6 @@ export class DailyContractUsageCollector extends BaseEventCollector<object> {
         const event = await this.createEvents(contract, row, uniqueEvents);
         recordHandles.push(...event);
       }
-      await this.recorder.wait(recordHandles);
     }
   }
 
@@ -262,7 +261,6 @@ export class DailyContractUsageCollector extends BaseEventCollector<object> {
         const events = await this.createEvents(contract, row, uniqueEvents);
         recordHandles.push(...events);
       }
-      await this.recorder.wait(recordHandles);
     }
   }
 
@@ -306,7 +304,7 @@ export class DailyContractUsageCollector extends BaseEventCollector<object> {
     const eventTime = DateTime.fromISO(row.date);
 
     if (!row.userAddress && !row.safeAddress) {
-      throw new Error("unexpectd no address");
+      throw new Error("unexpected: no address");
     }
 
     const from: IncompleteArtifact =

--- a/indexer/src/collectors/dune-funding-events.ts
+++ b/indexer/src/collectors/dune-funding-events.ts
@@ -7,7 +7,7 @@ import {
 } from "./dune/funding-events/client.js";
 import { ArtifactNamespace, ArtifactType } from "../db/orm-entities.js";
 import {
-  IEventRecorder,
+  IEventRecorderClient,
   IncompleteArtifact,
   IncompleteEvent,
 } from "../recorder/types.js";
@@ -49,7 +49,7 @@ export class FundingEventsCollector extends BatchedProjectArtifactsCollector {
   constructor(
     client: IFundingEventsClient,
     projectRepository: typeof ProjectRepository,
-    recorder: IEventRecorder,
+    recorder: IEventRecorderClient,
     cache: TimeSeriesCacheWrapper,
     batchSize: number,
     options?: Partial<FundingEventsCollectorOptions>,

--- a/indexer/src/collectors/github-commits.ts
+++ b/indexer/src/collectors/github-commits.ts
@@ -1,7 +1,7 @@
 import { DateTime } from "luxon";
 import _ from "lodash";
 import {
-  IEventRecorder,
+  IEventRecorderClient,
   IncompleteArtifact,
   IncompleteEvent,
   RecordHandle,
@@ -193,7 +193,7 @@ export class GithubCommitCollector extends GithubBatchedProjectArtifactsBaseColl
   constructor(
     projectRepository: Repository<Project>,
     gh: Octokit,
-    recorder: IEventRecorder,
+    recorder: IEventRecorderClient,
     cache: TimeSeriesCacheWrapper,
     batchSize: number,
     options?: Partial<GithubBaseCollectorOptions>,

--- a/indexer/src/collectors/github-followers.ts
+++ b/indexer/src/collectors/github-followers.ts
@@ -1,6 +1,6 @@
 import { DateTime } from "luxon";
 import {
-  IEventRecorder,
+  IEventRecorderClient,
   IncompleteArtifact,
   IncompleteEvent,
   RecordHandle,
@@ -194,7 +194,7 @@ const DefaultGithubFollowingCollectorOptions: GithubBaseCollectorOptions = {
 export class GithubFollowingCollector extends GithubBatchedProjectArtifactsBaseCollector {
   constructor(
     projectRepository: Repository<Project>,
-    recorder: IEventRecorder,
+    recorder: IEventRecorderClient,
     cache: TimeSeriesCacheWrapper,
     batchSize: number,
     options?: Partial<GithubBaseCollectorOptions>,
@@ -224,7 +224,6 @@ export class GithubFollowingCollector extends GithubBatchedProjectArtifactsBaseC
         const recordPromises = await this.collectEventsForRepo(repo, range);
         committer.commit(repo).withHandles(recordPromises);
       } catch (err) {
-        logger.debug(`encountered an error`);
         committer.commit(repo).withResults({
           errors: [err],
           success: [],

--- a/indexer/src/collectors/github-issues.ts
+++ b/indexer/src/collectors/github-issues.ts
@@ -1,7 +1,7 @@
 import { DateTime } from "luxon";
 import {
   IEventGroupRecorder,
-  IEventRecorder,
+  IEventRecorderClient,
   IncompleteArtifact,
   IncompleteEvent,
 } from "../recorder/types.js";
@@ -416,7 +416,7 @@ export class GithubIssueCollector extends GithubBatchedProjectArtifactsBaseColle
 
   constructor(
     projectRepository: Repository<Project>,
-    recorder: IEventRecorder,
+    recorder: IEventRecorderClient,
     cache: TimeSeriesCacheWrapper,
     batchSize: number,
     options?: Partial<GithubBaseCollectorOptions>,

--- a/indexer/src/collectors/github/common.ts
+++ b/indexer/src/collectors/github/common.ts
@@ -7,7 +7,7 @@ import {
   ArtifactNamespace,
 } from "../../db/orm-entities.js";
 import { GenericError } from "../../common/errors.js";
-import { IEventRecorder } from "../../recorder/types.js";
+import { IEventRecorderClient } from "../../recorder/types.js";
 import { TimeSeriesCacheWrapper } from "../../cacher/time-series.js";
 import { ClientError, RequestDocument, Variables } from "graphql-request";
 import { graphQLClient } from "./graphql-client.js";
@@ -186,7 +186,7 @@ export function GithubCollectorMixins<TBase extends Constructor>(Base: TBase) {
 }
 
 class _GithubByProjectBaseCollector extends ProjectArtifactsCollector {
-  protected recorder: IEventRecorder;
+  protected recorder: IEventRecorderClient;
   protected cache: TimeSeriesCacheWrapper;
   protected options: GithubBaseCollectorOptions;
   protected resetTime: DateTime | null;
@@ -194,7 +194,7 @@ class _GithubByProjectBaseCollector extends ProjectArtifactsCollector {
 
   constructor(
     projectRepository: Repository<Project>,
-    recorder: IEventRecorder,
+    recorder: IEventRecorderClient,
     cache: TimeSeriesCacheWrapper,
     options: GithubBaseCollectorOptions,
   ) {
@@ -210,14 +210,14 @@ class _GithubByProjectBaseCollector extends ProjectArtifactsCollector {
 }
 
 class _GithubBatchedProjectsBaseCollector extends BatchedProjectArtifactsCollector {
-  protected recorder: IEventRecorder;
+  protected recorder: IEventRecorderClient;
   protected cache: TimeSeriesCacheWrapper;
   protected options: GithubBaseCollectorOptions;
   protected resetTime: DateTime | null;
 
   constructor(
     projectRepository: Repository<Project>,
-    recorder: IEventRecorder,
+    recorder: IEventRecorderClient,
     cache: TimeSeriesCacheWrapper,
     batchSize: number,
     options: GithubBaseCollectorOptions,

--- a/indexer/src/collectors/npm-downloads.ts
+++ b/indexer/src/collectors/npm-downloads.ts
@@ -21,7 +21,7 @@ import {
   TimeSeriesCacheWrapper,
 } from "../cacher/time-series.js";
 import { In, Repository } from "typeorm";
-import { IEventRecorder, RecordHandle } from "../recorder/types.js";
+import { IEventRecorderClient, RecordHandle } from "../recorder/types.js";
 import { DateTime } from "luxon";
 import { sha1FromArray } from "../utils/source-ids.js";
 
@@ -48,7 +48,7 @@ export class NpmDownloadCollector extends ProjectArtifactsCollector {
 
   constructor(
     projectRepository: Repository<Project>,
-    recorder: IEventRecorder,
+    recorder: IEventRecorderClient,
     cache: TimeSeriesCacheWrapper,
     options?: Partial<NPMCollectorOptions>,
   ) {
@@ -121,7 +121,7 @@ export class NpmDownloadCollector extends ProjectArtifactsCollector {
         );
       }
     }
-    await this.recorder.wait(handles);
+    //await this.recorder.wait(handles);
     committer.commit(npmPackage).withHandles(handles);
   }
 }

--- a/indexer/src/recorder/group.ts
+++ b/indexer/src/recorder/group.ts
@@ -1,6 +1,6 @@
 import { EventEmitter } from "node:events";
 import {
-  IEventRecorder,
+  IEventRecorderClient,
   IEventGroupRecorder,
   IncompleteEvent,
   EventGroupRecorderCallback,
@@ -24,13 +24,13 @@ export class EventGroupRecorder<T> implements IEventGroupRecorder<T> {
   private grouperFn: EventGrouperFn<T>;
   private groupToStrFn: GroupObjToStrFn<T>;
   private emitter: EventEmitter;
-  private recorder: IEventRecorder;
+  private recorder: IEventRecorderClient;
   private committed: boolean;
   private listeningIds: Record<string, boolean>;
   private objectId: string;
 
   constructor(
-    recorder: IEventRecorder,
+    recorder: IEventRecorderClient,
     grouperFn: EventGrouperFn<T>,
     groupObjToStrFn: GroupObjToStrFn<T>,
   ) {
@@ -140,7 +140,7 @@ export class EventGroupRecorder<T> implements IEventGroupRecorder<T> {
 }
 
 export class ArtifactGroupRecorder extends EventGroupRecorder<IncompleteArtifact> {
-  constructor(recorder: IEventRecorder) {
+  constructor(recorder: IEventRecorderClient) {
     const artifactToString = (a: IncompleteArtifact) => {
       return `${a.name}:${a.namespace}:${a.type}`;
     };

--- a/indexer/src/recorder/recorder.test.ts
+++ b/indexer/src/recorder/recorder.test.ts
@@ -311,7 +311,7 @@ withDbDescribe("BatchEventRecorder", () => {
       const eventCount = await EventRepository.count();
       expect(eventCount).toEqual(eventCountToWrite / 2 + 1);
 
-      expect(results.uncommitted.length).toEqual(5);
+      expect(results.invalid.length).toEqual(5);
     }, 60000);
 
     // In the current iteration of the recorder, dupes aren't errors. skipping

--- a/indexer/src/recorder/recorder.test.ts
+++ b/indexer/src/recorder/recorder.test.ts
@@ -269,7 +269,7 @@ withDbDescribe("BatchEventRecorder", () => {
     });
 
     it("should do a large set of writes", async () => {
-      const eventCountToWrite = 200000;
+      const eventCountToWrite = 10000;
       const events = randomCommitEventsGenerator(eventCountToWrite, {
         fromProbability: 0.7,
         repoNameGenerator: () => `repo-${randomInt(100)}`,

--- a/indexer/src/recorder/recorder.ts
+++ b/indexer/src/recorder/recorder.ts
@@ -42,7 +42,7 @@ export interface BatchEventRecorderOptions {
 }
 
 const defaultBatchEventRecorderOptions: BatchEventRecorderOptions = {
-  maxBatchSize: 3000,
+  maxBatchSize: 100000,
 
   // 15 minute timeout seems sane for completing any db writes (in a normal
   // case). When backfilling this should be made much bigger.

--- a/indexer/src/recorder/recorder.ts
+++ b/indexer/src/recorder/recorder.ts
@@ -985,10 +985,6 @@ export class BatchEventRecorder implements IEventRecorder {
         if (artifactResponse.length !== 1) {
           throw new RecorderError("unexpected response writing artifacts");
         }
-        logger.debug(
-          `added ${artifactResponse[0].count} new artifacts in ${arStart.diffNow().milliseconds
-          }ms`,
-        );
         logger.debug(`added ${artifactResponse[0].count} new artifacts`);
 
         if (this.recorderOptions.overwriteExistingEvents) {

--- a/indexer/src/recorder/types.ts
+++ b/indexer/src/recorder/types.ts
@@ -30,7 +30,8 @@ export interface RecordHandle {
 
 export interface CommitResult {
   committed: string[];
-  uncommitted: string[];
+  skipped: string[];
+  invalid: string[];
   errors: unknown[];
 }
 

--- a/indexer/src/recorder/types.ts
+++ b/indexer/src/recorder/types.ts
@@ -28,7 +28,18 @@ export interface RecordHandle {
   wait(): Promise<RecordResponse>;
 }
 
-export interface IEventRecorder {
+export interface CommitResult {
+  committed: string[];
+  uncommitted: string[];
+  errors: unknown[];
+}
+
+export interface IEventRecorderClient {
+  // Record a single event. These are batched
+  record(event: IncompleteEvent): Promise<RecordHandle>;
+}
+
+export interface IEventRecorder extends IEventRecorderClient {
   // A generic event recorder that will automatically handle batching writes for
   // events and also resolving artifacts and contributors (and automatically
   // create any that we may need). This is so we don't have to manually control
@@ -39,22 +50,17 @@ export interface IEventRecorder {
 
   setup(): Promise<void>;
 
-  // Record a single event. These are batched
-  record(event: IncompleteEvent): Promise<RecordHandle>;
-
   setActorScope(namespaces: ArtifactNamespace[], types: ArtifactType[]): void;
 
   setRange(range: Range): void;
 
   setOptions(options: EventRecorderOptions): void;
 
+  begin(): Promise<void>;
+  commit(): Promise<CommitResult>;
+
   // Call this when you're done recording
   close(): Promise<void>;
-
-  wait(
-    handles: RecordHandle[],
-    timeout?: number,
-  ): Promise<AsyncResults<RecordResponse>>;
 
   addListener(listener: "error", cb: (err: unknown) => void): EventEmitter;
   addListener(listener: "flush-complete", cb: () => void): EventEmitter;

--- a/indexer/src/scheduler/common.ts
+++ b/indexer/src/scheduler/common.ts
@@ -8,7 +8,7 @@ import {
   IEventCollector,
 } from "./types.js";
 import { TimeSeriesCacheWrapper } from "../cacher/time-series.js";
-import { IEventRecorder } from "../recorder/types.js";
+import { IEventRecorderClient } from "../recorder/types.js";
 
 export class BasicArtifactGroup<T extends object> implements IArtifactGroup<T> {
   private _name: string;
@@ -74,12 +74,12 @@ export abstract class BaseEventCollector<T extends object>
 export class ProjectArtifactsCollector extends BaseEventCollector<Project> {
   protected projectRepository: Repository<Project>;
   protected cache: TimeSeriesCacheWrapper;
-  protected recorder: IEventRecorder;
+  protected recorder: IEventRecorderClient;
   protected artifactsWhere: FindOptionsWhere<Artifact>;
 
   constructor(
     projectRepository: Repository<Project>,
-    recorder: IEventRecorder,
+    recorder: IEventRecorderClient,
     cache: TimeSeriesCacheWrapper,
     artifactsWhere: FindOptionsWhere<Artifact>,
   ) {
@@ -142,11 +142,11 @@ export type Batch = {
 
 export class BatchArtifactsCollector extends BaseEventCollector<Batch> {
   protected cache: TimeSeriesCacheWrapper;
-  protected recorder: IEventRecorder;
+  protected recorder: IEventRecorderClient;
   protected batchSize: number;
 
   constructor(
-    recorder: IEventRecorder,
+    recorder: IEventRecorderClient,
     cache: TimeSeriesCacheWrapper,
     batchSize: number,
   ) {
@@ -198,7 +198,7 @@ export class BatchedProjectArtifactsCollector extends BatchArtifactsCollector {
 
   constructor(
     projectRepository: Repository<Project>,
-    recorder: IEventRecorder,
+    recorder: IEventRecorderClient,
     cache: TimeSeriesCacheWrapper,
     batchSize: number,
     artifactsWhere: FindOptionsWhere<Artifact>,

--- a/indexer/src/scheduler/types.ts
+++ b/indexer/src/scheduler/types.ts
@@ -10,6 +10,7 @@ import {
 import {
   IEventGroupRecorder,
   IEventRecorder,
+  IEventRecorderClient,
   IEventTypeStrategy,
   RecordHandle,
   RecordResponse,
@@ -214,7 +215,7 @@ interface CollectorRegistration {
 export interface EventCollectorRegistration extends CollectorRegistration {
   create(
     config: IConfig,
-    recorder: IEventRecorder,
+    recorder: IEventRecorderClient,
     cache: TimeSeriesCacheWrapper,
   ): Promise<IEventCollector>;
 
@@ -362,7 +363,6 @@ export class ArtifactRecordsCommitmentWrapper
   private emitter: EventEmitter;
   private eventPointerManager: IEventPointerManager;
   private duplicatesTracker: Record<number, number>;
-  private recorder: IEventRecorder;
 
   static setup(
     collectorName: string,

--- a/indexer/src/utils/debug.ts
+++ b/indexer/src/utils/debug.ts
@@ -1,0 +1,21 @@
+import { DateTime } from "luxon";
+import { logger } from "./logger.js";
+
+class Timer {
+  private start: DateTime;
+
+  constructor() {
+    this.start = DateTime.now();
+  }
+
+  finish(message: string) {
+    logger.info(`${this.start.diffNow().milliseconds * -1}ms: ${message}`);
+  }
+}
+
+export function timer(label: string) {
+  const timer = new Timer();
+  return () => {
+    timer.finish(`${label} completed`);
+  };
+}


### PR DESCRIPTION
We still have issues with some of the collectors for contract backfills. There are just so many events. This will need some clean up but it has a massive speed increase. Follow on issues will be created to clean all this up. This should significantly improve performance, but it comes at the cost of potentially more data written to the database that needs to be cleaned up periodically. 

In terms of speed comparisons. This can write millions of rows in ~20seconds. Compared with previous versions of the recorder that may have taken upwards of 15 minutes. It also needs a fraction of the ram on the executing machine as the original recorder.