### PR TITLE
fix: `sbom` performance improvements

### DIFF
--- a/warehouse/dbt/models/oss_directory_source.yml
+++ b/warehouse/dbt/models/oss_directory_source.yml
@@ -10,5 +10,7 @@ sources:
         identifier: collections
       - name: repositories
         identifier: repositories
+      - name: sbom
+        identifier: sbom
       - name: missing_sbom
         identifier: missing_sbom

--- a/warehouse/dbt/models/staging/oss-directory/stg_ossd__missing_sbom.sql
+++ b/warehouse/dbt/models/staging/oss-directory/stg_ossd__missing_sbom.sql
@@ -23,10 +23,10 @@ select
   `url` as artifact_url,
   ingestion_time as snapshot_at
 from
-  all_repos ar
+  all_repos as ar
 left join
-  all_ossd ao
+  all_ossd as ao
   on
-    CONCAT(ao.artifact_namespace, "/", ao.artifact_name) = ar.name_with_owner
+    CONCAT(ao.artifact_namespace, '/', ao.artifact_name) = ar.name_with_owner
 where
   ao.artifact_namespace is null

--- a/warehouse/dbt/models/staging/oss-directory/stg_ossd__missing_sbom.sql
+++ b/warehouse/dbt/models/staging/oss-directory/stg_ossd__missing_sbom.sql
@@ -5,13 +5,13 @@
 with all_repos as (
   select *
   from
-    `ossd.repositories`
+    {{ source('ossd', 'repositories') }}
 ),
 
 all_ossd as (
   select *
   from
-    `ossd.sbom`
+    {{ source('ossd', 'sbom') }}
   where
     artifact_source = 'GITHUB'
 )

--- a/warehouse/oso_dagster/assets/ossd.py
+++ b/warehouse/oso_dagster/assets/ossd.py
@@ -17,7 +17,6 @@ from dagster import (
 from oso_dagster.dlt_sources.github_repos import (
     oss_directory_github_repositories_resource,
     oss_directory_github_sbom_resource,
-    oss_directory_missing_sbom_repositories_resource,
 )
 from oso_dagster.factories import dlt_factory
 from oso_dagster.factories.common import AssetFactoryResponse
@@ -160,18 +159,6 @@ def sbom(
     gh_token: str = secret_ref_arg(group_name="ossd", key="github_token"),
 ):
     yield oss_directory_github_sbom_resource(projects_df, gh_token)
-
-
-@dlt_factory(
-    key_prefix="ossd",
-    ins={"projects_df": AssetIn(project_key)},
-    tags=common_tags,
-)
-def missing_sbom(
-    projects_df: pl.DataFrame,
-    gh_token: str = secret_ref_arg(group_name="ossd", key="github_token"),
-):
-    yield oss_directory_missing_sbom_repositories_resource(projects_df, gh_token)
 
 
 @discoverable_jobs(dependencies=[repositories])


### PR DESCRIPTION
This PR closes #2421 by:

- [x] creating `stg_ossd__missing_sbom` from `ossd.repositories` and `ossd.sbom`, instead of by API calls to the GitHub API.
- [x] stop calling `resolve_repo` when getting the `sbom` for a project, instead parsing the URL to avoid another API call.