### PR TITLE
fix: remove `end_date` parameter

### DIFF
--- a/warehouse/oso_dagster/assets/eas_optimism.py
+++ b/warehouse/oso_dagster/assets/eas_optimism.py
@@ -208,7 +208,6 @@ def get_optimism_eas(context: AssetExecutionContext, client: Client):
     key_prefix="ethereum_attestation_service_optimism",
     partitions_def=WeeklyPartitionsDefinition(
         start_date=EAS_OPTIMISM_FIRST_ATTESTATION.isoformat().split("T", maxsplit=1)[0],
-        end_date=(datetime.now()).isoformat().split("T", maxsplit=1)[0],
     ),
     op_tags={
         "dagster-k8s/config": K8S_CONFIG,

--- a/warehouse/oso_dagster/assets/open_collective.py
+++ b/warehouse/oso_dagster/assets/open_collective.py
@@ -592,7 +592,6 @@ def base_open_collective_client(personal_token: str):
     key_prefix="open_collective",
     partitions_def=WeeklyPartitionsDefinition(
         start_date=OPEN_COLLECTIVE_TX_EPOCH.split("T", maxsplit=1)[0],
-        end_date=(datetime.now()).isoformat().split("T")[0],
     ),
     op_tags={
         "dagster-k8s/config": K8S_CONFIG,
@@ -637,7 +636,6 @@ def expenses(
     key_prefix="open_collective",
     partitions_def=WeeklyPartitionsDefinition(
         start_date=OPEN_COLLECTIVE_TX_EPOCH.split("T", maxsplit=1)[0],
-        end_date=(datetime.now()).isoformat().split("T")[0],
     ),
     op_tags={
         "dagster-k8s/config": K8S_CONFIG,


### PR DESCRIPTION
Fixes #2300 by removing `end_date` parameter to partitions. TLDR; `end_date` was computed once when Dagster was deployed, making it miss future partitions.