### PR TITLE
Changing the type tag of the clickhouse assets

### DIFF
--- a/warehouse/oso_dagster/factories/bq2clickhouse.py
+++ b/warehouse/oso_dagster/factories/bq2clickhouse.py
@@ -115,7 +115,7 @@ def create_bq2clickhouse_asset(asset_config: Bq2ClickhouseAssetConfig):
     tags = {
         "opensource.observer/factory": "bq2clickhouse",
         "opensource.observer/environment": asset_config.environment,
-        "opensource.observer/type": "source",
+        "opensource.observer/type": "mart",
     }
 
     @asset(


### PR DESCRIPTION
Notices clickhouse was attempting to materialize when things weren't run in dbt. I'm thinking perhaps we have things with the `opensource.observer/type` be:

* `source` - Essentially a raw data source
* `staging` - Staging models
* `intermediate` - Intermediate models
* `mart` - Marts

We can be flexible but this will prevent errors from happening because it's expecting things in dbt. 