### PR TITLE
fix: remove strict packageManager version in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "prettier": "^3.2.4",
     "turbo": "^1.11.3"
   },
-  "packageManager": "pnpm@9.0.6",
   "engines": {
     "node": ">=18.x",
     "pnpm": ">=8"


### PR DESCRIPTION
* Not sure why this was added. I think it was a yarn thing?