### PR TITLE
docs: dark mode fiddling

### DIFF
--- a/apps/docs/.gitignore
+++ b/apps/docs/.gitignore
@@ -2,7 +2,6 @@
 /node_modules
 
 # Plasmic
-plasmic.lock
 src/components/plasmic/generated/
 static/plasmic/
 

--- a/apps/docs/docs/index.mdx
+++ b/apps/docs/docs/index.mdx
@@ -5,7 +5,7 @@ hide_title: true
 ---
 
 import { PlasmicRootProvider } from "@plasmicapp/react-web";
-import Overview from "../src/components/plasmic/Overview";
+import Overview from "@site/src/components/plasmic/Overview";
 
 <PlasmicRootProvider>
   <Overview /> 

--- a/apps/docs/plasmic.lock
+++ b/apps/docs/plasmic.lock
@@ -1,0 +1,74 @@
+{
+  "projects": [
+    {
+      "projectId": "2CtczDeUz9jL9qnFi6NWuQ",
+      "version": "0.2.3",
+      "dependencies": {},
+      "lang": "ts",
+      "fileLocks": [
+        {
+          "type": "globalVariant",
+          "assetId": "kb7NFax8VjYW",
+          "checksum": "9eb497dcb98641fa3805552f6211dd1f"
+        },
+        {
+          "type": "renderModule",
+          "assetId": "z50hW5Ihi9k5",
+          "checksum": "764f7ac9b1bc61e8a4dabc7c0cce30b7"
+        },
+        {
+          "type": "cssRules",
+          "assetId": "z50hW5Ihi9k5",
+          "checksum": "764f7ac9b1bc61e8a4dabc7c0cce30b7"
+        },
+        {
+          "type": "renderModule",
+          "assetId": "8u0yNVg3vXsq",
+          "checksum": "ac6bb58e7ce47ba42b269afa169726bf"
+        },
+        {
+          "type": "cssRules",
+          "assetId": "8u0yNVg3vXsq",
+          "checksum": "ac6bb58e7ce47ba42b269afa169726bf"
+        },
+        {
+          "type": "renderModule",
+          "assetId": "XdMR0R8lmSdz",
+          "checksum": "44eeb25bb981c336fe8a72b0d7b53448"
+        },
+        {
+          "type": "cssRules",
+          "assetId": "XdMR0R8lmSdz",
+          "checksum": "44eeb25bb981c336fe8a72b0d7b53448"
+        },
+        {
+          "type": "icon",
+          "assetId": "bBICBhwqdJEn",
+          "checksum": "6c340bbb97a866e45667be367e634e39"
+        },
+        {
+          "type": "icon",
+          "assetId": "4hUpITJttWoK",
+          "checksum": "be2769e464c565231e59eb1dbdcbc680"
+        },
+        {
+          "type": "image",
+          "assetId": "cyI4ZarUDDWI",
+          "checksum": "d4469b4760336bf35eefb3203c0813eb"
+        },
+        {
+          "type": "icon",
+          "assetId": "IUL_Z3b2VK27",
+          "checksum": "f747464e248d0fd06360dae746c9d7f8"
+        },
+        {
+          "assetId": "2CtczDeUz9jL9qnFi6NWuQ",
+          "type": "projectCss",
+          "checksum": "ca22df23535ee01348fd2e1587fefcbb"
+        }
+      ],
+      "codegenVersion": "0.0.1"
+    }
+  ],
+  "cliVersion": "0.1.327"
+}

--- a/apps/docs/src/components/plasmic/Overview.tsx
+++ b/apps/docs/src/components/plasmic/Overview.tsx
@@ -29,7 +29,7 @@ function Overview_(props: OverviewProps, ref: HTMLElementRefOf<"div">) {
   const { theme, ...rest } = props;
   const { colorMode } = useColorMode();
   const chosenTheme = [theme, colorMode].includes("dark") ? "dark" : undefined;
-  console.log(colorMode);
+  console.log(chosenTheme, colorMode);
 
   // Use PlasmicOverview to render this component as it was
   // designed in Plasmic, by activating the appropriate variants,
@@ -46,7 +46,7 @@ function Overview_(props: OverviewProps, ref: HTMLElementRefOf<"div">) {
   // By default, we are just piping all OverviewProps here, but feel free
   // to do whatever works for you.
 
-  return <PlasmicOverview root={{ ref }} {...rest} theme={chosenTheme} />;
+  return <PlasmicOverview {...rest} root={{ ref }} theme={chosenTheme} />;
 }
 
 const Overview = React.forwardRef(Overview_);


### PR DESCRIPTION
* Trying to fix a weird behavior on dark mode, everything seems to work locally, but on production, the Plasmic components don't re-render when the dark mode is toggled. Not sure what causes that
* Fixed the import on docs/index.mdx
* Adding plasmic.lock into the version control