### PR TITLE
add: `dagster/concurrency_key` to partitioned assets

### DIFF
--- a/warehouse/oso_dagster/factories/dlt.py
+++ b/warehouse/oso_dagster/factories/dlt.py
@@ -68,6 +68,7 @@ def _dlt_factory[
         deps: Optional[AssetDeps] = None,
         ins: Optional[Mapping[str, AssetIn]] = None,
         tags: Optional[MutableMapping[str, str]] = None,
+        op_tags: Optional[MutableMapping[str, Any]] = None,
         *args: P.args,
         **kwargs: P.kwargs,
     ):
@@ -80,9 +81,11 @@ def _dlt_factory[
         related dagster configuration.
         """
         tags = tags or {}
+        op_tags = op_tags or {}
 
         if "partitions_def" in kwargs:
             tags["opensource.observer/extra"] = "partitioned-assets"
+            op_tags["dagster/concurrency_key"] = "dlt_partitioned_assets"
 
         key_prefix_str = ""
         if key_prefix:
@@ -125,6 +128,7 @@ def _dlt_factory[
                     deps=deps,
                     ins=asset_ins,
                     tags=tags,
+                    op_tags=op_tags,
                     **kwargs,
                 )
                 def _dlt_asset(


### PR DESCRIPTION
This PR adds the `dagster/concurrency_key` to all partitioned assets created via the `dlt_factory` decorator. This tag will be used to limit concurrency to `1` for those assets to avoid race-conditions for the time being.