### PR TITLE
feat: build indices for mart models

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,25 @@
+# .env
+## This .env file is mostly used for Python data ops
+
+## Google Cloud setup
+GOOGLE_PROJECT_ID=
+# You will need to generate Google application credentials
+# Note: You can use your gcloud auth credentials
+GOOGLE_APPLICATION_CREDENTIALS=<path-to-valid-gcp-creds>
+# Used for data transfer between databases
+CLOUDSTORAGE_BUCKET_NAME=
+# Used for storing all BigQuery data in the dbt pipeline
+BIGQUERY_DATASET_ID=
+# Used for Frontend/API-facing services
+CLOUDSQL_REGION=
+CLOUDSQL_INSTANCE_ID=
+CLOUDSQL_DB_NAME=
+CLOUDSQL_DB_PASSWORD=
+CLOUDSQL_DB_USER=
+
+## Dagster Setup
+# You may want to change the location of dagster home if you want it to survive resets 
+DAGSTER_HOME=/tmp/dagster-home 
+# This is used to put generated dbt profiles for dagster in a specific place
+DAGSTER_DBT_TARGET_BASE_DIR=/tmp/dagster-home/generated-dbt
+DAGSTER_DBT_PARSE_PROJECT_ON_LOAD=1

--- a/warehouse/bq2cloudsql/README.md
+++ b/warehouse/bq2cloudsql/README.md
@@ -1,0 +1,41 @@
+# bq2cloudsql
+
+This utility script copies the final mart models from the end of
+the dbt pipeline into a Google CloudSQL postgres database for
+serving the API / frontend.
+
+The general strategy is to dump the models into CSV files
+on GCS, then import them into the Postgres database
+into temporary tables. When the copy is done, we drop the old tables
+and rename the fresh import.
+
+Note: Because we only maintain a single database, this operation can
+severely load the production server during copies.
+
+## Setup
+
+Copy `.env.example` to `.env` in the root of the monorepo.
+Populate the values there.
+
+Then from the monorepo root, run install Python dependencies
+
+```bash
+poetry install
+```
+
+## Running
+
+Run the copy with
+
+```bash
+poetry run bq2cloudsql
+```
+
+Note: this command is defined in the root `pyproject.toml`
+
+## Development
+
+For now, we've been developing / testing this on the production servers.
+In the future, we should create staging and development databases for this.
+
+You can copy only select tables by slicing `table_sync_configs` in `./script.py`.

--- a/warehouse/dbt/models/marts/directory/artifacts_by_project_v1.sql
+++ b/warehouse/dbt/models/marts/directory/artifacts_by_project_v1.sql
@@ -1,6 +1,11 @@
 {{ 
   config(meta = {
-    'sync_to_db': True
+    'sync_to_db': True,
+    'index': {
+      'idx_project_id': ["project_id"],
+      'idx_project_name': ["project_source", "project_namespace", "project_name"],
+      'idx_artifact_id': ["artifact_id"],
+    }
   }) 
 }}
 

--- a/warehouse/dbt/models/marts/directory/artifacts_v1.sql
+++ b/warehouse/dbt/models/marts/directory/artifacts_v1.sql
@@ -1,7 +1,10 @@
 {{ 
   config(meta = {
-    'sync_to_db': True
-
+    'sync_to_db': True,
+    'index': {
+      'idx_artifact_id': ["artifact_id"],
+      'idx_artifact_name': ["artifact_source", "artifact_namespace", "artifact_name"],
+    }
   }) 
 }}
 

--- a/warehouse/dbt/models/marts/directory/collections_v1.sql
+++ b/warehouse/dbt/models/marts/directory/collections_v1.sql
@@ -1,6 +1,10 @@
 {{ 
   config(meta = {
-    'sync_to_db': True
+    'sync_to_db': True,
+    'index': {
+      'idx_collection_id': ["collection_id"],
+      'idx_collection_name': ["collection_source", "collection_namespace", "collection_name"],
+    }
   }) 
 }}
 

--- a/warehouse/dbt/models/marts/directory/contracts_v1.sql
+++ b/warehouse/dbt/models/marts/directory/contracts_v1.sql
@@ -1,6 +1,9 @@
 {{ 
   config(meta = {
-    'sync_to_db': True
+    'sync_to_db': True,
+    'index': {
+      'idx_deployer': ["root_deployer_address"],
+    }
   }) 
 }}
 

--- a/warehouse/dbt/models/marts/directory/projects_by_collection_v1.sql
+++ b/warehouse/dbt/models/marts/directory/projects_by_collection_v1.sql
@@ -1,6 +1,11 @@
 {{ 
   config(meta = {
-    'sync_to_db': True
+    'sync_to_db': True,
+    'index': {
+      'idx_collection_id': ["collection_id"],
+      'idx_collection_name': ["collection_source", "collection_namespace", "collection_name"],
+      'idx_project_id': ["project_id"],
+    }
   }) 
 }}
 select

--- a/warehouse/dbt/models/marts/directory/projects_v1.sql
+++ b/warehouse/dbt/models/marts/directory/projects_v1.sql
@@ -1,6 +1,10 @@
 {{ 
   config(meta = {
-    'sync_to_db': True
+    'sync_to_db': True,
+    'index': {
+      'idx_project_id': ["project_id"],
+      'idx_project_name': ["project_source", "project_namespace", "project_name"],
+    }
   }) 
 }}
 

--- a/warehouse/dbt/models/marts/directory/users_v1.sql
+++ b/warehouse/dbt/models/marts/directory/users_v1.sql
@@ -1,6 +1,10 @@
 {{ 
   config(meta = {
-    'sync_to_db': True
+    'sync_to_db': True,
+    'index': {
+      'idx_user_id': ["user_id"],
+      'idx_source_id': ["user_source", "user_source_id"],
+    }
   }) 
 }}
 


### PR DESCRIPTION
* Allows the mart model author to specify which indices to build
* Adds a few indices in `marts/directory`
* Adds a README to bq2cloudsql
* Adds an .env.example in monorepo root
* Adds a utility to read the index config from the mart model and create the indices on copy Note: This will not work on incremental mode in bq2cloudsql