### PR TITLE
fix: Add a retry page

### DIFF
--- a/apps/frontend/app/artifacts/[source]/[...name]/page.tsx
+++ b/apps/frontend/app/artifacts/[source]/[...name]/page.tsx
@@ -1,4 +1,4 @@
-import { notFound } from "next/navigation";
+import { notFound, redirect } from "next/navigation";
 import { cache } from "react";
 import { PlasmicComponent } from "@plasmicapp/loader-nextjs";
 import { PLASMIC } from "../../../../plasmic-init";
@@ -10,6 +10,7 @@ import {
 } from "../../../../lib/clickhouse/cached-queries";
 import { logger } from "../../../../lib/logger";
 
+const RETRY_URL = "/retry";
 const PLASMIC_COMPONENT = "ArtifactPage";
 //export const dynamic = STATIC_EXPORT ? "force-static" : "force-dynamic";
 export const dynamic = "force-dynamic";
@@ -70,51 +71,56 @@ export default async function ArtifactPage(props: ArtifactPageProps) {
   const [namespace, name] =
     params.name.length > 1 ? params.name : [undefined, params.name[0]];
 
-  // Get artifact metadata from the database
-  const artifactArray = await cachedGetArtifactByName({
-    artifactSource: source,
-    artifactNamespace: namespace,
-    artifactName: name,
-  });
-  if (!Array.isArray(artifactArray) || artifactArray.length < 1) {
-    logger.warn(
-      `Cannot find artifact (source=${source}, namespace=${namespace}, name=${name})`,
+  try {
+    // Get artifact metadata from the database
+    const artifactArray = await cachedGetArtifactByName({
+      artifactSource: source,
+      artifactNamespace: namespace,
+      artifactName: name,
+    });
+    if (!Array.isArray(artifactArray) || artifactArray.length < 1) {
+      logger.warn(
+        `Cannot find artifact (source=${source}, namespace=${namespace}, name=${name})`,
+      );
+      notFound();
+    }
+    const artifact = artifactArray[0];
+    const artifactId = artifact.artifact_id;
+
+    const data = await Promise.all([
+      cachedGetAllEventTypes(),
+      cachedGetCodeMetricsByArtifactIds({
+        artifactIds: [artifactId],
+      }),
+    ]);
+    const eventTypes = data[0];
+    const codeMetrics = data[1];
+
+    //console.log(artifact);
+    const plasmicData = await cachedFetchComponent(PLASMIC_COMPONENT);
+    if (!plasmicData) {
+      logger.warn(`Unable to get componentName=${PLASMIC_COMPONENT}`);
+      notFound();
+    }
+    const compMeta = plasmicData.entryCompMetas[0];
+
+    return (
+      <PlasmicClientRootProvider
+        prefetchedData={plasmicData}
+        pageParams={compMeta.params}
+      >
+        <PlasmicComponent
+          component={compMeta.displayName}
+          componentProps={{
+            metadata: artifact,
+            eventTypes: eventTypes,
+            codeMetrics: codeMetrics,
+          }}
+        />
+      </PlasmicClientRootProvider>
     );
-    notFound();
+  } catch (_e) {
+    // Most likely caused by database timing out
+    redirect(RETRY_URL);
   }
-  const artifact = artifactArray[0];
-  const artifactId = artifact.artifact_id;
-
-  const data = await Promise.all([
-    cachedGetAllEventTypes(),
-    cachedGetCodeMetricsByArtifactIds({
-      artifactIds: [artifactId],
-    }),
-  ]);
-  const eventTypes = data[0];
-  const codeMetrics = data[1];
-
-  //console.log(artifact);
-  const plasmicData = await cachedFetchComponent(PLASMIC_COMPONENT);
-  if (!plasmicData) {
-    logger.warn(`Unable to get componentName=${PLASMIC_COMPONENT}`);
-    notFound();
-  }
-  const compMeta = plasmicData.entryCompMetas[0];
-
-  return (
-    <PlasmicClientRootProvider
-      prefetchedData={plasmicData}
-      pageParams={compMeta.params}
-    >
-      <PlasmicComponent
-        component={compMeta.displayName}
-        componentProps={{
-          metadata: artifact,
-          eventTypes: eventTypes,
-          codeMetrics: codeMetrics,
-        }}
-      />
-    </PlasmicClientRootProvider>
-  );
 }

--- a/apps/frontend/app/projects/[...name]/page.tsx
+++ b/apps/frontend/app/projects/[...name]/page.tsx
@@ -1,4 +1,4 @@
-import { notFound } from "next/navigation";
+import { notFound, redirect } from "next/navigation";
 import { cache } from "react";
 import { PlasmicComponent } from "@plasmicapp/loader-nextjs";
 import { PLASMIC } from "../../../plasmic-init";
@@ -12,6 +12,7 @@ import {
 import { logger } from "../../../lib/logger";
 import { catchallPathToString } from "../../../lib/paths";
 
+const RETRY_URL = "/retry";
 const PLASMIC_COMPONENT = "ProjectPage";
 //export const dynamic = STATIC_EXPORT ? "force-static" : "force-dynamic";
 //export const dynamic = "force-static";
@@ -57,55 +58,60 @@ export default async function ProjectPage(props: ProjectPageProps) {
     notFound();
   }
 
-  // Get project metadata from the database
-  const name = catchallPathToString(params.name);
-  const projectArray = await cachedGetProjectByName({
-    projectName: name,
-  });
-  if (!Array.isArray(projectArray) || projectArray.length < 1) {
-    logger.warn(`Cannot find project (name=${name})`);
-    notFound();
+  try {
+    // Get project metadata from the database
+    const name = catchallPathToString(params.name);
+    const projectArray = await cachedGetProjectByName({
+      projectName: name,
+    });
+    if (!Array.isArray(projectArray) || projectArray.length < 1) {
+      logger.warn(`Cannot find project (name=${name})`);
+      notFound();
+    }
+    const project = projectArray[0];
+    const projectId = project.project_id;
+    //console.log("project", project);
+
+    // Parallelize getting things related to the project
+    const data = await Promise.all([
+      cachedGetAllEventTypes(),
+      cachedGetCodeMetricsByProjectIds({
+        projectIds: [projectId],
+      }),
+      cachedGetOnchainMetricsByProjectIds({
+        projectIds: [projectId],
+      }),
+    ]);
+    const eventTypes = data[0];
+    const codeMetrics = data[1];
+    const onchainMetrics = data[2];
+
+    // Get Plasmic component
+    const plasmicData = await cachedFetchComponent(PLASMIC_COMPONENT);
+    if (!plasmicData) {
+      logger.warn(`Unable to get componentName=${PLASMIC_COMPONENT}`);
+      notFound();
+    }
+    const compMeta = plasmicData.entryCompMetas[0];
+
+    return (
+      <PlasmicClientRootProvider
+        prefetchedData={plasmicData}
+        pageParams={compMeta.params}
+      >
+        <PlasmicComponent
+          component={compMeta.displayName}
+          componentProps={{
+            metadata: project,
+            codeMetrics,
+            onchainMetrics,
+            eventTypes,
+          }}
+        />
+      </PlasmicClientRootProvider>
+    );
+  } catch (_e) {
+    // Most likely caused by database timing out
+    redirect(RETRY_URL);
   }
-  const project = projectArray[0];
-  const projectId = project.project_id;
-  //console.log("project", project);
-
-  // Parallelize getting things related to the project
-  const data = await Promise.all([
-    cachedGetAllEventTypes(),
-    cachedGetCodeMetricsByProjectIds({
-      projectIds: [projectId],
-    }),
-    cachedGetOnchainMetricsByProjectIds({
-      projectIds: [projectId],
-    }),
-  ]);
-  const eventTypes = data[0];
-  const codeMetrics = data[1];
-  const onchainMetrics = data[2];
-
-  // Get Plasmic component
-  const plasmicData = await cachedFetchComponent(PLASMIC_COMPONENT);
-  if (!plasmicData) {
-    logger.warn(`Unable to get componentName=${PLASMIC_COMPONENT}`);
-    notFound();
-  }
-  const compMeta = plasmicData.entryCompMetas[0];
-
-  return (
-    <PlasmicClientRootProvider
-      prefetchedData={plasmicData}
-      pageParams={compMeta.params}
-    >
-      <PlasmicComponent
-        component={compMeta.displayName}
-        componentProps={{
-          metadata: project,
-          codeMetrics,
-          onchainMetrics,
-          eventTypes,
-        }}
-      />
-    </PlasmicClientRootProvider>
-  );
 }


### PR DESCRIPTION
* If the server-side logic for collections/projects/artifacts pages fail for any reason, redirect to /retry, which will ask the user to retry their request.
* This assumes that all failures are caused by Clickhouse idling and a simple retry will fix it.