### PR TITLE
feat: use OSO API keys in our own app

### DIFF
--- a/.github/workflows/ci-default.yml
+++ b/.github/workflows/ci-default.yml
@@ -11,6 +11,7 @@ env:
   PLASMIC_PROJECT_API_TOKEN: ${{ vars.PLASMIC_PROJECT_API_TOKEN }}
   NEXT_PUBLIC_DOMAIN: ${{ vars.NEXT_PUBLIC_DOMAIN }}
   NEXT_PUBLIC_DB_GRAPHQL_URL: ${{ vars.NEXT_PUBLIC_DB_GRAPHQL_URL }}
+  OSO_API_KEY: ${{ secrets.OSO_API_KEY }}
   NEXT_PUBLIC_SUPABASE_URL: ${{ vars.NEXT_PUBLIC_SUPABASE_URL }}
   NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
   SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
@@ -20,14 +21,7 @@ env:
   NEXT_PUBLIC_ALGOLIA_INDEX: ${{ vars.NEXT_PUBLIC_ALGOLIA_INDEX }}
   NEXT_PUBLIC_FEEDBACK_FARM_ID: ${{ vars.NEXT_PUBLIC_FEEDBACK_FARM_ID }}
   # Indexer variables
-  DB_HOST: ${{ vars.DB_HOST }}
-  DB_PORT: ${{ vars.DB_PORT }}
-  DB_USER: ${{ vars.DB_USER }}
-  DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
-  DB_DATABASE: ${{ vars.DB_DATABASE }}
   DB_APPLICATION_NAME: oso-ci
-  X_GITHUB_GRAPHQL_API: ${{ vars.X_GITHUB_GRAPHQL_API }}
-  X_GITHUB_TOKEN: ${{ secrets.X_GITHUB_TOKEN }}
   GOOGLE_PROJECT_ID: "opensource-observer"
 
   # should not be set to a legitimate value for testing. This will use up API

--- a/apps/frontend/.env.local.example
+++ b/apps/frontend/.env.local.example
@@ -15,6 +15,7 @@ PLASMIC_PROJECT_API_TOKEN=
 NEXT_PUBLIC_DOMAIN=www.opensource.observer
 ### GraphQL API endpoint for database
 NEXT_PUBLIC_DB_GRAPHQL_URL=
+OSO_API_KEY=
 ### Supabase for database
 NEXT_PUBLIC_SUPABASE_URL=
 NEXT_PUBLIC_SUPABASE_ANON_KEY=

--- a/apps/frontend/codegen.ts
+++ b/apps/frontend/codegen.ts
@@ -4,11 +4,18 @@ const envPath = [__dirname, "./.env.local"].join("/");
 dotenv.config();
 dotenv.config({ path: envPath, override: true });
 
-const DB_GRAPHQL_URL = process.env.NEXT_PUBLIC_DB_GRAPHQL_URL;
+const DB_GRAPHQL_URL = process.env.NEXT_PUBLIC_DB_GRAPHQL_URL!;
+const OSO_API_KEY = process.env.OSO_API_KEY;
 console.log(DB_GRAPHQL_URL);
 
+const SCHEMA: Record<string, any> = {};
+SCHEMA[DB_GRAPHQL_URL] = {
+  headers: {
+    Authorization: `Bearer ${OSO_API_KEY}`,
+  },
+};
 const config: CodegenConfig = {
-  schema: DB_GRAPHQL_URL,
+  schema: SCHEMA,
   documents: [
     "app/**/*.{ts,tsx}",
     "pages/**/*.{ts,tsx}",

--- a/apps/frontend/lib/clients/apollo.ts
+++ b/apps/frontend/lib/clients/apollo.ts
@@ -1,12 +1,15 @@
 import { ApolloClient, InMemoryCache, HttpLink } from "@apollo/client";
 import { registerApolloClient } from "@apollo/experimental-nextjs-app-support/rsc";
-import { DB_GRAPHQL_URL } from "../config";
+import { DB_GRAPHQL_URL, OSO_API_KEY } from "../config";
 
 const { getClient: getApolloClient } = registerApolloClient(() => {
   return new ApolloClient({
     cache: new InMemoryCache(),
     link: new HttpLink({
       uri: DB_GRAPHQL_URL,
+      headers: {
+        Authorization: `Bearer ${OSO_API_KEY}`,
+      },
     }),
   });
 });

--- a/apps/frontend/lib/config.ts
+++ b/apps/frontend/lib/config.ts
@@ -22,6 +22,8 @@ export const DB_GRAPHQL_URL = requireEnv(
   "NEXT_PUBLIC_DB_GRAPHQL_URL",
 );
 
+export const OSO_API_KEY = requireEnv(process.env.OSO_API_KEY, "OSO_API_KEY");
+
 export const SUPABASE_URL = requireEnv(
   process.env.NEXT_PUBLIC_SUPABASE_URL,
   "NEXT_PUBLIC_SUPABASE_URL",


### PR DESCRIPTION
* We currently use the OSO API in 2 places: (1) to generate types for the GraphQL API via codegen and (2) to make server-side queries to the database.
* Added OSO API keys in various GraphQL initializers so we don't get a broken build if we exhaust the anon rate limit