### PR TITLE
feat: rewrite /blog and /docs on www.opensource.observer to point to …

### DIFF
--- a/docs/docs/index.mdx
+++ b/docs/docs/index.mdx
@@ -1,0 +1,62 @@
+---
+title: "Docs | Open Source Observer"
+description: "Open Source Observer (OSO) Documentation site"
+---
+
+import Link from "@docusaurus/Link";
+
+# Open Source Observer Documentation
+
+Care about open source impact?
+You've come to the right place.
+The documentation will help you both contribute to OSO and share results with the commmunity.
+
+💡**Tip**: Open search with <kbd>/</kbd>, then <kbd>Tab</kbd> to search docs
+
+## Contribute to OSO
+
+OSO is community-led. Learn how to contribute to the OSO effort
+with new data sources, new data analysis, new visualizations, or source code.
+
+<Link to="/docs/contribute/intro" className="button button--secondary button--lg">Learn more</Link>
+
+---
+
+## Integrate with OSO
+
+Pull data and visualizations from OSO to integrate into your site or app.
+
+<Link to="/docs/integrate/getting-started" className="button button--secondary button--lg">Learn more</Link>
+
+---
+
+## Understand how OSO works
+
+Learn the internal architecture of how OSO is put together.
+We are [open source, open data, and open infrastructure](/blog/open-source-open-data-open-infra),
+with continuously-deployed and fully-transparent devops setup,
+ready to evolve with community contributions.
+
+<Link to="/docs/how-oso-works/intro" className="button button--secondary button--lg">Learn more</Link>
+
+---
+
+## Blog
+
+Check out the blog for impact reports, thought pieces and updates from the OSO team.
+
+<Link to="/blog" className="button button--secondary button--lg">Read</Link>
+
+---
+
+### Subscribe for updates
+
+<iframe
+  src={"https://kariba.substack.com/embed"}
+  width={400}
+  height={120}
+  style={{
+    background: "white",
+  }}
+  scrolling={"no"}
+/>

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -7,7 +7,7 @@ const config: Config = {
   tagline: "Measure impact on your platform.",
   favicon: "img/oso-emblem-black.svg",
 
-  url: "https://docs.opensource.observer",
+  url: "https://www.opensource.observer",
   // Set the /<baseUrl>/ pathname under which your site is served
   // For GitHub pages deployment, it is often '/<projectName>/'
   baseUrl: "/",

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -11,17 +11,27 @@ const nextConfig = {
       }
     : {
         // Options for non-static-export
+        async rewrites() {
+          return [
+            {
+              source: "/docs/:path*",
+              destination: "https://docs.opensource.observer/docs/:path*",
+            },
+            {
+              source: "/blog/:path*",
+              destination: "https://docs.opensource.observer/blog/:path*",
+            },
+            {
+              source: "/assets/:path*",
+              destination: "https://docs.opensource.observer/assets/:path*",
+            },
+          ];
+        },
         async redirects() {
           return [
             {
               source: "/discord",
               destination: "https://discord.com/invite/NGEJ35aWsq",
-              permanent: false,
-            },
-            {
-              source: "/docs",
-              destination:
-                "https://github.com/opensource-observer/oso/tree/main/docs",
               permanent: false,
             },
             {


### PR DESCRIPTION
…docs

* Keeping the separate docusaurus build, I'd like www.opensource.observer/docs and /blog to be canonical.