### PR TITLE
Fix dlt factory

### DIFF
--- a/warehouse/oso_dagster/factories/dlt.py
+++ b/warehouse/oso_dagster/factories/dlt.py
@@ -182,9 +182,6 @@ def _dlt_factory[
                     )
                     for result in results:
                         yield cast(R, result)
-                    # else:
-                    #     # If an empty set is returned we need to return something
-                    #     return MaterializeResult(metadata={})
 
                 return AssetFactoryResponse([_dlt_asset])
 


### PR DESCRIPTION
This is a preliminary bug fix for some DLT factory things. I realize actually we _can't_ do multiple dlt resources from one of these factories so some additional logic needs to be removed but I'd prefer to get #1952 merged in before because that will require some rewriting. This still _works_ it's just not actually semantically correct.

This fixes a bug where the dlt factory errors when running locally because of `jsonl` and duckdb usage. 