### PR TITLE
Redeploy with small scale up to unblock dagster

### DIFF
--- a/ops/k8s-apps/base/cloudsql-proxy/proxy.yaml
+++ b/ops/k8s-apps/base/cloudsql-proxy/proxy.yaml
@@ -34,6 +34,7 @@ spec:
     remediation:
       retries: 3
   values:
+    replicasCount: 4
     cloudsql:
       instances:
         - instance: oso-playground-psql

--- a/ops/k8s-apps/base/dagster/dagster.yaml
+++ b/ops/k8s-apps/base/dagster/dagster.yaml
@@ -53,9 +53,9 @@ spec:
                   - key: pool_type
                     effect: NoSchedule
                     operator: Equal
-                    value: persistent
+                    value: spot 
                 nodeSelector:
-                  pool_type: persistent
+                  pool_type: spot
       dagsterWebserver:
         enableReadOnly: true
         env:


### PR DESCRIPTION
Also uses spot instances again due to some memory constraints. 
