### PR TITLE
fix: float `overflow` for base traces

### DIFF
--- a/warehouse/dbt/models/intermediate/blockchain_events/int_base_traces.sql
+++ b/warehouse/dbt/models/intermediate/blockchain_events/int_base_traces.sql
@@ -11,4 +11,19 @@
     incremental_strategy="insert_overwrite"
   )
 }}
-{{ filtered_blockchain_events("BASE", "base", "traces") }}
+
+with base_traces as (
+  {{ filtered_blockchain_events("BASE", "base", "traces") }}
+),
+
+transformed_traces as (
+  select
+    *,
+    CAST(`value` as FLOAT64) as numeric_value
+  from base_traces
+)
+
+select
+  * except (`value`, numeric_value),
+  numeric_value as `value`
+from transformed_traces

--- a/warehouse/dbt/models/marts/superchain/4337_traces.sql
+++ b/warehouse/dbt/models/marts/superchain/4337_traces.sql
@@ -58,7 +58,19 @@
 
 with filtered_traces as (
   {{ final_query }}
+),
+
+transformed_traces as (
+  select
+    *,
+    case
+      when network = 'BASE' then CAST(`value` as FLOAT64)
+      else `value`
+    end as numeric_value
+  from filtered_traces
 )
 
-select *
-from filtered_traces
+select
+  * except (`value`, numeric_value),
+  numeric_value as `value`
+from transformed_traces

--- a/warehouse/oso_dagster/assets/base.py
+++ b/warehouse/oso_dagster/assets/base.py
@@ -7,7 +7,7 @@ base_network = goldsky_network_assets(
     working_destination_dataset_name="oso_raw_sources",
     traces_config=NetworkAssetSourceConfigDict(
         schema_overrides=[
-            {"name": "value", "field_type": "BYTES"},
+            {"name": "value", "field_type": "STRING"},
         ]
     ),
 )

--- a/warehouse/oso_dagster/assets/base.py
+++ b/warehouse/oso_dagster/assets/base.py
@@ -1,7 +1,13 @@
 from ..factories.goldsky import goldsky_network_assets
+from ..factories.goldsky.config import NetworkAssetSourceConfigDict
 
 base_network = goldsky_network_assets(
     network_name="base",
     destination_dataset_name="superchain",
     working_destination_dataset_name="oso_raw_sources",
+    traces_config=NetworkAssetSourceConfigDict(
+        schema_overrides=[
+            {"name": "value", "field_type": "BYTES"},
+        ]
+    ),
 )


### PR DESCRIPTION
Closes #2269 by storing the `amount` field as `bytes` on the oso raw sources, and casting it back in direct downstream dependencies. This results in precession loss for really big numbers. As discussed, we'll follow this approach for the moment.