### PR TITLE
fix: allow `assets` to materialize the current week on demand

### DIFF
--- a/warehouse/oso_dagster/assets/eas_optimism.py
+++ b/warehouse/oso_dagster/assets/eas_optimism.py
@@ -208,6 +208,7 @@ def get_optimism_eas(context: AssetExecutionContext, client: Client):
     key_prefix="ethereum_attestation_service_optimism",
     partitions_def=WeeklyPartitionsDefinition(
         start_date=EAS_OPTIMISM_FIRST_ATTESTATION.isoformat().split("T", maxsplit=1)[0],
+        end_offset=1,
     ),
     op_tags={
         "dagster-k8s/config": K8S_CONFIG,

--- a/warehouse/oso_dagster/assets/open_collective.py
+++ b/warehouse/oso_dagster/assets/open_collective.py
@@ -592,6 +592,7 @@ def base_open_collective_client(personal_token: str):
     key_prefix="open_collective",
     partitions_def=WeeklyPartitionsDefinition(
         start_date=OPEN_COLLECTIVE_TX_EPOCH.split("T", maxsplit=1)[0],
+        end_offset=1,
     ),
     op_tags={
         "dagster-k8s/config": K8S_CONFIG,
@@ -636,6 +637,7 @@ def expenses(
     key_prefix="open_collective",
     partitions_def=WeeklyPartitionsDefinition(
         start_date=OPEN_COLLECTIVE_TX_EPOCH.split("T", maxsplit=1)[0],
+        end_offset=1,
     ),
     op_tags={
         "dagster-k8s/config": K8S_CONFIG,


### PR DESCRIPTION
This PR closes #2295 by enabling partitioned jobs to materialize an additional range. Specifically, for a weekly partition, it includes the current partial week, allowing the asset to materialize the available data for the current week without waiting for the full week to complete.
