### PR TITLE
Fixes indexer execution errors

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20
+FROM node:18
 
 #COPY . /usr/src/app
 RUN npm install -g pnpm

--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -3,6 +3,7 @@ version: '3'
 volumes:
   node_modules:
   indexer_modules:
+  docs_modules:
   indexer_dist:
   frontend_modules:
   frontend_next:
@@ -26,6 +27,7 @@ services:
       - indexer_dist:/usr/src/app/indexer/dist
       - frontend_next:/usr/src/app/frontend/.next
       - frontend_modules:/usr/src/app/frontend/node_modules
+      - docs_modules:/usr/src/app/docs/node_modules
       - pnpm_home:/pnpm
     environment:
       - PNPM_HOME=/pnpm
@@ -105,4 +107,5 @@ services:
       - indexer_dist:/usr/src/app/indexer/dist
       - frontend_next:/usr/src/app/frontend/.next
       - frontend_modules:/usr/src/app/frontend/node_modules
+      - docs_modules:/usr/src/app/docs/node_modules
       - pnpm_home:/pnpm

--- a/docker/install.sh
+++ b/docker/install.sh
@@ -1,6 +1,6 @@
 set -euxo pipefail
 
 npm install -g pnpm
-pnpm install
+pnpm i --frozen-lockfile
 # For now let's just build the indexer
 pnpm build:indexer

--- a/docker/install.sh
+++ b/docker/install.sh
@@ -1,6 +1,17 @@
 set -euxo pipefail
 
+# Ensure all of the node modules directorys aren't empty. A change in pnpm v8.12
+# caused it to attempt deletion of empty node_modules directories. This fixes
+# that issue.
+touch /usr/src/app/node_modules/.noop
+touch /usr/src/app/indexer/node_modules/.noop
+touch /usr/src/app/frontend/node_modules/.noop
+touch /usr/src/app/docs/node_modules/.noop
+
 npm install -g pnpm
-pnpm i --frozen-lockfile
+node -v
+
+pnpm i --frozen-lockfile --ignore-scripts
+
 # For now let's just build the indexer
-pnpm build:indexer
+pnpm build:indexer 

--- a/indexer/package.json
+++ b/indexer/package.json
@@ -32,7 +32,7 @@
     "migration:generate": "typeorm-ts-node-esm migration:generate -d ./src/db/data-source.ts",
     "migration:run": "typeorm-ts-node-esm migration:run -d ./src/db/data-source.ts",
     "migration:revert": "typeorm-ts-node-esm migration:revert -d ./src/db/data-source.ts",
-    "start": "ts-node --esm src/cli.ts",
+    "start": "node --loader ts-node/esm src/cli.ts",
     "test": "NODE_OPTIONS=\"--no-warnings --experimental-vm-modules\" jest",
     "typeorm": "typeorm-ts-node-commonjs"
   },


### PR DESCRIPTION
Something must of have changed about the node or ts-node version deployed on github actions. It was no longer accepting ts-node --esm. This addresses that. Sadly, this wasted a few hours