### PR TITLE
fix: use updated `k8s` config

### DIFF
--- a/warehouse/oso_dagster/assets/clickhouse_dbt_marts.py
+++ b/warehouse/oso_dagster/assets/clickhouse_dbt_marts.py
@@ -89,14 +89,16 @@ def clickhouse_assets_from_manifests_map(
                             "op_tags": {
                                 "dagster-k8s/config": {
                                     "merge_behavior": "SHALLOW",
-                                    "resources": {
-                                        "requests": {
-                                            "cpu": "1000m",
-                                            "memory": "1024i",
-                                        },
-                                        "limits": {
-                                            "cpu": "1000m",
-                                            "memory": "1024Mi",
+                                    "container_config": {
+                                        "resources": {
+                                            "requests": {
+                                                "cpu": "1000m",
+                                                "memory": "1024i",
+                                            },
+                                            "limits": {
+                                                "cpu": "1000m",
+                                                "memory": "1024Mi",
+                                            },
                                         },
                                     },
                                     "pod_spec_config": {


### PR DESCRIPTION
This PR fixes #2335 by updating the `clickhouse_dbt_mart` k8s config, which used the old one. I have also checked all the other `dagster-k8s/config` uses, which are following the new format, so we should be fine!