### PR TITLE
fix: use `oso` production source

### DIFF
--- a/warehouse/oso_dagster/assets/npm.py
+++ b/warehouse/oso_dagster/assets/npm.py
@@ -150,7 +150,7 @@ def downloads(
         SELECT
           DISTINCT(artifact_name)
         FROM
-          `oso_playground.artifacts_v1`
+          `oso.artifacts_v1`
         WHERE
           artifact_source = "NPM"
     """


### PR DESCRIPTION
This PR uses `oso.artifacts_v1` instead of `oso_playground.artifacts_v1` when fetching all `npm` packages.