### PR TITLE
sqlmesh manual load ops fix

### DIFF
--- a/ops/tf-modules/warehouse-cluster/main.tf
+++ b/ops/tf-modules/warehouse-cluster/main.tf
@@ -135,7 +135,7 @@ locals {
     # SQLMesh Workers
     {
       name                              = "${var.cluster_name}-sqlmesh-worker-node-pool"
-      machine_type                      = "n2-highmem-32"
+      machine_type                      = "n1-highmem-32"
       node_locations                    = join(",", var.cluster_zones)
       min_count                         = 0
       max_count                         = 10


### PR DESCRIPTION
n2 with greater than 20 CPUs can't be used here sadly. It forces 4,8, or 16 ssds which costs way too much. 