### PR TITLE
feat: any_evm addresses warns if you're tagging `contract`

### DIFF
--- a/ops/external-prs/README.md
+++ b/ops/external-prs/README.md
@@ -44,7 +44,18 @@ pnpm external-prs oso test-deploy clean {ttl-seconds}
 
 ### OSS-Directory Specific
 
+First configure `.env`.
+
+Then `git clone` to 2 different paths on your filesystem,
+the oss-directory main branch
+and the PR branch to compare.
+
+You can run the app via:
+
 ```bash
 # Handle PR validations
-pnpm external-prs ossd validate-prs {pr} {sha} {main-path} {pr-path}
+pnpm external-prs ossd validate-prs {pr_number} {commit_sha} {main_path} {pr_path}
 ```
+
+If you've configured your GitHub secrets correctly,
+this should post a comment in the PR with the results

--- a/ops/external-prs/package.json
+++ b/ops/external-prs/package.json
@@ -50,7 +50,7 @@
     "lodash": "^4.17.21",
     "mustache": "^4.2.0",
     "octokit": "^3.1.0",
-    "oss-directory": "^0.0.14",
+    "oss-directory": "^0.0.15",
     "tmp-promise": "^3.0.3",
     "ts-dedent": "^2.2.0",
     "winston": "^3.11.0",

--- a/ops/external-prs/src/base.ts
+++ b/ops/external-prs/src/base.ts
@@ -81,7 +81,7 @@ export class GHAppUtils {
     const taggedMessage = `${messageIdText}\n${message}`;
 
     const appId = this.appMeta.appId;
-    console.log(`appId: ${appId}`);
+    logger.info(`Setting status comment with appId: ${appId}`);
     // Search for a comment with the messageId
     // If it doesn't exist, create a comment
     // If it does exist update that comment
@@ -91,11 +91,11 @@ export class GHAppUtils {
       issue_number: pr,
     });
 
-    console.log(allCommentRefs.data.map((c) => c.user));
+    //console.log(allCommentRefs.data.map((c) => c.user));
     const appCommentRefs = allCommentRefs.data.filter((c) => {
       return c.performed_via_github_app?.id === appId;
     });
-    console.log(appCommentRefs);
+    //console.log(appCommentRefs);
 
     // If this app has never commented on this PR, just create it
     if (appCommentRefs.length === 0) {

--- a/ops/external-prs/src/ossd/templating.ts
+++ b/ops/external-prs/src/ossd/templating.ts
@@ -1,0 +1,12 @@
+import * as fsPromise from "fs/promises";
+import mustache from "mustache";
+
+async function renderMustacheFromFile(
+  filePath: string,
+  params?: Record<string, unknown>,
+) {
+  const raw = await fsPromise.readFile(filePath, "utf-8");
+  return mustache.render(raw, params);
+}
+
+export { renderMustacheFromFile };

--- a/ops/external-prs/src/ossd/validation-results.ts
+++ b/ops/external-prs/src/ossd/validation-results.ts
@@ -1,0 +1,119 @@
+import _ from "lodash";
+import * as path from "path";
+import { fileURLToPath } from "node:url";
+import { logger } from "../utils/logger.js";
+import { renderMustacheFromFile } from "./templating.js";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+function relativeDir(...args: string[]) {
+  return path.join(__dirname, ...args);
+}
+const OVERVIEW_KEY = "overview";
+const TEMPLATE_FILE = relativeDir("messages", "validation-message.md");
+/**
+ * Struct to store validation results for a single artifact
+ */
+type ValidationResultsItem = {
+  name: string;
+  messages: string[];
+  errors: string[];
+  warnings: string[];
+  successes: string[];
+};
+
+const initValidationResultsItem = (name: string) => ({
+  name,
+  messages: [],
+  errors: [],
+  warnings: [],
+  successes: [],
+});
+
+class ValidationResults {
+  private overview: ValidationResultsItem;
+  private results: Record<string, ValidationResultsItem>;
+
+  static async create() {
+    const vr = new ValidationResults();
+    return vr;
+  }
+
+  private constructor() {
+    this.overview = initValidationResultsItem("Overview");
+    this.results = {};
+  }
+
+  // Add a name to the results
+  private getItem(key?: string): ValidationResultsItem {
+    if (!key || key === OVERVIEW_KEY) {
+      return this.overview;
+    }
+    const item = this.results[key];
+    if (!item) {
+      this.results[key] = initValidationResultsItem(key);
+    }
+    return this.results[key];
+  }
+
+  addMessage(message: string, key?: string, ctx?: any) {
+    const item = this.getItem(key);
+    logger.debug({ message, ...ctx });
+    item.messages.push(message);
+  }
+
+  addError(message: string, key?: string, ctx?: any) {
+    const item = this.getItem(key);
+    logger.warn({ message, ...ctx });
+    item.errors.push(message);
+  }
+
+  addWarning(message: string, key?: string, ctx?: any) {
+    const item = this.getItem(key);
+    logger.warn({ message, ...ctx });
+    item.warnings.push(message);
+  }
+
+  addSuccess(message: string, key?: string, ctx?: any) {
+    const item = this.getItem(key);
+    logger.debug({ message, ...ctx });
+    item.successes.push(message);
+  }
+
+  // Render the results into the markdown file
+  async render(commit_sha: string) {
+    const items: ValidationResultsItem[] = [
+      this.overview,
+      ..._.values(this.results),
+    ];
+
+    const numErrors = _.sumBy(
+      items,
+      (item: ValidationResultsItem) => item.errors.length,
+    );
+    const numWarningsMessages = _.sumBy(
+      items,
+      (item: ValidationResultsItem) =>
+        item.warnings.length + item.messages.length,
+    );
+    const summaryMessage =
+      numErrors > 0
+        ? `⛔ Found ${numErrors} errors ⛔`
+        : numWarningsMessages > 0
+          ? "⚠️ Please review messages before approving ⚠️"
+          : "✅ Good to go as long as status checks pass";
+    const commentBody = await renderMustacheFromFile(TEMPLATE_FILE, {
+      sha: commit_sha,
+      summaryMessage,
+      validationItems: items,
+    });
+
+    return {
+      numErrors,
+      summaryMessage,
+      commentBody,
+    };
+  }
+}
+
+export { ValidationResults };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -413,8 +413,8 @@ importers:
         specifier: ^3.1.0
         version: 3.1.0
       oss-directory:
-        specifier: ^0.0.14
-        version: 0.0.14(ts-node@10.9.1(@types/node@20.11.17)(typescript@5.3.3))(typescript@5.3.3)
+        specifier: ^0.0.15
+        version: 0.0.15(ts-node@10.9.1(@types/node@20.11.17)(typescript@5.3.3))(typescript@5.3.3)
       tmp-promise:
         specifier: ^3.0.3
         version: 3.0.3
@@ -566,8 +566,8 @@ importers:
         specifier: ^4.17.21
         version: 4.17.21
       oss-directory:
-        specifier: ^0.0.13
-        version: 0.0.13(ts-node@10.9.1(@types/node@20.14.1)(typescript@5.3.3))(typescript@5.3.3)
+        specifier: ^0.0.15
+        version: 0.0.15(ts-node@10.9.1(@types/node@20.14.1)(typescript@5.3.3))(typescript@5.3.3)
       read-pkg-up:
         specifier: ^11.0.0
         version: 11.0.0
@@ -6905,6 +6905,7 @@ packages:
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
+    deprecated: Glob versions prior to v9 are no longer supported
 
   glob@8.1.0:
     resolution: {integrity: sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==}
@@ -8952,13 +8953,8 @@ packages:
     resolution: {integrity: sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==}
     engines: {node: '>=0.10.0'}
 
-  oss-directory@0.0.13:
-    resolution: {integrity: sha512-jSAGOAq2m9HcnpL1v0Wk5WKLQe4ZsIAFHWpbbdrfbsEG/M2cSsMzTkxVXSHKI8ex7eHYMie8LPnhR9Um27w7pQ==}
-    engines: {node: '>=16'}
-    hasBin: true
-
-  oss-directory@0.0.14:
-    resolution: {integrity: sha512-8KlwavAOto7VR4IuO1RuNk8Q2DxQq74aOvEhCRFSkgzoxffdc9/jikRaGZ1IqAGTNMTHL2K4GDKKHZKj8yoRpw==}
+  oss-directory@0.0.15:
+    resolution: {integrity: sha512-DAQtoaYvDGr7kPGcXTe1I02g/X3W2bdoxf+CKsnHlun5MlGRocAqUlT86g/hrZ0i7tI9QPcPAQs0V1M+5+5Y5w==}
     engines: {node: '>=16'}
     hasBin: true
 
@@ -10042,6 +10038,7 @@ packages:
 
   rimraf@2.7.1:
     resolution: {integrity: sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==}
+    deprecated: Rimraf versions prior to v4 are no longer supported
     hasBin: true
 
   rimraf@3.0.2:
@@ -23608,9 +23605,9 @@ snapshots:
 
   os-tmpdir@1.0.2: {}
 
-  oss-directory@0.0.13(ts-node@10.9.1(@types/node@20.14.1)(typescript@5.3.3))(typescript@5.3.3):
+  oss-directory@0.0.15(ts-node@10.9.1(@types/node@20.11.17)(typescript@5.3.3))(typescript@5.3.3):
     dependencies:
-      '@ethereum-attestation-service/eas-sdk': 1.4.0(ts-node@10.9.1(@types/node@20.14.1)(typescript@5.3.3))(typescript@5.3.3)
+      '@ethereum-attestation-service/eas-sdk': 1.4.0(ts-node@10.9.1(@types/node@20.11.17)(typescript@5.3.3))(typescript@5.3.3)
       ajv: 8.12.0
       ajv-formats: 2.1.1(ajv@8.12.0)
       chalk: 5.3.0
@@ -23632,9 +23629,9 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  oss-directory@0.0.14(ts-node@10.9.1(@types/node@20.11.17)(typescript@5.3.3))(typescript@5.3.3):
+  oss-directory@0.0.15(ts-node@10.9.1(@types/node@20.14.1)(typescript@5.3.3))(typescript@5.3.3):
     dependencies:
-      '@ethereum-attestation-service/eas-sdk': 1.4.0(ts-node@10.9.1(@types/node@20.11.17)(typescript@5.3.3))(typescript@5.3.3)
+      '@ethereum-attestation-service/eas-sdk': 1.4.0(ts-node@10.9.1(@types/node@20.14.1)(typescript@5.3.3))(typescript@5.3.3)
       ajv: 8.12.0
       ajv-formats: 2.1.1(ajv@8.12.0)
       chalk: 5.3.0

--- a/warehouse/cloudquery-oss-directory/package.json
+++ b/warehouse/cloudquery-oss-directory/package.json
@@ -23,7 +23,7 @@
     "camelcase-keys": "^9.1.2",
     "dayjs": "^1.11.9",
     "lodash": "^4.17.21",
-    "oss-directory": "^0.0.13",
+    "oss-directory": "^0.0.15",
     "read-pkg-up": "^11.0.0",
     "ts-essentials": "^9.4.1",
     "typescript": "^5.2.2"


### PR DESCRIPTION
* This comes with some pretty major refactoring of how we store ValidationResults
* Move mustache templating code to separate module
* Create a generic class for storing ValidationResults that will be rendered to a GitHub issue comment
* Updates to oss-directory 0.0.15
* Fixes up some minor logging too