### PR TITLE
Add filecoin dbt sources

### DIFF
--- a/warehouse/dbt/models/filecoin_sources.yml
+++ b/warehouse/dbt/models/filecoin_sources.yml
@@ -1,0 +1,168 @@
+sources:
+  - name: filecoin
+    database: opensource-observer
+    schema: filecoin_lily
+    tables:
+      - name: messages
+        identifier: parsed_messages
+        description: Messages parsed to extract useful information.
+        columns:
+          - name: cid
+            description: "CID of the message."
+          - name: height
+            description: "Epoch this message was executed at."
+          - name: from
+            description: "Address of the actor that sent the message."
+          - name: to
+            description: "Address of the actor that received the message."
+          - name: value
+            description: "Amount of FIL (in attoFIL) transferred by this message."
+          - name: method
+            description: "The name of the method that was invoked on the recipient actor."
+          - name: params
+            description: "Method parameters parsed and serialized as a JSON object."
+      - name: blocks
+        identifier: block_headers
+        description: "Blocks included in tipsets at an epoch."
+        columns:
+          - name: height
+            description: "Epoch when this block was mined."
+          - name: cid
+            description: "CID of the block."
+          - name: parent_weight
+            description: "Aggregate chain weight of the block’s parent set."
+          - name: parent_state_root
+            description: "Address of the miner who mined this block."
+          - name: miner
+            description: "Address of the miner who mined this block."
+          - name: timestamp
+            description: "Time the block was mined in Unix time, the number of seconds elapsed since January 1, 1970 UTC."
+          - name: win_count
+            description: "Number of reward units won in this block."
+          - name: parent_base_fee
+            description: "The base fee after executing the parent tipset."
+          - name: fork_signaling
+            description: "Flag used as part of signaling forks."
+      - name: receipts
+        identifier: message_receipts
+        description: Message receipts after being applied to chain state by message CID and parent state root CID of tipset when message was executed.
+        columns:
+          - name: message
+            description: "CID of the message this receipt belongs to."
+          - name: state_root
+            description: "CID of the parent state root that this epoch."
+          - name: idx
+            description: "Index of message indicating execution order."
+          - name: exit_code
+            description: "The exit code that was returned as a result of executing the message. Exit code 0 indicates success. Codes 0-15 are reserved for use by the runtime. Codes 16-31 are common codes shared by different actors. Codes 32+ are actor specific."
+          - name: gas_used
+            description: "A measure of the amount of resources (or units of gas) consumed, in order to execute a message."
+          - name: height
+            description: "Epoch the message was executed and receipt generated."
+          - name: return
+            description: "Returns value of message receipt."
+          - name: parsed_return
+            description: "Result returned from executing a message parsed and serialized as a JSON object."
+      - name: actors
+        identifier: actor
+        description: Actors on chain that were added or updated at an epoch. Associates the actor’s state root CID (head) with the chain state root CID from which it descends. Includes account ID nonce, balance and state data at each state.
+        columns:
+          - name: id
+            description: "Actor address."
+          - name: code
+            description: "Human readable identifier for the type of the actor."
+          - name: head
+            description: "CID of the root of the state tree for the actor."
+          - name: nonce
+            description: "The next actor nonce that is expected to appear on chain."
+          - name: balance
+            description: "Actor balance in attoFIL."
+          - name: state_root
+            description: "CID of the state root."
+          - name: height
+            description: "Epoch when this actor was created or updated."
+          - name: state
+            description: "Top level of state data."
+      - name: builtin_actor_events
+        identifier: builtin_actor_event
+        description: >
+          This table provides the events of built-in actors at each epoch, but it is very important to note that it does not include the operations of the cron actor. Therefore, events like sector-terminated and deal-activated are only subsets of all events.
+        columns:
+          - name: height
+            description: "Epoch when the event was created or updated."
+          - name: cid
+            description: "Content identifier related to the event."
+          - name: emitter
+            description: "Identifier of the entity that emitted the event."
+          - name: event_type
+            description: "Type or category of the event."
+          - name: event_entries
+            description: "JSON array containing entries related to the event."
+          - name: event_idx
+            description: "Event index at the specific height."
+      - name: market_deal_proposals
+        identifier: market_deal_proposal
+        description: All storage deal states with latest values applied to end_epoch when updates are detected on-chain.
+        columns:
+          - name: deal_id
+            description: "Identifier for the deal."
+          - name: state_root
+            description: "CID of the parent state root for this deal."
+          - name: piece_cid
+            description: "CID of a sector piece. A Piece is an object that represents a whole or part of a File."
+          - name: padded_piece_size
+            description: "The piece size in bytes with padding."
+          - name: unpadded_piece_size
+            description: "The piece size in bytes without padding."
+          - name: is_verified
+            description: "Deal is with a verified provider."
+          - name: client_id
+            description: "Address of the actor proposing the deal."
+          - name: provider_id
+            description: "Address of the actor providing the services."
+          - name: start_epoch
+            description: "The epoch at which this deal will begin. Storage deal must appear in a sealed (proven) sector no later than start_epoch, otherwise it is invalid."
+          - name: end_epoch
+            description: "The epoch at which this deal will end."
+          - name: storage_price_per_epoch
+            description: "The amount of FIL (in attoFIL) that will be transferred from the client to the provider every epoch this deal is active for."
+          - name: provider_collateral
+            description: "The amount of FIL (in attoFIL) the provider has pledged as collateral. The Provider deal collateral is only slashed when a sector is terminated before the deal expires."
+          - name: client_collateral
+            description: "The amount of FIL (in attoFIL) the client has pledged as collateral."
+          - name: label
+            description: "An arbitrary client chosen label to apply to the deal."
+          - name: height
+            description: "Epoch at which this deal proposal was added or changed."
+          - name: is_string
+            description: "When true, Label contains a valid UTF-8 string encoded in base64. When false, Label contains raw bytes encoded in base64. Required by FIP: 27."
+      - name: market_deal_states
+        identifier: market_deal_state
+        description: All storage deal state transitions detected on-chain.
+        columns:
+          - name: deal_id
+            description: "Identifier for the deal."
+          - name: sector_start_epoch
+            description: "Epoch this deal was included in a proven sector. -1 if not yet included in proven sector."
+          - name: last_update_epoch
+            description: "Epoch this deal was last updated at. -1 if deal state never updated."
+          - name: slash_epoch
+            description: "Epoch this deal was slashed at. -1 if deal was never slashed."
+          - name: state_root
+            description: "CID of the parent state root for this deal."
+          - name: height
+            description: "Epoch at which this deal was added or changed."
+      - name: miner_sector_events
+        identifier: miner_sector_event
+        description: Sector events on-chain per Miner/Sector.
+        columns:
+          - name: miner_id
+            description: "Address of the miner who owns the sector."
+          - name: sector_id
+            description: "Numeric identifier of the sector."
+          - name: state_root
+            description: "CID of the parent state root at this epoch."
+          - name: event
+            description: "Name of the event that occurred. Possible values: PRECOMMIT_ADDED, PRECOMMIT_EXPIRED, COMMIT_CAPACITY_ADDED, SECTOR_ADDED, SECTOR_EXTENDED, SECTOR_FAULTED, SECTOR_FAULTED, SECTOR_SNAPPED, SECTOR_RECOVERING, SECTOR_RECOVERED, SECTOR_EXPIRED, or SECTOR_TERMINATED."
+          - name: height
+            description: "Epoch at which this event occurred."


### PR DESCRIPTION
Added some of the most useful tables to the dbt sources files from `https://lilium.sh/`.

Note that not all tables that Starboard is publishing are updated se we can use this to expose the ones that are maintained and used.

Closes https://github.com/opensource-observer/oso/issues/1989