### PR TITLE
feat: add Supabase migration for a Hasura auth hook

### DIFF
--- a/frontend/components/dataprovider/auth-router.tsx
+++ b/frontend/components/dataprovider/auth-router.tsx
@@ -44,20 +44,28 @@ function AuthRouter(props: AuthRouterProps) {
   } = props;
   const key = variableName ?? DEFAULT_PLASMIC_VARIABLE;
 
-  const { value, error, loading } = useAsync(async () => {
+  const {
+    value: data,
+    error,
+    loading,
+  } = useAsync(async () => {
     if (useTestData) {
       return testData;
     }
     const {
       data: { user },
     } = await supabaseClient.auth.getUser();
+    const {
+      data: { session },
+    } = await supabaseClient.auth.getSession();
     console.log("User: ", user);
-    return user;
+    console.log("Session: ", session);
+    return {
+      user,
+      session,
+      supabase: supabaseClient,
+    };
   }, []);
-  const data = {
-    user: value,
-    supabase: supabaseClient,
-  };
 
   // Error messages are currently silently logged
   if (!loading && error) {
@@ -65,7 +73,7 @@ function AuthRouter(props: AuthRouterProps) {
   }
 
   // Show unauthenticated view
-  if (testNoAuth || (!loading && !value)) {
+  if (testNoAuth || (!loading && !data?.user)) {
     return <div className={className}>{noAuthChildren}</div>;
   }
 

--- a/frontend/supabase/migrations/20240209235914_hasura_claim.sql
+++ b/frontend/supabase/migrations/20240209235914_hasura_claim.sql
@@ -1,0 +1,30 @@
+--- Creates an auth hook to insert hasura custom claims into JWT tokens
+--- See https://supabase.com/docs/guides/auth/auth-hooks?language=add-admin-role#hook-custom-access-token
+
+create or replace function public.hasura_token_hook(event jsonb)
+returns jsonb
+language plv8
+as $$
+  // Check if 'claims.app_metadata' exists in the event object; if not, initialize it
+  if (!event.claims) {
+    event.claims = {};
+  }
+  if (!event.claims.app_metadata) {
+    event.claims.app_metadata = {};
+  }
+  // Set Hasura custom claims
+  event.claims.app_metadata["x-hasura-default-role"] = 'user';
+  event.claims.app_metadata["x-hasura-allowed-roles"] = ['user'];
+  event.claims.app_metadata["x-hasura-user-id"] = event.user_id;
+  return event;
+$$;
+
+grant execute
+  on function public.hasura_token_hook
+  to supabase_auth_admin;
+
+grant usage on schema public to supabase_auth_admin;
+
+revoke execute
+  on function public.hasura_token_hook
+  from authenticated, anon;


### PR DESCRIPTION
* The auth hook will take the user's id and put it in a custom claim under app_metadata using the fields that Hasura expects.
* Add print debugging on the Supabase session
* This needs to be enabled under the Supabase Auth Hook settings