### PR TITLE
feat: MetricsDataProvider supports projects and collections

### DIFF
--- a/apps/frontend/lib/graphql/queries.ts
+++ b/apps/frontend/lib/graphql/queries.ts
@@ -43,13 +43,12 @@ const GET_TIMESERIES_METRICS_BY_ARTIFACT = gql(`
   }
 `);
 
-/**
 const GET_TIMESERIES_METRICS_BY_PROJECT = gql(`
   query TimeseriesMetricsByProject(
     $projectIds: [String!],
     $metricIds: [String!],
-    $startDate: Oso_DateTime!,
-    $endDate: Oso_DateTime!, 
+    $startDate: Oso_Date!,
+    $endDate: Oso_Date!, 
   ) {
     oso_timeseriesMetricsByProjectV0(where: {
       projectId: {_in: $projectIds},
@@ -80,9 +79,46 @@ const GET_TIMESERIES_METRICS_BY_PROJECT = gql(`
     }
   }
 `);
- */
+
+const GET_TIMESERIES_METRICS_BY_COLLECTION = gql(`
+  query TimeseriesMetricsByCollection(
+    $collectionIds: [String!],
+    $metricIds: [String!],
+    $startDate: Oso_Date!,
+    $endDate: Oso_Date!, 
+  ) {
+    oso_timeseriesMetricsByCollectionV0(where: {
+      collectionId: {_in: $collectionIds},
+      metricId: {_in: $metricIds},
+      sampleDate: { _gte: $startDate, _lte: $endDate }
+    }) {
+      amount
+      metricId
+      collectionId
+      sampleDate
+      unit
+    }
+    oso_collectionsV1(where: { collectionId: { _in: $collectionIds }}) {
+      collectionId
+      collectionSource
+      collectionNamespace
+      collectionName
+      displayName
+      description
+    }
+    oso_metricsV0(where: {metricId: {_in: $metricIds}}) {
+      metricId
+      metricSource
+      metricNamespace
+      metricName
+      displayName
+      description
+    }
+  }
+`);
 
 export {
   GET_TIMESERIES_METRICS_BY_ARTIFACT,
-  //GET_TIMESERIES_METRICS_BY_PROJECT,
+  GET_TIMESERIES_METRICS_BY_PROJECT,
+  GET_TIMESERIES_METRICS_BY_COLLECTION,
 };


### PR DESCRIPTION
* Copying logic from the metrics provider for artifacts