### PR TITLE
Ingest all optimism data sources

### DIFF
--- a/warehouse/oso_dagster/assets/optimism.py
+++ b/warehouse/oso_dagster/assets/optimism.py
@@ -1,31 +1,7 @@
-from ..factories.goldsky import goldsky_asset, traces_extensions
-from ..constants import staging_bucket
-from oso_dagster.utils import gcs_to_bucket_name
+from ..factories.goldsky import goldsky_network_assets
 
-
-transactions_table_fqn = (
-    "bigquery-public-data.goog_blockchain_optimism_mainnet_us.transactions"
-)
-staging_bucket_name = gcs_to_bucket_name(staging_bucket)
-
-optimism_traces = goldsky_asset(
-    key_prefix="optimism",
-    name="traces",
-    source_name="optimism-traces",
-    project_id="opensource-observer",
-    destination_table_name="optimism_traces",
-    working_destination_dataset_name="oso_raw_sources",
+optimism_network = goldsky_network_assets(
+    network_name="optimism",
     destination_dataset_name="superchain",
-    partition_column_name="block_timestamp",
-    dedupe_model="optimism_dedupe.sql",
-    source_bucket_name=staging_bucket_name,
-    destination_bucket_name=staging_bucket_name,
-    additional_factories=[
-        traces_extensions(
-            transactions_table_fqn=transactions_table_fqn,
-            transactions_transaction_hash_column_name="transaction_hash",
-        ),
-    ],
-    # uncomment the following value to test
-    # max_objects_to_load=2000,
+    working_destination_dataset_name="oso_raw_sources",
 )


### PR DESCRIPTION
Originally, had some custom code for using optimism transactions with google blocks but realized we are also getting the blocks from goldsky so we're just loading all into the `superchain` data source. 

Closes #1873 