### PR TITLE
Fix errors when installing with poetry 1.7+

### DIFF
--- a/dbt/oso_dbt/__init__.py
+++ b/dbt/oso_dbt/__init__.py
@@ -1,0 +1,4 @@
+# This is a dummy __init__.py because of an issue with python poetry. We are
+# waiting for https://github.com/python-poetry/poetry/pull/8650 to be merged
+# then we can remove this. We added this here because without it the
+# installation for the dbt folder appears to error on some versions of poetry.

--- a/dbt/pyproject.toml
+++ b/dbt/pyproject.toml
@@ -5,6 +5,7 @@ description = ""
 authors = ["Kariba Labs"]
 license = "Apache 2.0"
 readme = "README.md"
+packages = [{ include = "oso_dbt" }]
 
 [tool.poetry.dependencies]
 python = "^3.11"


### PR DESCRIPTION
I put context into the dummy `__init__.py` file. 

This should address issues @ccerv1 and I encountered when using poetry 1.7.x.