### PR TITLE
feat: ArtifactPage props updated

### DIFF
--- a/apps/frontend/components/dataprovider/metrics-data-provider.tsx
+++ b/apps/frontend/components/dataprovider/metrics-data-provider.tsx
@@ -354,9 +354,8 @@ function ArtifactMetricsDataProvider(props: MetricsDataProviderProps) {
       ensure<string>(x.artifactName, "Missing artifactName"),
     ]),
   );
-  const normalizedData: EventData[] = ensure(
-    rawData?.oso_timeseriesMetricsByArtifactV0,
-    "Data missing time series metrics",
+  const normalizedData: EventData[] = (
+    rawData?.oso_timeseriesMetricsByArtifactV0 ?? []
   ).map((x: any) => ({
     metricId: ensure<string>(x.metricId, "Data missing 'metricId'"),
     metricName: ensure<string>(


### PR DESCRIPTION
* For the ArtifactPage, I'm trying to keep this as generic as possible, so now you can pass in which key metrics to show directly, as well as which metric IDs to show in the time series chart.
* This gives ultimate flexibility to pass in different values depending on whether this is a repo, or package, or contract etc.