### PR TITLE
feat: automatically create `schedules` to materialise `partitioned` assets dynamically

### DIFF
--- a/warehouse/oso_dagster/definitions.py
+++ b/warehouse/oso_dagster/definitions.py
@@ -7,7 +7,7 @@ from dagster_sqlmesh import SQLMeshContextConfig, SQLMeshResource
 from dagster_embedded_elt.dlt import DagsterDltResource
 from dotenv import load_dotenv
 from . import constants
-from .schedules import schedules
+from .schedules import schedules, get_partitioned_schedules
 from .cbt import CBTResource
 from .factories import load_all_assets_from_package
 from .utils import (
@@ -91,6 +91,8 @@ def load_definitions():
 
     asset_factories = asset_factories + alerts
 
+    all_schedules = schedules + get_partitioned_schedules(asset_factories)
+
     # Each of the dbt environments needs to be setup as a resource to be used in
     # the dbt assets
     resources = {
@@ -116,7 +118,7 @@ def load_definitions():
 
     return Definitions(
         assets=asset_factories.assets,
-        schedules=schedules,
+        schedules=all_schedules,
         jobs=asset_factories.jobs,
         asset_checks=asset_factories.checks,
         sensors=asset_factories.sensors,

--- a/warehouse/oso_dagster/factories/common.py
+++ b/warehouse/oso_dagster/factories/common.py
@@ -73,6 +73,11 @@ class AssetFactoryResponse:
         filtered = self.filter_assets(lambda a: a.key.path[-1] == name)
         return filtered
 
+    def find_job_by_name(
+        self, name: str
+    ) -> Optional[Union[JobDefinition, UnresolvedAssetJobDefinition]]:
+        return next((job for job in self.jobs if job.name == name), None)
+
 
 type EarlyResourcesAssetDecoratedFunction[**P] = Callable[
     P, AssetFactoryResponse | AssetsDefinition

--- a/warehouse/oso_dagster/schedules.py
+++ b/warehouse/oso_dagster/schedules.py
@@ -1,11 +1,72 @@
-"""
-To add a daily schedule that materializes your dbt assets, uncomment the following lines.
-"""
+from typing import Generator, Iterable, List, cast
 
-from dagster import define_asset_job, ScheduleDefinition, AssetSelection
+from dagster import (
+    AssetKey,
+    AssetSelection,
+    AssetsDefinition,
+    RunRequest,
+    ScheduleDefinition,
+    ScheduleEvaluationContext,
+    define_asset_job,
+)
+from oso_dagster.factories.common import AssetFactoryResponse
+
+partitioned_assets = AssetSelection.tag(
+    "opensource.observer/extra", "partitioned-assets"
+)
+
+
+def get_partitioned_schedules(
+    factory: AssetFactoryResponse,
+) -> List[ScheduleDefinition]:
+    resolved_assets = partitioned_assets.resolve(
+        cast(Iterable[AssetsDefinition], factory.assets)
+    )
+
+    def create_schedule(asset_key: AssetKey):
+        asset_path = "_".join(asset_key.path)
+        job_name = f"{asset_path}_job"
+        factory_job = factory.find_job_by_name(job_name)
+
+        if not factory_job:
+            raise ValueError(f"Job {job_name} not found in factory response")
+
+        def execution_fn(
+            context: ScheduleEvaluationContext,
+        ) -> Generator[RunRequest, None, None]:
+            if not factory_job.partitions_def:
+                raise ValueError(
+                    f"Job {job_name} does not have a partitions definition, but is being used "
+                    "in a partitioned schedule"
+                )
+
+            materialized_partitions = set(
+                context.instance.get_materialized_partitions(asset_key)
+            )
+
+            yield from (
+                RunRequest(
+                    run_key=f"{asset_path}_{partition_key}",
+                    partition_key=partition_key,
+                )
+                for partition_key in factory_job.partitions_def.get_partition_keys()
+                if partition_key not in materialized_partitions
+            )
+
+        # Run unmaterilized partitions every sunday at midnight
+        return ScheduleDefinition(
+            job=factory_job,
+            cron_schedule="0 0 * * 0",
+            name=f"materialize_{asset_path}_schedule",
+            execution_fn=execution_fn,
+        )
+
+    return [create_schedule(asset_key) for asset_key in resolved_assets]
+
 
 materialize_all_assets = define_asset_job(
-    "materialize_all_assets_job", AssetSelection.all()
+    "materialize_all_assets_job",
+    AssetSelection.all() - partitioned_assets,
 )
 
 materialize_source_assets = define_asset_job(
@@ -14,8 +75,8 @@ materialize_source_assets = define_asset_job(
     | AssetSelection.tag("opensource.observer/type", "source-qa"),
 )
 
-schedules = [
-    # Run everything once a week on sunday at midnight
+schedules: list[ScheduleDefinition] = [
+    # Run everything except partitioned assets once a week on sunday at midnight
     ScheduleDefinition(
         job=materialize_all_assets,
         cron_schedule="0 0 * * 0",


### PR DESCRIPTION
This PR closes #2119 and unblocks the merging of #2110 by enhancing the [`dlt_factory`](https://github.com/opensource-observer/oso/blob/4202708b428fc6ce7867d68b5d8a6f3cfaf7b1ee/warehouse/oso_dagster/factories/dlt.py#L121) decorator by automatically creating daily schedules for assets with `partition_def`. The key features include:

1. **Daily Schedule & Weekly Job**: It sets up a daily schedule for the asset and a job that materializes weekly on Sunday. Partitions that are already materialized are skipped.
   
2. **Custom Tagging**: The `dlt_factory` decorator now adds a custom tag (`opensource.observer/extra -> partitioned-assets`) to Dagster assets to indicate they are partitioned.

3. **Job Creation**: An internal job is created using the provided partition and is included in the `AssetFactoryResponse`.

4. **RunRequest & ScheduleDefinition**: The definitions are loaded to create `RunRequests` for the partitions, which are used to build `ScheduleDefinition`. Partitions that are already materialized are filtered out.

5. **Merging Schedules**: The dynamically generated schedules are then merged with schedules from `all_assets_job` and passed to the main Dagster definition.