### PR TITLE
Rename GitHub metrics

### DIFF
--- a/dbt/models/intermediate/contributors/int_devs.sql
+++ b/dbt/models/intermediate/contributors/int_devs.sql
@@ -24,4 +24,4 @@ WHERE
     'ISSUE_CLOSED',
     'ISSUE_CREATED'
   )
-GROUP BY 1, 2, 3
+GROUP BY e.project_id, bucket_month, e.from_id, repository_source

--- a/dbt/models/intermediate/contributors/int_devs.sql
+++ b/dbt/models/intermediate/contributors/int_devs.sql
@@ -1,15 +1,22 @@
 SELECT
   e.project_id,
+  e.to_namespace AS repository_source,
   e.from_id,
+  1 AS amount,
   TIMESTAMP_TRUNC(e.time, MONTH) AS bucket_month,
-  CASE 
-    WHEN COUNT(DISTINCT CASE WHEN e.event_type = 'COMMIT_CODE' THEN e.time END) >= 10 THEN 'FULL_TIME_DEV'
-    WHEN COUNT(DISTINCT CASE WHEN e.event_type = 'COMMIT_CODE' THEN e.time END) >= 1 THEN 'PART_TIME_DEV'
+  CASE
+    WHEN
+      COUNT(DISTINCT CASE WHEN e.event_type = 'COMMIT_CODE' THEN e.time END)
+      >= 10
+      THEN 'FULL_TIME_DEV'
+    WHEN
+      COUNT(DISTINCT CASE WHEN e.event_type = 'COMMIT_CODE' THEN e.time END)
+      >= 1
+      THEN 'PART_TIME_DEV'
     ELSE 'OTHER_CONTRIBUTOR'
-  END AS user_segment_type,
-  1 AS amount
-FROM {{ ref('int_events_to_project') }} as e
-WHERE 
+  END AS user_segment_type
+FROM {{ ref('int_events_to_project') }} AS e
+WHERE
   e.event_type IN (
     'PULL_REQUEST_CREATED',
     'PULL_REQUEST_MERGED',
@@ -17,4 +24,4 @@ WHERE
     'ISSUE_CLOSED',
     'ISSUE_CREATED'
   )
-GROUP BY 1,2,3
+GROUP BY 1, 2, 3

--- a/dbt/models/intermediate/contributors/int_users.sql
+++ b/dbt/models/intermediate/contributors/int_users.sql
@@ -1,13 +1,14 @@
-SELECT 
+SELECT
   e.project_id,
+  e.to_namespace AS onchain_network,
   e.from_id,
+  1 AS amount,
   TIMESTAMP_TRUNC(e.time, MONTH) AS bucket_month,
-  CASE 
+  CASE
     WHEN SUM(e.amount) >= 1000 THEN 'HIGH_FREQUENCY_USER'
     WHEN SUM(e.amount) >= 10 THEN 'HIGH_VALUE_USER'
     ELSE 'LOW_VALUE_USER'
-  END AS user_segment_type,
-  1 AS amount
-FROM {{ ref('int_events_to_project') }} as e
+  END AS user_segment_type
+FROM {{ ref('int_events_to_project') }} AS e
 WHERE e.event_type = 'CONTRACT_INVOCATION_DAILY_COUNT'
-GROUP BY 1,2,3
+GROUP BY 1, 2, 3

--- a/dbt/models/intermediate/contributors/int_users.sql
+++ b/dbt/models/intermediate/contributors/int_users.sql
@@ -11,4 +11,4 @@ SELECT
   END AS user_segment_type
 FROM {{ ref('int_events_to_project') }} AS e
 WHERE e.event_type = 'CONTRACT_INVOCATION_DAILY_COUNT'
-GROUP BY 1, 2, 3
+GROUP BY e.project_id, onchain_network, e.from_id, bucket_month

--- a/dbt/models/marts/onchain_metrics/onchain_metrics_by_project.sql
+++ b/dbt/models/marts/onchain_metrics/onchain_metrics_by_project.sql
@@ -21,7 +21,7 @@
 WITH txns AS (
   SELECT
     a.project_id,
-    c.to_namespace AS network,
+    c.to_namespace AS onchain_network,
     c.from_source_id AS from_id,
     c.l2_gas,
     c.tx_count,
@@ -36,37 +36,37 @@ WITH txns AS (
 metrics_all_time AS (
   SELECT
     project_id,
-    network,
+    onchain_network,
     MIN(bucket_month) AS first_txn_date,
     COUNT(DISTINCT from_id) AS total_users,
     SUM(l2_gas) AS total_l2_gas,
     SUM(tx_count) AS total_txns
   FROM txns
-  GROUP BY project_id, network
+  GROUP BY project_id, onchain_network
 ),
 
 metrics_6_months AS (
   SELECT
     project_id,
-    network,
+    onchain_network,
     COUNT(DISTINCT from_id) AS users_6_months,
     SUM(l2_gas) AS l2_gas_6_months,
     SUM(tx_count) AS txns_6_months
   FROM txns
   WHERE bucket_month >= DATE_ADD(CURRENT_DATE(), INTERVAL -6 MONTH)
-  GROUP BY project_id, network
+  GROUP BY project_id, onchain_network
 ),
 
 -- CTE for identifying new users to the project in the last 3 months
 new_users AS (
   SELECT
     project_id,
-    network,
+    onchain_network,
     SUM(is_new_user) AS new_user_count
   FROM (
     SELECT
       project_id,
-      network,
+      onchain_network,
       from_id,
       CASE
         WHEN
@@ -75,36 +75,36 @@ new_users AS (
             1
       END AS is_new_user
     FROM txns
-    GROUP BY project_id, network, from_id
+    GROUP BY project_id, onchain_network, from_id
   )
-  GROUP BY project_id, network
+  GROUP BY project_id, onchain_network
 ),
 
 -- CTEs for segmenting different types of active users based on txn volume
 user_txns_aggregated AS (
   SELECT
     project_id,
-    network,
+    onchain_network,
     from_id,
     SUM(tx_count) AS total_tx_count
   FROM txns
   WHERE bucket_month >= DATE_ADD(CURRENT_DATE(), INTERVAL -3 MONTH)
-  GROUP BY project_id, network, from_id
+  GROUP BY project_id, onchain_network, from_id
 ),
 
 multi_project_users AS (
   SELECT
-    network,
+    onchain_network,
     from_id,
     COUNT(DISTINCT project_id) AS projects_transacted_on
   FROM user_txns_aggregated
-  GROUP BY network, from_id
+  GROUP BY onchain_network, from_id
 ),
 
 user_segments AS (
   SELECT
     project_id,
-    network,
+    onchain_network,
     COUNT(DISTINCT CASE
       WHEN user_segment = 'HIGH_FREQUENCY_USER' THEN from_id
     END) AS high_frequency_users,
@@ -120,7 +120,7 @@ user_segments AS (
   FROM (
     SELECT
       uta.project_id,
-      uta.network,
+      uta.onchain_network,
       uta.from_id,
       mpu.projects_transacted_on,
       CASE
@@ -132,23 +132,23 @@ user_segments AS (
     INNER JOIN multi_project_users AS mpu
       ON uta.from_id = mpu.from_id
   )
-  GROUP BY project_id, network
+  GROUP BY project_id, onchain_network
 ),
 
 -- CTE to count the number of contracts deployed by a project
 contracts AS (
   SELECT
     project_id,
-    artifact_namespace AS network,
+    artifact_namespace AS onchain_network,
     COUNT(artifact_source_id) AS num_contracts
   FROM {{ ref('stg_ossd__artifacts_by_project') }}
-  GROUP BY project_id, network
+  GROUP BY project_id, onchain_network
 ),
 
 project_by_network AS (
   SELECT
     p.project_id,
-    ctx.network,
+    ctx.onchain_network,
     p.project_name
   FROM {{ ref('projects') }} AS p
   INNER JOIN contracts AS ctx
@@ -158,7 +158,7 @@ project_by_network AS (
 -- Final query to join all the metrics together
 SELECT
   p.project_id,
-  p.network,
+  p.onchain_network,
   p.project_name,
   -- TODO: add deployers owned by project
   c.num_contracts,

--- a/dbt/models/marts/onchain_metrics/onchain_metrics_by_project.sql
+++ b/dbt/models/marts/onchain_metrics/onchain_metrics_by_project.sql
@@ -181,20 +181,20 @@ FROM project_by_network AS p
 LEFT JOIN metrics_all_time AS ma
   ON
     p.project_id = ma.project_id
-    AND p.network = ma.network
+    AND p.onchain_network = ma.onchain_network
 LEFT JOIN metrics_6_months AS m6
   ON
     p.project_id = m6.project_id
-    AND p.network = m6.network
+    AND p.onchain_network = m6.onchain_network
 LEFT JOIN new_users AS nu
   ON
     p.project_id = nu.project_id
-    AND p.network = nu.network
+    AND p.onchain_network = nu.onchain_network
 LEFT JOIN user_segments AS us
   ON
     p.project_id = us.project_id
-    AND p.network = us.network
+    AND p.onchain_network = us.onchain_network
 LEFT JOIN contracts AS c
   ON
     p.project_id = c.project_id
-    AND p.network = c.network
+    AND p.onchain_network = c.onchain_network

--- a/dbt/models/marts/repository_metrics/repository_metrics_by_project.sql
+++ b/dbt/models/marts/repository_metrics/repository_metrics_by_project.sql
@@ -22,6 +22,7 @@
 WITH project_commit_dates AS (
   SELECT
     e.project_id,
+    r.repository_source,
     MIN(e.time) AS first_commit_date,
     MAX(e.time) AS last_commit_date
   FROM {{ ref('int_events_to_project') }} AS e
@@ -31,19 +32,23 @@ WITH project_commit_dates AS (
   WHERE
     e.event_type = 'COMMIT_CODE'
     AND r.is_fork = false
-  GROUP BY e.project_id
+  GROUP BY e.project_id, r.repository_source
 ),
 
 -- CTE for aggregating stars, forks, and repository counts by project 
-stars_forks_repos AS (
+project_repos_summary AS (
   SELECT
-    project_id,
-    COUNT(DISTINCT id) AS repos,
-    SUM(star_count) AS stars,
-    SUM(fork_count) AS forks
-  FROM {{ ref('stg_ossd__repositories_by_project') }}
-  WHERE is_fork = false
-  GROUP BY project_id
+    p.project_id,
+    p.project_name,
+    r.repository_source,
+    COUNT(DISTINCT r.id) AS repositories,
+    SUM(r.star_count) AS stars,
+    SUM(r.fork_count) AS forks
+  FROM {{ ref('stg_ossd__repositories_by_project') }} AS r
+  INNER JOIN {{ ref('projects') }} AS p
+    ON p.project_id = r.project_id
+  WHERE r.is_fork = false
+  GROUP BY p.project_id, p.project_name, r.repository_source
 ),
 
 -- CTE for calculating contributor counts and new contributors in the last 6 
@@ -51,6 +56,7 @@ stars_forks_repos AS (
 contributors_cte AS (
   SELECT
     project_id,
+    repository_source,
     COUNT(DISTINCT from_id) AS contributors,
     COUNT(
       DISTINCT CASE
@@ -88,6 +94,7 @@ contributors_cte AS (
     SELECT
       from_id,
       project_id,
+      repository_source,
       user_segment_type,
       DATE(bucket_month) AS bucket_month,
       MIN(DATE(bucket_month))
@@ -95,13 +102,14 @@ contributors_cte AS (
         AS first_contribution_date
     FROM {{ ref('int_devs') }}
   )
-  GROUP BY project_id
+  GROUP BY project_id, repository_source
 ),
 
 -- CTE for summarizing project activity metrics over the past 6 months
 activity_cte AS (
   SELECT
     project_id,
+    to_namespace AS repository_source,
     SUM(CASE WHEN event_type = 'COMMIT_CODE' THEN amount END)
       AS commits_6_months,
     SUM(CASE WHEN event_type = 'ISSUE_OPENED' THEN amount END)
@@ -114,13 +122,14 @@ activity_cte AS (
       AS pull_requests_merged_6_months
   FROM {{ ref('int_events_to_project') }}
   WHERE DATE(time) >= DATE_ADD(CURRENT_DATE(), INTERVAL -180 DAY)
-  GROUP BY project_id
+  GROUP BY project_id, repository_source
 )
 
 -- Final query to join all the metrics together
 SELECT
   p.project_id,
   p.project_name,
+  p.repository_source,
   pcd.first_commit_date,
   pcd.last_commit_date,
   sfr.repos,
@@ -138,6 +147,6 @@ SELECT
   act.pull_requests_merged_6_months
 FROM {{ ref('projects') }} AS p
 LEFT JOIN project_commit_dates AS pcd ON p.project_id = pcd.project_id
-LEFT JOIN stars_forks_repos AS sfr ON p.project_id = sfr.project_id
+LEFT JOIN project_repos_summary AS sfr ON p.project_id = sfr.project_id
 LEFT JOIN contributors_cte AS c ON p.project_id = c.project_id
 LEFT JOIN activity_cte AS act ON p.project_id = act.project_id

--- a/dbt/models/staging/oss-directory/stg_ossd__repositories_by_project.sql
+++ b/dbt/models/staging/oss-directory/stg_ossd__repositories_by_project.sql
@@ -1,11 +1,16 @@
 SELECT
-  projects.id as project_id,
+  projects.id AS project_id,
+  {# 
+    Currently this is just Github. 
+    oss-directory needs some refactoring to support multiple repository providers 
+  #}
+  "GITHUB" AS repository_source,
   repos.*
 FROM
   {{ ref('stg_ossd__current_projects')}} AS projects
 CROSS JOIN
   UNNEST(JSON_QUERY_ARRAY(projects.github)) AS github
-JOIN
+INNER JOIN
   {{ ref('stg_ossd__current_repositories') }} AS repos
 ON
   LOWER(CONCAT("https://github.com/", repos.owner)) = LOWER(JSON_VALUE(github.url))


### PR DESCRIPTION
* `github_metrics_*` metrics now renamed to `repository_metrics_*`
* Renamed `network` field in `onchain_*` to `onchain_network` to follow the same format as `repository_source`
* Fixed some linting in various files

Closes #974 