### PR TITLE
Allow overriding k8s config

### DIFF
--- a/ops/k8s-apps/base/dagster/dagster.yaml
+++ b/ops/k8s-apps/base/dagster/dagster.yaml
@@ -90,15 +90,14 @@ spec:
               repository: "ghcr.io/opensource-observer/dagster-dask"
               tag: latest
               pullPolicy: Always
-            env:
-              - name: DAGSTER_DBT_GENERATE_AND_AUTH_GCP
-                value: "1"
             envConfigMaps:
               - name: dagster-oso-extra-env
             port: 3030
             dagsterApiGrpcArgs:
               - "-m"
               - "oso_dagster.definitions"
+            includeConfigInLaunchedRuns:
+              enabled: false
 
   postRenderers:
     - kustomize:


### PR DESCRIPTION
Making this change before our full refresh, this should make that whole process more reliable in that it won't be killed by google's spot instance termination. This will prevent us from running the full refresh multiple times due to those kinds of unpredictable errors. 