### PR TITLE
Fix the `startDate` for `refresh-mvs`

### DIFF
--- a/.github/workflows/indexer-create-job.yml
+++ b/.github/workflows/indexer-create-job.yml
@@ -45,20 +45,6 @@ jobs:
     environment: indexer
     runs-on: ubuntu-latest
 
-    services:
-      redis:
-        # Docker Hub image
-        image: redis
-        # Set health checks to wait until redis has started
-        options: >-
-          --health-cmd "redis-cli ping"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-        ports:
-          # Maps port 6379 on service container to the host
-          - 6379:6379
-      
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/indexer-refresh-mvs.yml
+++ b/.github/workflows/indexer-refresh-mvs.yml
@@ -20,8 +20,9 @@ on:
       start-date:
         description: 'the start date for continous aggregates (ISO8601)'
         required: true
+        default: '2013-01-01T00:00:00Z'
       end-date:
-        description: 'the start date for continous aggregates (ISO8601)'
+        description: 'the end date for continous aggregates (ISO8601)'
         required: true
 
 jobs:

--- a/indexer/src/scripts/db-utilities.ts
+++ b/indexer/src/scripts/db-utilities.ts
@@ -28,7 +28,7 @@ export function dbUtilitiesCommandGroup(topYargs: Argv) {
         .option("start-date", {
           type: "string",
           describe: "ISO8601 of the start date",
-          default: "2015-01-01T00:00:00Z",
+          default: "2010-01-01T00:00:00Z",
         })
         .coerce("start-date", coerceDateTime)
         .option("end-date", {
@@ -138,6 +138,7 @@ export async function refreshAggregates(
     logger.info(resp);
   }
 
+  logger.debug(`refreshing indexes in ${intervalDays} day intervals`);
   // Continuous aggregates will start
   for (const agg of aggregatesList) {
     let currentStart = endDate.minus({ days: intervalDays });


### PR DESCRIPTION
On the CLI it defaulted to 2015 which caused us to miss many events when refreshing.