### PR TITLE
fix: external-prs better error messages

### DIFF
--- a/.github/workflows/test-deploy-owners.yml
+++ b/.github/workflows/test-deploy-owners.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Setup external pr tools
         uses: ./.github/workflows/setup-external-pr-tools
-      
+
       - name: Initialize check
         run: |
           cd ops/external-prs &&
@@ -48,9 +48,9 @@ jobs:
           echo "${{ github.event.pull_request.author_association }}"
 
       - name: Login to google
-        uses: 'google-github-actions/auth@v2'
+        uses: "google-github-actions/auth@v2"
         with:
-          credentials_json: '${{ secrets.GOOGLE_BQ_ADMIN_CREDENTIALS_JSON }}'
+          credentials_json: "${{ secrets.GOOGLE_BQ_ADMIN_CREDENTIALS_JSON }}"
           create_credentials_file: true
         if: ${{ contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR", "CONTRIBUTOR"]'), github.event.pull_request.author_association) }}
 

--- a/ops/external-prs/.env.example
+++ b/ops/external-prs/.env.example
@@ -1,0 +1,7 @@
+# .env
+
+# GitHub App ID, which you can find here
+# https://github.com/organizations/opensource-observer/settings/apps/oso-prs
+PR_TOOLS_GITHUB_APP_ID=
+# Base64 encoded private key for the GitHub App
+PR_TOOLS_GITHUB_APP_PRIVATE_KEY=


### PR DESCRIPTION
* Adds an .env.example so folks know how to configure this for local testing
* Reports in an error message what the valid commands are if you specified an invalid one
* Adds a bunch of comments in places