### PR TITLE
fix: stop copying event aggregation tables to Clickhouse

### DIFF
--- a/warehouse/dbt/models/marts/events/daily/events_daily_to_artifact.sql
+++ b/warehouse/dbt/models/marts/events/daily/events_daily_to_artifact.sql
@@ -3,7 +3,7 @@
 #}
 {{ 
   config(meta = {
-    'sync_to_db': True
+    'sync_to_db': False
   }) 
 }}
 

--- a/warehouse/dbt/models/marts/events/daily/events_daily_to_collection.sql
+++ b/warehouse/dbt/models/marts/events/daily/events_daily_to_collection.sql
@@ -1,6 +1,6 @@
 {{ 
   config(meta = {
-    'sync_to_db': True
+    'sync_to_db': False
   }) 
 }}
 

--- a/warehouse/dbt/models/marts/events/daily/events_daily_to_project.sql
+++ b/warehouse/dbt/models/marts/events/daily/events_daily_to_project.sql
@@ -3,7 +3,7 @@
 #}
 {{ 
   config(meta = {
-    'sync_to_db': True
+    'sync_to_db': False
   }) 
 }}
 

--- a/warehouse/dbt/models/marts/events/monthly/events_monthly_to_artifact.sql
+++ b/warehouse/dbt/models/marts/events/monthly/events_monthly_to_artifact.sql
@@ -3,7 +3,7 @@
 #}
 {{ 
   config(meta = {
-    'sync_to_db': True
+    'sync_to_db': False
   }) 
 }}
 

--- a/warehouse/dbt/models/marts/events/monthly/events_monthly_to_collection.sql
+++ b/warehouse/dbt/models/marts/events/monthly/events_monthly_to_collection.sql
@@ -3,7 +3,7 @@
 #}
 {{ 
   config(meta = {
-    'sync_to_db': True
+    'sync_to_db': False
   }) 
 }}
 

--- a/warehouse/dbt/models/marts/events/monthly/events_monthly_to_project.sql
+++ b/warehouse/dbt/models/marts/events/monthly/events_monthly_to_project.sql
@@ -3,7 +3,7 @@
 #}
 {{ 
   config(meta = {
-    'sync_to_db': True
+    'sync_to_db': False
   }) 
 }}
 

--- a/warehouse/dbt/models/marts/events/weekly/events_weekly_to_artifact.sql
+++ b/warehouse/dbt/models/marts/events/weekly/events_weekly_to_artifact.sql
@@ -3,7 +3,7 @@
 #}
 {{ 
   config(meta = {
-    'sync_to_db': True
+    'sync_to_db': False
   }) 
 }}
 

--- a/warehouse/dbt/models/marts/events/weekly/events_weekly_to_collection.sql
+++ b/warehouse/dbt/models/marts/events/weekly/events_weekly_to_collection.sql
@@ -3,7 +3,7 @@
 #}
 {{ 
   config(meta = {
-    'sync_to_db': True
+    'sync_to_db': False
   }) 
 }}
 

--- a/warehouse/dbt/models/marts/events/weekly/events_weekly_to_project.sql
+++ b/warehouse/dbt/models/marts/events/weekly/events_weekly_to_project.sql
@@ -3,7 +3,7 @@
 #}
 {{ 
   config(meta = {
-    'sync_to_db': True
+    'sync_to_db': False
   }) 
 }}
 


### PR DESCRIPTION
* We are migrating to the sqlmesh metrics pipeline. yay!