### PR TITLE
fix: use dagster `retry` mechanism

### DIFF
--- a/warehouse/oso_dagster/assets/eas_optimism.py
+++ b/warehouse/oso_dagster/assets/eas_optimism.py
@@ -133,30 +133,23 @@ def get_optimism_eas_data(
     )
 
     for step in generate_steps(total_count, EAS_OPTIMISM_STEP_NODES_PER_PAGE):
-        try:
-            query = client.execute(
-                attestations_query,
-                variable_values={
-                    "take": EAS_OPTIMISM_STEP_NODES_PER_PAGE,
-                    "skip": step,
-                    "where": {
-                        "time": {
-                            "gte": date_from,
-                            "lte": date_to,
-                        },
+        query = client.execute(
+            attestations_query,
+            variable_values={
+                "take": EAS_OPTIMISM_STEP_NODES_PER_PAGE,
+                "skip": step,
+                "where": {
+                    "time": {
+                        "gte": date_from,
+                        "lte": date_to,
                     },
                 },
-            )
-            context.log.info(
-                f"Fetching attestation {step}/{total_count}",
-            )
-            yield query["attestations"]
-        except Exception as exception:
-            context.log.warning(
-                f"An error occurred while fetching EAS data: '{exception}'. "
-                "We will stop this materialization instead of retrying for now."
-            )
-            return []
+            },
+        )
+        context.log.info(
+            f"Fetching attestation {step}/{total_count}",
+        )
+        yield query["attestations"]
 
 
 def get_optimism_eas(context: AssetExecutionContext, client: Client):
@@ -208,4 +201,5 @@ def attestations(context: AssetExecutionContext):
         name="attestations",
         columns=pydantic_to_dlt_nullable_columns(Attestation),
         primary_key="id",
+        write_disposition="merge",
     )

--- a/warehouse/oso_dagster/assets/eas_optimism.py
+++ b/warehouse/oso_dagster/assets/eas_optimism.py
@@ -1,13 +1,14 @@
 from datetime import datetime, timedelta
+from typing import Any, Dict
 
 import dlt
 from dagster import AssetExecutionContext, WeeklyPartitionsDefinition
 from gql import Client, gql
 from gql.transport.aiohttp import AIOHTTPTransport
 from oso_dagster.factories import dlt_factory, pydantic_to_dlt_nullable_columns
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
-from .open_collective import generate_steps
+from ..utils.common import QueryArguments, QueryConfig, query_with_retry
 
 
 class Attestation(BaseModel):
@@ -29,11 +30,34 @@ class Attestation(BaseModel):
     isOffchain: bool
 
 
+class EASOptimismParameters(QueryArguments):
+    take: int = Field(
+        ...,
+        gt=0,
+        description="The number of nodes to fetch per query.",
+    )
+    skip: int = Field(
+        ...,
+        ge=0,
+        description="The number of nodes to skip.",
+    )
+    where: Dict[str, Any] = Field(
+        ...,
+        description="The where clause for the query.",
+    )
+
+
 # The first attestation on EAS Optimism was created on the 07/28/2023 9:22:35 am
 EAS_OPTIMISM_FIRST_ATTESTATION = datetime.fromtimestamp(1690557755)
 
 # A sensible limit for the number of nodes to fetch per page
 EAS_OPTIMISM_STEP_NODES_PER_PAGE = 10_000
+
+# Minimum limit for the query, after which the query will fail
+EAS_OPTIMISM_MINIMUM_LIMIT = 100
+
+# The rate limit wait time in seconds
+EAS_OPTIMISM_RATELIMIT_WAIT_SECONDS = 65
 
 # Kubernetes configuration for the asset materialization
 K8S_CONFIG = {
@@ -132,24 +156,32 @@ def get_optimism_eas_data(
         """
     )
 
-    for step in generate_steps(total_count, EAS_OPTIMISM_STEP_NODES_PER_PAGE):
-        query = client.execute(
-            attestations_query,
-            variable_values={
-                "take": EAS_OPTIMISM_STEP_NODES_PER_PAGE,
-                "skip": step,
-                "where": {
-                    "time": {
-                        "gte": date_from,
-                        "lte": date_to,
-                    },
-                },
+    config = QueryConfig(
+        limit=EAS_OPTIMISM_STEP_NODES_PER_PAGE,
+        minimum_limit=EAS_OPTIMISM_MINIMUM_LIMIT,
+        query_arguments=EASOptimismParameters(
+            take=EAS_OPTIMISM_STEP_NODES_PER_PAGE,
+            offset=0,
+            skip=0,
+            where={
+                "time": {
+                    "gte": date_from,
+                    "lte": date_to,
+                }
             },
-        )
-        context.log.info(
-            f"Fetching attestation {step}/{total_count}",
-        )
-        yield query["attestations"]
+        ),
+        step_key="skip",
+        extract_fn=lambda data: data["attestations"],
+        ratelimit_wait_seconds=EAS_OPTIMISM_RATELIMIT_WAIT_SECONDS,
+    )
+
+    yield from query_with_retry(
+        client,
+        context,
+        attestations_query,
+        total_count,
+        config,
+    )
 
 
 def get_optimism_eas(context: AssetExecutionContext, client: Client):

--- a/warehouse/oso_dagster/utils/common.py
+++ b/warehouse/oso_dagster/utils/common.py
@@ -1,8 +1,16 @@
 from enum import Enum
-from typing import TypeVar, Never, Optional
+from time import sleep
+from typing import Any, Callable, Dict, Generator, Never, Optional, TypeVar
+
+from dagster import AssetExecutionContext
+from gql import Client
+from graphql import DocumentNode
+from pydantic import BaseModel, Field
+
 from .errors import NullOrUndefinedValueError
 
 T = TypeVar("T")
+
 
 # An enum for specifying time intervals
 class TimeInterval(Enum):
@@ -11,6 +19,7 @@ class TimeInterval(Enum):
     Weekly = 2
     Monthly = 3
 
+
 # Configures how we should handle incoming data
 class SourceMode(Enum):
     # Add new time-partitioned data incrementally
@@ -18,15 +27,18 @@ class SourceMode(Enum):
     # Overwrite the entire dataset on each import
     Overwrite = 1
 
+
 # Simple snake case to camel case
 def to_camel_case(snake_str):
     return "".join(x.capitalize() for x in snake_str.lower().split("_"))
+
 
 def to_lower_camel_case(snake_str):
     # We capitalize the first letter of each component except the first one
     # with the 'capitalize' method and join them together.
     camel_string = to_camel_case(snake_str)
     return snake_str[0].lower() + camel_string[1:]
+
 
 def safeCast[T](x: T) -> T:
     """
@@ -36,12 +48,14 @@ def safeCast[T](x: T) -> T:
     y: T = x
     return y
 
+
 def assertNever(_x: Never) -> Never:
     """
     Asserts that a branch is never taken.
     Useful for exhaustiveness checking.
     """
     raise Exception("unexpected branch taken")
+
 
 def ensure[T](x: Optional[T], msg: str) -> T:
     """
@@ -66,3 +80,136 @@ def ensure[T](x: Optional[T], msg: str) -> T:
     else:
         y: T = x
         return y
+
+
+def generate_steps(total: int, step: int):
+    """
+    Generates a sequence of numbers from 0 up to the specified total, incrementing by the specified step.
+    If the total is not divisible by the step, the last iteration will yield the remaining value.
+
+    Args:
+        total (int): The desired total value.
+        step (int): The increment value for each iteration.
+
+    Yields:
+        int: The next number in the sequence.
+
+    Example:
+        >>> for num in generate_steps(10, 3):
+        ...     print(num)
+        0
+        3
+        6
+        9
+        10
+    """
+
+    for i in range(0, total, step):
+        yield i
+    if total % step != 0:
+        yield total
+
+
+class QueryArguments(BaseModel):
+    offset: int = Field(
+        ...,
+        ge=0,
+        description="The offset to start fetching nodes from.",
+    )
+
+
+class QueryConfig(BaseModel):
+    limit: int = Field(
+        ...,
+        gt=0,
+        description="Maximum number of nodes to fetch per query.",
+    )
+    minimum_limit: int = Field(
+        ...,
+        gt=0,
+        description="Minimum limit for the query, after which the query will fail.",
+    )
+    query_arguments: QueryArguments = Field(
+        ...,
+        description="Arguments for the query to be executed.",
+    )
+    step_key: str = Field(
+        ...,
+        description="The key in the query arguments to update with the offset.",
+    )
+    extract_fn: Callable[[Dict[str, Any]], Any] = Field(
+        ...,
+        description="Function to extract the data from the query response.",
+    )
+    ratelimit_wait_seconds: int = Field(
+        ...,
+        gt=0,
+        description="Time to wait before retrying the query after being rate limited.",
+    )
+
+
+def query_with_retry(
+    client: Client,
+    context: AssetExecutionContext,
+    query_str: DocumentNode,
+    total_count: int,
+    config: QueryConfig,
+) -> Generator[Dict[str, Any], None, None]:
+    """
+    Queries the GraphQL API with retry logic. The query will be retried
+    with a lower limit if it fails. If the limit reaches the minimum limit,
+    the query will fail. It will also handle rate limiting by waiting for
+    the specified number of seconds before retrying.
+
+    Args:
+        client (Client): The GraphQL client to execute the query.
+        context (AssetExecutionContext): The context for the asset.
+        query_str (DocumentNode): The GraphQL query to execute.
+        total_count (int): The total number of nodes to fetch.
+        config (QueryConfig): The configuration for the query.
+
+    Yields:
+        Dict[str, Any]: A dictionary containing the transaction nodes.
+    """
+
+    max_retries = 3
+    current_index = 0
+    limit = config.limit
+    steps = list(generate_steps(total_count, limit))
+
+    while limit >= config.minimum_limit:
+        while current_index < len(steps):
+            setattr(config.query_arguments, config.step_key, steps[current_index])
+
+            if max_retries == 0:
+                raise ValueError(
+                    "Query failed after reaching the maximum number of retries."
+                )
+
+            try:
+                query = client.execute(
+                    query_str, variable_values=config.query_arguments.model_dump()
+                )
+                context.log.info(
+                    f"Fetching transaction {steps[current_index]}/{total_count}"
+                )
+                current_index += 1
+                yield config.extract_fn(query)
+            except Exception as exception:
+                context.log.error(f"Query failed with error: {exception}")
+                if "429" in str(exception):
+                    context.log.info(
+                        f"Got rate-limited, retrying in {config.ratelimit_wait_seconds} seconds."
+                    )
+                    sleep(config.ratelimit_wait_seconds)
+                    max_retries -= 1
+                    continue
+                limit //= 2
+                steps = list(generate_steps(total_count, limit))
+                current_index *= 2
+                if limit < config.minimum_limit:
+                    raise ValueError(
+                        f"Query failed after reaching the minimum limit of {limit}."
+                    ) from exception
+                context.log.info(f"Retrying with limit: {limit}")
+        break


### PR DESCRIPTION
This PR updates failed queries to use Dagster's retry mechanism instead of failing silently, adjusts the data fetching to reduce nodes to 500 per query—since the Open Collective API returns 503 errors for larger queries—which seems sensible based on local testing and will require further triage, and changes the write disposition to "merge" to prevent duplicates in the dataset.