### PR TITLE
fix: add `dagster/concurrency_key` to `ossd` assets

### DIFF
--- a/warehouse/oso_dagster/assets/ossd.py
+++ b/warehouse/oso_dagster/assets/ossd.py
@@ -30,6 +30,7 @@ common_tags: t.Dict[str, str] = {
     "opensource.observer/environment": "production",
     "opensource.observer/group": "ossd",
     "opensource.observer/type": "source",
+    "dagster/concurrency_key": "ossd",
 }
 
 


### PR DESCRIPTION
This PR closes #2404 by adding the `dagster/concurrency_key` tag to all `ossd` assets.