### PR TITLE
Add macro and airdrop addresses to staging

### DIFF
--- a/warehouse/dbt/macros/models/combine_op_airdrops.sql
+++ b/warehouse/dbt/macros/models/combine_op_airdrops.sql
@@ -14,7 +14,7 @@
 -- Loop through each suffix and generate the full table reference
 {% for suffix in suffixes %}
     {% set table_name = 'op_airdrop' ~ suffix ~ '_addresses_detailed_list' %}
-    {% set query = "select address, op_amount_raw/1e18 as op_amount, '" ~ suffix ~ "' as airdrop_round from " ~ source('static_data_sources', table_name) %}
+    {% set query = "select address, op_amount_raw/1e18 as op_amount, cast('" ~ suffix ~ "' as int) as airdrop_round from " ~ source('static_data_sources', table_name) %}
     {% do queries.append(query) %}
 {% endfor %}
 

--- a/warehouse/dbt/macros/models/combine_op_airdrops.sql
+++ b/warehouse/dbt/macros/models/combine_op_airdrops.sql
@@ -1,0 +1,24 @@
+-- Generate a range of numbers
+{% macro generate_range(start, end) %}
+  {% set range_list = [] %}
+  {% for i in range(start, end + 1) %}
+    {% do range_list.append(i) %}
+  {% endfor %}
+  {{ return(range_list) }}
+{% endmacro %}
+
+{% macro combine_op_airdrops(suffixes) %}
+
+{% set queries = [] %}
+
+-- Loop through each suffix and generate the full table reference
+{% for suffix in suffixes %}
+    {% set table_name = 'op_airdrop' ~ suffix ~ '_addresses_detailed_list' %}
+    {% set query = "select address, op_amount_raw/1e18 as op_amount, '" ~ suffix ~ "' as airdrop_round from " ~ source('static_data_sources', table_name) %}
+    {% do queries.append(query) %}
+{% endfor %}
+
+{# Join all queries with UNION ALL #}
+{{ return(queries | join(' UNION ALL\n')) }}
+
+{% endmacro %}

--- a/warehouse/dbt/models/staging/optimism/stg_optimism_airdrop_addresses.sql
+++ b/warehouse/dbt/models/staging/optimism/stg_optimism_airdrop_addresses.sql
@@ -1,0 +1,13 @@
+{{
+  config(
+    materialized="incremental",
+    partition_by="airdrop_round",
+    unique_key="concat(airdrop_round, address)",
+    on_schema_change="append_new_columns",
+    incremental_strategy="insert_overwrite"
+  )
+}}
+
+{{
+  combine_op_airdrops(generate_range(1, 4))
+}}

--- a/warehouse/dbt/models/staging/optimism/stg_optimism_airdrop_addresses.sql
+++ b/warehouse/dbt/models/staging/optimism/stg_optimism_airdrop_addresses.sql
@@ -1,12 +1,15 @@
-{{
-  config(
-    materialized="incremental",
-    partition_by="airdrop_round",
-    unique_key="concat(airdrop_round, address)",
-    on_schema_change="append_new_columns",
-    incremental_strategy="insert_overwrite"
-  )
-}}
+{{ config(
+    materialized='table',
+    partition_by={
+      "field": "airdrop_round",
+      "data_type": "int64",
+      "range": {
+        "start": 0,
+        "end": 100,
+        "interval": 10
+      }
+    }
+) }}
 
 {{
   combine_op_airdrops(generate_range(1, 4))

--- a/warehouse/dbt/models/static_data_sources.yml
+++ b/warehouse/dbt/models/static_data_sources.yml
@@ -17,19 +17,19 @@ sources:
         identifier: op_airdrop1_addresses_detailed_list
         columns:
           - name: address
-            data_type: STRING
+            data_type: string
       - name: op_airdrop2_addresses_detailed_list
         identifier: op_airdrop2_addresses_detailed_list
         columns:
           - name: address
-            data_type: STRING
+            data_type: string
       - name: op_airdrop3_addresses_detailed_list
         identifier: op_airdrop3_addresses_detailed_list
         columns:
           - name: address
-            data_type: STRING
+            data_type: string
       - name: op_airdrop4_addresses_detailed_list
         identifier: op_airdrop4_addresses_detailed_list
         columns:
           - name: address
-            data_type: STRING
+            data_type: string

--- a/warehouse/dbt/models/static_data_sources.yml
+++ b/warehouse/dbt/models/static_data_sources.yml
@@ -15,9 +15,21 @@ sources:
         identifier: agora_rf4_repos_with_contracts
       - name: op_airdrop1_addresses_detailed_list
         identifier: op_airdrop1_addresses_detailed_list
+        columns:
+          - name: address
+            data_type: STRING
       - name: op_airdrop2_addresses_detailed_list
         identifier: op_airdrop2_addresses_detailed_list
+        columns:
+          - name: address
+            data_type: STRING
       - name: op_airdrop3_addresses_detailed_list
         identifier: op_airdrop3_addresses_detailed_list
+        columns:
+          - name: address
+            data_type: STRING
       - name: op_airdrop4_addresses_detailed_list
         identifier: op_airdrop4_addresses_detailed_list
+        columns:
+          - name: address
+            data_type: STRING


### PR DESCRIPTION
As per discussed, adding the macro and closing https://github.com/opensource-observer/oso/pull/1637

Got a question related to datatype as the addresses are currently set as float, no matter how i change the source data type or cast to string in query, they continue showing up as numbers 
![image](https://github.com/opensource-observer/oso/assets/30974572/cfc794a1-3942-4ab3-885c-4457418b15f0)
