### PR TITLE
feat: wire up the new project page

### DIFF
--- a/apps/frontend/app/api/auth/route.ts
+++ b/apps/frontend/app/api/auth/route.ts
@@ -42,6 +42,7 @@ export async function GET(request: NextRequest) {
 
   // If no token provided, then return anonymous role
   if (!auth) {
+    console.log(`/api/auth: No token => anon`);
     return NextResponse.json(makeAnonRole());
   }
 
@@ -54,9 +55,9 @@ export async function GET(request: NextRequest) {
   // Try JWT decoding
   try {
     const decoded = jwtDecode(token);
-    console.log("JWT token:", decoded);
+    console.log("JWT token: ", decoded);
   } catch (e) {
-    console.warn("JWT error: ", e);
+    console.warn("JWT decoding error: ", e);
   }
 
   // Get the user
@@ -66,12 +67,13 @@ export async function GET(request: NextRequest) {
     .eq(API_KEY_COLUMN, token);
 
   if (keyError || !keyData) {
-    console.warn("Error retrieving API keys", keyError);
+    console.warn(`/api/auth: Error retrieving API keys => anon`, keyError);
     return NextResponse.json(makeAnonRole());
   }
 
   const activeKeys = keyData.filter((x) => !x.deleted_at);
   if (activeKeys.length < 1) {
+    console.log(`/api/auth: API key not valid => anon`);
     return NextResponse.json(makeAnonRole());
   }
 
@@ -86,12 +88,13 @@ export async function GET(request: NextRequest) {
 
   if (collectiveError || !collectiveData) {
     console.warn(
-      "Error retrieving data collective membership",
+      `/api/auth: Valid key, error retrieving data collective membership => user`,
       collectiveError,
     );
     return NextResponse.json(makeUserRole(userId));
   } else if (collectiveData.length < 1) {
     // Not a member
+    console.log(`/api/auth: Valid key, not data collective member => user`);
     return NextResponse.json(makeUserRole(userId));
   }
 

--- a/apps/frontend/components/dataprovider/event-data-provider.tsx
+++ b/apps/frontend/components/dataprovider/event-data-provider.tsx
@@ -4,7 +4,7 @@ import _ from "lodash";
 import React from "react";
 import { assertNever, ensure, uncheckedCast } from "../../lib/common";
 import {
-  GET_ARTIFACT_BY_IDS,
+  GET_ARTIFACTS_BY_IDS,
   GET_PROJECTS_BY_IDS,
   GET_COLLECTIONS_BY_IDS,
   GET_EVENTS_DAILY_TO_ARTIFACT,
@@ -359,7 +359,7 @@ function ArtifactEventDataProvider(props: EventDataProviderProps) {
     data: artifactData,
     error: artifactError,
     loading: artifactLoading,
-  } = useQuery(GET_ARTIFACT_BY_IDS, {
+  } = useQuery(GET_ARTIFACTS_BY_IDS, {
     variables: {
       artifact_ids: props.ids,
     },

--- a/apps/frontend/lib/graphql/cached-queries.ts
+++ b/apps/frontend/lib/graphql/cached-queries.ts
@@ -1,10 +1,15 @@
 import { cache } from "react";
 import { getApolloClient } from "../clients/apollo";
+import { QueryOptions } from "@apollo/client";
 import {
-  GET_ALL_ARTIFACTS,
+  GET_ARTIFACTS_BY_IDS,
   GET_ARTIFACT_BY_NAME,
-  GET_ALL_PROJECTS,
+  GET_ARTIFACT_IDS_BY_PROJECT_IDS,
   GET_PROJECTS_BY_SLUGS,
+  GET_COLLECTIONS_BY_IDS,
+  GET_COLLECTION_IDS_BY_PROJECT_IDS,
+  GET_CODE_METRICS_BY_PROJECT,
+  GET_ONCHAIN_METRICS_BY_PROJECT,
   GET_ALL_EVENT_TYPES,
 } from "./queries";
 import { logger } from "../logger";
@@ -12,76 +17,98 @@ import { logger } from "../logger";
 // Revalidate the data at most every hour
 export const revalidate = false; // 3600 = 1 hour
 
-// Cached getters
-const cachedGetAllArtifacts = cache(async () => {
-  const { data, error } = await getApolloClient().query({
-    query: GET_ALL_ARTIFACTS,
-  });
+const queryWrapper = async (opts: QueryOptions) => {
+  const { data, error } = await getApolloClient().query(opts);
   if (error) {
     logger.error(error);
     throw error;
   }
   return data;
-});
+};
+
+// Cached getters
+const cachedGetAllEventTypes = cache(async () =>
+  queryWrapper({
+    query: GET_ALL_EVENT_TYPES,
+  }),
+);
+
+const cachedGetProjectsBySlugs = cache(
+  async (variables: { project_slugs: string[] }) =>
+    queryWrapper({
+      query: GET_PROJECTS_BY_SLUGS,
+      variables,
+    }),
+);
+
+const cachedGetArtifactsByIds = cache(
+  async (variables: { artifact_ids: string[] }) =>
+    queryWrapper({
+      query: GET_ARTIFACTS_BY_IDS,
+      variables,
+    }),
+);
 
 const cachedGetArtifactByName = cache(
   async (variables: {
     artifact_namespace: string;
     artifact_type: string;
     artifact_name: string;
-  }) => {
-    const { data, error } = await getApolloClient().query({
+  }) =>
+    queryWrapper({
       query: GET_ARTIFACT_BY_NAME,
       variables,
-    });
-    if (error) {
-      logger.error(error);
-      throw error;
-    }
-    return data;
-  },
+    }),
 );
 
-const cachedGetAllProjects = cache(async () => {
-  const { data, error } = await getApolloClient().query({
-    query: GET_ALL_PROJECTS,
-  });
-  if (error) {
-    logger.error(error);
-    throw error;
-  }
-  return data;
-});
-
-const cachedGetProjectsBySlugs = cache(
-  async (variables: { project_slugs: string[] }) => {
-    const { data, error } = await getApolloClient().query({
-      query: GET_PROJECTS_BY_SLUGS,
+const cachedGetArtifactIdsByProjectIds = cache(
+  async (variables: { project_ids: string[] }) =>
+    queryWrapper({
+      query: GET_ARTIFACT_IDS_BY_PROJECT_IDS,
       variables,
-    });
-    if (error) {
-      logger.error(error);
-      throw error;
-    }
-    return data;
-  },
+    }),
 );
 
-const cachedGetAllEventTypes = cache(async () => {
-  const { data, error } = await getApolloClient().query({
-    query: GET_ALL_EVENT_TYPES,
-  });
-  if (error) {
-    logger.error(error);
-    throw error;
-  }
-  return data;
-});
+const cachedGetCollectionsByIds = cache(
+  async (variables: { collection_ids: string[] }) =>
+    queryWrapper({
+      query: GET_COLLECTIONS_BY_IDS,
+      variables,
+    }),
+);
+
+const cachedGetCollectionIdsByProjectIds = cache(
+  async (variables: { project_ids: string[] }) =>
+    queryWrapper({
+      query: GET_COLLECTION_IDS_BY_PROJECT_IDS,
+      variables,
+    }),
+);
+
+const cachedGetCodeMetricsByProjectIds = cache(
+  async (variables: { project_ids: string[] }) =>
+    queryWrapper({
+      query: GET_CODE_METRICS_BY_PROJECT,
+      variables,
+    }),
+);
+
+const cachedGetOnchainMetricsByProjectIds = cache(
+  async (variables: { project_ids: string[] }) =>
+    queryWrapper({
+      query: GET_ONCHAIN_METRICS_BY_PROJECT,
+      variables,
+    }),
+);
 
 export {
-  cachedGetAllArtifacts,
+  cachedGetArtifactsByIds,
   cachedGetArtifactByName,
-  cachedGetAllProjects,
+  cachedGetArtifactIdsByProjectIds,
   cachedGetProjectsBySlugs,
+  cachedGetCollectionsByIds,
+  cachedGetCollectionIdsByProjectIds,
+  cachedGetCodeMetricsByProjectIds,
+  cachedGetOnchainMetricsByProjectIds,
   cachedGetAllEventTypes,
 };

--- a/apps/frontend/lib/graphql/queries.ts
+++ b/apps/frontend/lib/graphql/queries.ts
@@ -20,7 +20,7 @@ const GET_ALL_ARTIFACTS = gql(`
   }
 `);
 
-const GET_ARTIFACT_BY_IDS = gql(`
+const GET_ARTIFACTS_BY_IDS = gql(`
   query ArtifactByIds($artifact_ids: [String!]) @cached(ttl: 300) {
     artifacts(where: { artifact_id: { _in: $artifact_ids }}) {
       artifact_id
@@ -44,6 +44,14 @@ const GET_ARTIFACT_BY_NAME = gql(`
       artifact_latest_name
       artifact_names
       artifact_url
+    }
+  }
+`);
+
+const GET_ARTIFACT_IDS_BY_PROJECT_IDS = gql(`
+  query ArtifactIdsByProjectIds($project_ids: [String!]) @cached(ttl: 300) {
+    artifacts_by_project(where: { project_id: { _in: $project_ids }}) {
+      artifact_id
     }
   }
 `);
@@ -118,6 +126,75 @@ const GET_COLLECTIONS_BY_SLUGS = gql(`
       user_namespace
       collection_slug
       collection_name
+    }
+  }
+`);
+
+const GET_COLLECTION_IDS_BY_PROJECT_IDS = gql(`
+  query CollectionIdsByProjectIds($project_ids: [String!]) @cached(ttl: 300) {
+    projects_by_collection(where: { project_id: { _in: $project_ids }}) {
+      collection_id
+    }
+  }
+`);
+
+/**********************
+ * METRICS
+ **********************/
+
+const GET_CODE_METRICS_BY_PROJECT = gql(`
+  query CodeMetricsByProject(
+    $project_ids: [String!],
+  ) {
+    code_metrics_by_project(where: {
+      project_id: { _in: $project_ids },
+    }) {
+      project_id
+      project_name
+      stars
+      source
+      repositories
+      pull_requests_opened_6_months
+      pull_requests_merged_6_months
+      new_contributors_6_months
+      last_commit_date
+      issues_opened_6_months
+      issues_closed_6_months
+      avg_active_devs_6_months
+      avg_fulltime_devs_6_months
+      commits_6_months
+      contributors
+      contributors_6_months
+      first_commit_date
+      forks
+    }
+  }
+`);
+
+const GET_ONCHAIN_METRICS_BY_PROJECT = gql(`
+  query OnchainMetricsByProject(
+    $project_ids: [String!],
+  ) {
+    onchain_metrics_by_project(where: {
+      project_id: { _in: $project_ids },
+    }) {
+      project_id
+      project_name
+      active_users
+      first_txn_date
+      high_frequency_users
+      l2_gas_6_months
+      less_active_users
+      more_active_users
+      multi_project_users
+      network
+      new_user_count
+      num_contracts
+      total_l2_gas
+      total_txns
+      total_users
+      txns_6_months
+      users_6_months
     }
   }
 `);
@@ -336,14 +413,18 @@ const GET_EVENTS_MONTHLY_TO_ARTIFACT = gql(`
 
 export {
   GET_ALL_ARTIFACTS,
-  GET_ARTIFACT_BY_IDS,
+  GET_ARTIFACTS_BY_IDS,
   GET_ARTIFACT_BY_NAME,
+  GET_ARTIFACT_IDS_BY_PROJECT_IDS,
   GET_ALL_PROJECTS,
   GET_PROJECTS_BY_IDS,
   GET_PROJECTS_BY_SLUGS,
   GET_ALL_COLLECTIONS,
   GET_COLLECTIONS_BY_IDS,
   GET_COLLECTIONS_BY_SLUGS,
+  GET_COLLECTION_IDS_BY_PROJECT_IDS,
+  GET_CODE_METRICS_BY_PROJECT,
+  GET_ONCHAIN_METRICS_BY_PROJECT,
   GET_ALL_EVENT_TYPES,
   GET_EVENTS_DAILY_TO_ARTIFACT,
   GET_EVENTS_WEEKLY_TO_ARTIFACT,


### PR DESCRIPTION
* Reflected in Plasmic v48.0.0, this does the main data queries server-side (cached), and then passes it in as props to the page.
* Adds a bunch of new GraphQL queries that we use for the project page
* Adds a `queryWrapper` to cache new queries easily
* Added some minor logging to the auth route for later