### PR TITLE
fix: `ossd` failing pipeline

### DIFF
--- a/warehouse/oso_dagster/dlt_sources/github_repos/__init__.py
+++ b/warehouse/oso_dagster/dlt_sources/github_repos/__init__.py
@@ -60,8 +60,8 @@ class Repository(BaseModel):
     license_spdx_id: str
     license_name: str
     language: str
-    created_at: Optional[datetime]
-    updated_at: Optional[datetime]
+    created_at: datetime
+    updated_at: datetime
 
 
 class InvalidGithubURL(Exception):
@@ -131,8 +131,8 @@ def gh_repository_to_repository(
         url=repo.html_url,
         is_fork=repo.fork,
         language=repo.language or "",
-        created_at=repo.created_at or None,
-        updated_at=repo.updated_at or None,
+        created_at=repo.created_at or datetime.fromtimestamp(0),
+        updated_at=repo.updated_at or datetime.fromtimestamp(0),
     )
 
 


### PR DESCRIPTION
The pipeline fails with a `401 Unauthorized` error when attempting to fetch repository data using `githubkit`. After investigating, it appears the issue stems from the Pydantic validation for the full repository model. Specifically, `githubkit`'s full repository model expects a `datetime` field, whereas we were using `Optional[datetime]` due to the signature in the `MinimalRepository` for API version `2022-11-28`. This caused the validation to fail. There is a comment in the library explaining this design choice:

https://github.com/yanyongyu/githubkit/blob/1857d5e711fa400df74782775b53fa3ffe5acef8/githubkit/typing.py#L81-L83

This is a potential fix and requires further testing to confirm that the validation issue is indeed the root cause.
