### PR TITLE
[Feature] Add subcommand recce to test-deploy for external PRs

### DIFF
--- a/ops/external-prs/README.md
+++ b/ops/external-prs/README.md
@@ -24,22 +24,22 @@ pnpm external-prs initialize-check {sha} {login} {check-name}
 
 ```bash
 # Handle oso comments
-pnpm external-prs oso parse-comment {comment} {output}
+pnpm tools oso parse-comment {comment} {output}
 
 # Refresh gcp credentials for the test deployment infrastructure
-pnpm external-prs oso refresh-gcp-credentials {environment} {creds-path} {name}
+pnpm tools oso refresh-gcp-credentials {environment} {creds-path} {name}
 
 # Test deployment sub commands
-pnpm external-prs oso test-deploy --help
+pnpm tools oso test-deploy --help
 
 # Test deployment setup
-pnpm external-prs oso test-deploy setup {pr} {sha} {profile-path} {service-account-path} {checkout-path}
+pnpm tools oso test-deploy setup {pr} {sha} {profile-path} {service-account-path} {checkout-path}
 
 # Test deployment teardown
-pnpm external-prs oso test-deploy teardown {pr}
+pnpm tools oso test-deploy teardown {pr}
 
 # Test deployment clean
-pnpm external-prs oso test-deploy clean {ttl-seconds}
+pnpm tools oso test-deploy clean {ttl-seconds}
 ```
 
 ### OSS-Directory Specific
@@ -54,7 +54,7 @@ You can run the app via:
 
 ```bash
 # Handle PR validations
-pnpm external-prs ossd validate-prs {pr_number} {commit_sha} {main_path} {pr_path}
+pnpm tools ossd validate-prs {pr_number} {commit_sha} {main_path} {pr_path}
 ```
 
 If you've configured your GitHub secrets correctly,

--- a/ops/external-prs/src/oso/index.ts
+++ b/ops/external-prs/src/oso/index.ts
@@ -310,6 +310,16 @@ async function testDeploySetup(args: TestDeploySetupArgs) {
   );
 }
 
+async function testDeployRecce(args: TestDeploySetupArgs) {
+  return args.coordinator.recce(
+    args.pr,
+    args.sha,
+    args.profilePath,
+    args.serviceAccountPath,
+    args.checkoutPath,
+  );
+}
+
 async function testDeployTeardown(args: TestDeployTeardownArgs) {
   return args.coordinator.teardown(args.pr);
 }
@@ -370,6 +380,28 @@ function testDeployGroup(group: Argv) {
         });
       },
       (args) => handleError(testDeploySetup(args)),
+    )
+    .command<TestDeployRecceArgs>(
+      "recce <pr> <sha> <profile-path> <service-account-path> <checkout-path>",
+      "subcommand for a setting up Recce for the test deployment",
+      (yags) => {
+        yags.positional("pr", {
+          description: "The PR",
+        });
+        yags.positional("sha", {
+          description: "the sha to deploy",
+        });
+        yags.positional("profile-path", {
+          description: "the profile path to write to",
+        });
+        yags.positional("service-account-path", {
+          description: "the profile path to write to",
+        });
+        yags.positional("checkout-path", {
+          description: "the path to the checked out code",
+        });
+      },
+      (args) => handleError(testDeployRecce(args)),
     )
     .command<TestDeployTeardownArgs>(
       "teardown <pr>",

--- a/ops/external-prs/src/oso/index.ts
+++ b/ops/external-prs/src/oso/index.ts
@@ -381,7 +381,7 @@ function testDeployGroup(group: Argv) {
       },
       (args) => handleError(testDeploySetup(args)),
     )
-    .command<TestDeployRecceArgs>(
+    .command<TestDeploySetupArgs>(
       "recce <pr> <sha> <profile-path> <service-account-path> <checkout-path>",
       "subcommand for a setting up Recce for the test deployment",
       (yags) => {


### PR DESCRIPTION
- Add subcommand `recce` to test-deploy
- Add optional arguments to `runDbt`
- Add `generateDbtDocs`