### PR TITLE
feat: Error page for Collection/Project/Artifact pages

### DIFF
--- a/apps/frontend/app/artifacts/[source]/[...name]/error.tsx
+++ b/apps/frontend/app/artifacts/[source]/[...name]/error.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import { redirect } from "next/navigation";
+import { useEffect } from "react";
+import { logger } from "../../../../lib/logger";
+
+const REDIRECT_URL = "/retry";
+
+type ErrorPageProps = {
+  error: Error & { digest?: string };
+  reset: () => void;
+};
+
+export default function Error(props: ErrorPageProps) {
+  const { error } = props;
+  useEffect(() => {
+    logger.error(error);
+  }, [error]);
+
+  redirect(REDIRECT_URL);
+}

--- a/apps/frontend/app/collections/[...name]/error.tsx
+++ b/apps/frontend/app/collections/[...name]/error.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import { redirect } from "next/navigation";
+import { useEffect } from "react";
+import { logger } from "../../../lib/logger";
+
+const REDIRECT_URL = "/retry";
+
+type ErrorPageProps = {
+  error: Error & { digest?: string };
+  reset: () => void;
+};
+
+export default function Error(props: ErrorPageProps) {
+  const { error } = props;
+  useEffect(() => {
+    logger.error(error);
+  }, [error]);
+
+  redirect(REDIRECT_URL);
+}

--- a/apps/frontend/app/collections/[...name]/page.tsx
+++ b/apps/frontend/app/collections/[...name]/page.tsx
@@ -1,4 +1,4 @@
-import { notFound, redirect } from "next/navigation";
+import { notFound } from "next/navigation";
 import { cache } from "react";
 import { PlasmicComponent } from "@plasmicapp/loader-nextjs";
 import { PLASMIC } from "../../../plasmic-init";
@@ -14,7 +14,6 @@ import { catchallPathToString } from "../../../lib/paths";
 
 const COLLECTION_SOURCE = "OSS_DIRECTORY";
 const COLLECTION_NAMESPACE = "oso";
-const RETRY_URL = "/retry";
 const PLASMIC_COMPONENT = "CollectionPage";
 //export const dynamic = STATIC_EXPORT ? "force-static" : "force-dynamic";
 //export const dynamic = "force-static";
@@ -60,72 +59,67 @@ export default async function CollectionPage(props: CollectionPageProps) {
     notFound();
   }
 
-  try {
-    // Get project metadata from the database
-    const name = catchallPathToString(params.name);
-    const data1 = await Promise.all([
-      await cachedGetCollectionByName({
-        collectionSource: COLLECTION_SOURCE,
-        collectionNamespace: COLLECTION_NAMESPACE,
-        collectionName: name,
-      }),
-      await cachedGetProjectIdsByCollectionName({
-        collectionSource: COLLECTION_SOURCE,
-        collectionNamespace: COLLECTION_NAMESPACE,
-        collectionName: name,
-      }),
-    ]);
-    const collectionArray = data1[0];
-    const projectIdArray = data1[1];
-    if (
-      !Array.isArray(collectionArray) ||
-      collectionArray.length < 1 ||
-      !Array.isArray(projectIdArray)
-    ) {
-      logger.warn(`Cannot find collection (name=${name})`);
-      notFound();
-    }
-    const collection = collectionArray[0];
-    //console.log("project", project);
-
-    // Parallelize getting things related to the project
-    const projectIds = projectIdArray.map((x) => x.project_id);
-    const data2 = await Promise.all([
-      cachedGetCodeMetricsByProjectIds({
-        projectIds,
-      }),
-      cachedGetOnchainMetricsByProjectIds({
-        projectIds,
-      }),
-    ]);
-    const codeMetrics = data2[0];
-    const onchainMetrics = data2[1];
-
-    // Get Plasmic component
-    const plasmicData = await cachedFetchComponent(PLASMIC_COMPONENT);
-    if (!plasmicData) {
-      logger.warn(`Unable to get componentName=${PLASMIC_COMPONENT}`);
-      notFound();
-    }
-    const compMeta = plasmicData.entryCompMetas[0];
-
-    return (
-      <PlasmicClientRootProvider
-        prefetchedData={plasmicData}
-        pageParams={compMeta.params}
-      >
-        <PlasmicComponent
-          component={compMeta.displayName}
-          componentProps={{
-            metadata: collection,
-            codeMetrics,
-            onchainMetrics,
-          }}
-        />
-      </PlasmicClientRootProvider>
-    );
-  } catch (_e) {
-    // Most likely caused by database timing out
-    redirect(RETRY_URL);
+  // Get project metadata from the database
+  const name = catchallPathToString(params.name);
+  const data1 = await Promise.all([
+    await cachedGetCollectionByName({
+      collectionSource: COLLECTION_SOURCE,
+      collectionNamespace: COLLECTION_NAMESPACE,
+      collectionName: name,
+    }),
+    await cachedGetProjectIdsByCollectionName({
+      collectionSource: COLLECTION_SOURCE,
+      collectionNamespace: COLLECTION_NAMESPACE,
+      collectionName: name,
+    }),
+  ]);
+  const collectionArray = data1[0];
+  const projectIdArray = data1[1];
+  if (
+    !Array.isArray(collectionArray) ||
+    collectionArray.length < 1 ||
+    !Array.isArray(projectIdArray)
+  ) {
+    logger.warn(`Cannot find collection (name=${name})`);
+    notFound();
   }
+  const collection = collectionArray[0];
+  //console.log("project", project);
+
+  // Parallelize getting things related to the project
+  const projectIds = projectIdArray.map((x) => x.project_id);
+  const data2 = await Promise.all([
+    cachedGetCodeMetricsByProjectIds({
+      projectIds,
+    }),
+    cachedGetOnchainMetricsByProjectIds({
+      projectIds,
+    }),
+  ]);
+  const codeMetrics = data2[0];
+  const onchainMetrics = data2[1];
+
+  // Get Plasmic component
+  const plasmicData = await cachedFetchComponent(PLASMIC_COMPONENT);
+  if (!plasmicData) {
+    logger.warn(`Unable to get componentName=${PLASMIC_COMPONENT}`);
+    notFound();
+  }
+  const compMeta = plasmicData.entryCompMetas[0];
+
+  return (
+    <PlasmicClientRootProvider
+      prefetchedData={plasmicData}
+      pageParams={compMeta.params}
+    >
+      <PlasmicComponent
+        component={compMeta.displayName}
+        componentProps={{
+          metadata: collection,
+          codeMetrics,
+          onchainMetrics,
+        }}
+      />
+    </PlasmicClientRootProvider>
+  );
 }

--- a/apps/frontend/app/projects/[...name]/error.tsx
+++ b/apps/frontend/app/projects/[...name]/error.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import { redirect } from "next/navigation";
+import { useEffect } from "react";
+import { logger } from "../../../lib/logger";
+
+const REDIRECT_URL = "/retry";
+
+type ErrorPageProps = {
+  error: Error & { digest?: string };
+  reset: () => void;
+};
+
+export default function Error(props: ErrorPageProps) {
+  const { error } = props;
+  useEffect(() => {
+    logger.error(error);
+  }, [error]);
+
+  redirect(REDIRECT_URL);
+}


### PR DESCRIPTION
* Following the guide here https://nextjs.org/docs/app/building-your-application/routing/error-handling
* Recommended not to use try/catch
* By default, just redirect to /retry for now.
* In the future we should switch on different types of errors