### PR TITLE
feat: refactor external-prs to use oss-directory types

### DIFF
--- a/ops/external-prs/package.json
+++ b/ops/external-prs/package.json
@@ -49,7 +49,7 @@
     "lodash": "^4.17.21",
     "mustache": "^4.2.0",
     "octokit": "^3.1.0",
-    "oss-directory": "^0.0.13",
+    "oss-directory": "^0.0.14",
     "tmp-promise": "^3.0.3",
     "ts-dedent": "^2.2.0",
     "winston": "^3.11.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -388,8 +388,8 @@ importers:
         specifier: ^3.1.0
         version: 3.1.0
       oss-directory:
-        specifier: ^0.0.13
-        version: 0.0.13(ts-node@10.9.1(@types/node@20.11.17)(typescript@5.3.3))(typescript@5.3.3)
+        specifier: ^0.0.14
+        version: 0.0.14(ts-node@10.9.1(@types/node@20.11.17)(typescript@5.3.3))(typescript@5.3.3)
       tmp-promise:
         specifier: ^3.0.3
         version: 3.0.3
@@ -8926,6 +8926,11 @@ packages:
 
   oss-directory@0.0.13:
     resolution: {integrity: sha512-jSAGOAq2m9HcnpL1v0Wk5WKLQe4ZsIAFHWpbbdrfbsEG/M2cSsMzTkxVXSHKI8ex7eHYMie8LPnhR9Um27w7pQ==}
+    engines: {node: '>=16'}
+    hasBin: true
+
+  oss-directory@0.0.14:
+    resolution: {integrity: sha512-8KlwavAOto7VR4IuO1RuNk8Q2DxQq74aOvEhCRFSkgzoxffdc9/jikRaGZ1IqAGTNMTHL2K4GDKKHZKj8yoRpw==}
     engines: {node: '>=16'}
     hasBin: true
 
@@ -23552,9 +23557,9 @@ snapshots:
 
   os-tmpdir@1.0.2: {}
 
-  oss-directory@0.0.13(ts-node@10.9.1(@types/node@20.11.17)(typescript@5.3.3))(typescript@5.3.3):
+  oss-directory@0.0.13(ts-node@10.9.1(@types/node@20.12.7)(typescript@5.3.3))(typescript@5.3.3):
     dependencies:
-      '@ethereum-attestation-service/eas-sdk': 1.4.0(ts-node@10.9.1(@types/node@20.11.17)(typescript@5.3.3))(typescript@5.3.3)
+      '@ethereum-attestation-service/eas-sdk': 1.4.0(ts-node@10.9.1(@types/node@20.12.7)(typescript@5.3.3))(typescript@5.3.3)
       ajv: 8.12.0
       ajv-formats: 2.1.1(ajv@8.12.0)
       chalk: 5.3.0
@@ -23576,9 +23581,9 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  oss-directory@0.0.13(ts-node@10.9.1(@types/node@20.12.7)(typescript@5.3.3))(typescript@5.3.3):
+  oss-directory@0.0.14(ts-node@10.9.1(@types/node@20.11.17)(typescript@5.3.3))(typescript@5.3.3):
     dependencies:
-      '@ethereum-attestation-service/eas-sdk': 1.4.0(ts-node@10.9.1(@types/node@20.12.7)(typescript@5.3.3))(typescript@5.3.3)
+      '@ethereum-attestation-service/eas-sdk': 1.4.0(ts-node@10.9.1(@types/node@20.11.17)(typescript@5.3.3))(typescript@5.3.3)
       ajv: 8.12.0
       ajv-formats: 2.1.1(ajv@8.12.0)
       chalk: 5.3.0


### PR DESCRIPTION
* oss-directory now exposes BlockchainTag and BlockchainNetwork
* Use these types to make sure that we are using the correct strings in validation logic