### PR TITLE
fix: cloudquery-oss-directory should import `description`

### DIFF
--- a/.lintstagedrc
+++ b/.lintstagedrc
@@ -9,7 +9,7 @@
     "prettier --ignore-path .gitignore --log-level warn --check"
   ],
   "warehouse/dbt/**/*.sql": [
-    "poetry run sqlfluff fix -f --dialect bigquery",
-    "poetry run sqlfluff lint --dialect bigquery"
+    "poetry run sqlfluff fix -f",
+    "poetry run sqlfluff lint"
   ]
 }

--- a/warehouse/cloudquery-oss-directory/src/tables.ts
+++ b/warehouse/cloudquery-oss-directory/src/tables.ts
@@ -104,6 +104,7 @@ export const getTables = async (options: TableOptions): Promise<Table[]> => {
         newColumn("display_name", {
           notNull: true,
         }),
+        newColumn("description", {}),
         newColumn("version", {
           type: new Int64(),
         }),
@@ -135,6 +136,7 @@ export const getTables = async (options: TableOptions): Promise<Table[]> => {
         newColumn("display_name", {
           notNull: true,
         }),
+        newColumn("description", {}),
         newColumn("github", {
           type: new JSONType(),
           // Ideally we'd be able to use structs to more precisely specify the


### PR DESCRIPTION
* Minor, we get the SQL dialect from .sqlfluff now, so we don't need to explicitly flag it