### PR TITLE
fix: frontend

### DIFF
--- a/apps/frontend/lib/graphql/queries.ts
+++ b/apps/frontend/lib/graphql/queries.ts
@@ -149,7 +149,6 @@ const GET_CODE_METRICS_BY_PROJECT = gql(`
       project_id
       project_name
       stars
-      source
       repositories
       pull_requests_opened_6_months
       pull_requests_merged_6_months

--- a/apps/hasura/metadata/api_limits.yaml
+++ b/apps/hasura/metadata/api_limits.yaml
@@ -19,5 +19,5 @@ time_limit:
   global: 60
   per_role:
     anonymous: 5
-    user: 10
+    user: 15
     developer: 60


### PR DESCRIPTION
* There was a broken query: `source` no longer existed on code_metrics, which caused a confusing generic "Apollo database error"
* Updated the Hasura API limits, just because