### PR TITLE
feat: python common utils

### DIFF
--- a/warehouse/oso_dagster/utils/common.py
+++ b/warehouse/oso_dagster/utils/common.py
@@ -1,4 +1,8 @@
 from enum import Enum
+from typing import TypeVar, Never, Optional
+from .errors import NullOrUndefinedValueError
+
+T = TypeVar("T")
 
 # An enum for specifying time intervals
 class TimeInterval(Enum):
@@ -23,3 +27,34 @@ def to_lower_camel_case(snake_str):
     # with the 'capitalize' method and join them together.
     camel_string = to_camel_case(snake_str)
     return snake_str[0].lower() + camel_string[1:]
+
+def safeCast[T](x: T) -> T:
+    """
+    Explicitly mark that a cast is safe.
+    e.g. `safeCast(x as string[])`.
+    """
+    y: T = x
+    return y
+
+def assertNever(_x: Never) -> Never:
+    """
+    Asserts that a branch is never taken.
+    Useful for exhaustiveness checking.
+    @param _x
+    """
+    raise Exception("unexpected branch taken")
+
+def ensure[T](x: Optional[T], msg: str) -> T:
+    """
+    Asserts that a value is not null or undefined.
+    @param x
+    @param msg
+    @returns
+    """
+    if x is None:
+        raise NullOrUndefinedValueError(
+            f"Value must not be undefined or null{f" - {msg}" if msg else ""}"
+        )
+    else:
+        y: T = x
+        return y

--- a/warehouse/oso_dagster/utils/errors.py
+++ b/warehouse/oso_dagster/utils/errors.py
@@ -1,0 +1,24 @@
+
+class UnsupportedTableColumn(Exception):
+    """
+    This is thrown when we have a database column type that we don't support
+    """
+    pass
+
+class MalformedUrl(Exception):
+    """
+    This is thrown when we have a malformed URL
+    """
+    pass
+
+class AssertionError(Exception):
+    """
+    Fails an assertion
+    """
+    pass
+
+class NullOrUndefinedValueError(Exception):
+    """
+    This is thrown when we have a null or undefined value
+    """
+    pass


### PR DESCRIPTION
* Add file for custom errors in Dagster
* Add python common utils, ported from TypeScript * Includes, assertNever, ensure, cast