### PR TITLE
Metrics fixes for metrics_v0

### DIFF
--- a/warehouse/metrics_mesh/config.py
+++ b/warehouse/metrics_mesh/config.py
@@ -45,10 +45,10 @@ config = Config(
                     os.environ.get("SQLMESH_CLICKHOUSE_CONCURRENT_TASKS", "16")
                 ),
                 send_receive_timeout=1800,
-                connection_settings={"allow_nondeterministic_mutations": 1},
+                # connection_settings={"allow_nondeterministic_mutations": 1},
                 connection_pool_options={
                     "maxsize": 24,
-                    "retries": 3,
+                    "retries": 0,
                 },
             ),
             state_connection=GCPPostgresConnectionConfig(

--- a/warehouse/metrics_tools/lib/factories/definition.py
+++ b/warehouse/metrics_tools/lib/factories/definition.py
@@ -729,7 +729,7 @@ class DailyTimeseriesRollingWindowOptions(t.TypedDict):
 def join_all_of_entity_type(evaluator: MacroEvaluator, *, db: str, tables: t.List[str], columns: t.List[str]):
     query = exp.select(*columns).from_(sqlglot.to_table(f"{db}.{tables[0]}"))
     for table in tables[1:]:
-        query.union(exp.select(*columns).from_(sqlglot.to_table(f"{db}.{table}")), distinct=False)
+        query = query.union(exp.select(*columns).from_(sqlglot.to_table(f"{db}.{table}")), distinct=False)
     return query
 
 


### PR DESCRIPTION
Fixes issues with the metrics ids not getting into `metrics_v0`