### PR TITLE
fix: various chart fixes

### DIFF
--- a/apps/frontend/app/artifacts/[source]/[...name]/page.tsx
+++ b/apps/frontend/app/artifacts/[source]/[...name]/page.tsx
@@ -27,7 +27,7 @@ const STATIC_EXPORT_PARAMS: ArtifactPagePath[] = [
 export async function generateStaticParams() {
   return STATIC_EXPORT_PARAMS;
 }
- */
+*/
 
 async function getDefaultProps() {
   return {


### PR DESCRIPTION
* Bug in CollectionMetricsDataProvider that was getting by projectId instead of collectionId
* Instead of filling missing dates with 0, use null, and then leverage Tremor's ability to connect nulls for smooth graphs