### PR TITLE
revert: github `repository` model properties

### DIFF
--- a/warehouse/oso_dagster/dlt_sources/github_repos/__init__.py
+++ b/warehouse/oso_dagster/dlt_sources/github_repos/__init__.py
@@ -60,8 +60,6 @@ class Repository(BaseModel):
     license_spdx_id: str
     license_name: str
     language: str
-    created_at: Optional[datetime]
-    updated_at: Optional[datetime]
 
 
 class InvalidGithubURL(Exception):
@@ -131,8 +129,6 @@ def gh_repository_to_repository(
         url=repo.html_url,
         is_fork=repo.fork,
         language=repo.language or "",
-        created_at=repo.created_at or None,
-        updated_at=repo.updated_at or None,
     )
 
 

--- a/warehouse/oso_dagster/dlt_sources/github_repos/__init__.py
+++ b/warehouse/oso_dagster/dlt_sources/github_repos/__init__.py
@@ -60,8 +60,8 @@ class Repository(BaseModel):
     license_spdx_id: str
     license_name: str
     language: str
-    created_at: datetime
-    updated_at: datetime
+    created_at: Optional[datetime]
+    updated_at: Optional[datetime]
 
 
 class InvalidGithubURL(Exception):
@@ -131,8 +131,8 @@ def gh_repository_to_repository(
         url=repo.html_url,
         is_fork=repo.fork,
         language=repo.language or "",
-        created_at=repo.created_at or datetime.fromtimestamp(0),
-        updated_at=repo.updated_at or datetime.fromtimestamp(0),
+        created_at=repo.created_at or None,
+        updated_at=repo.updated_at or None,
     )
 
 


### PR DESCRIPTION
This PR reverts the changes made to the `created_at` and `updated_at` fields. If this does not resolve the issue, the failing pipeline error may be related to authentication. However, if the issue is resolved, it indicates a mismatch with the API version model.
