### PR TITLE
fix: flatten `npm` manifest structure

### DIFF
--- a/warehouse/dbt/models/intermediate/directory/int_artifact_ownership.sql
+++ b/warehouse/dbt/models/intermediate/directory/int_artifact_ownership.sql
@@ -7,17 +7,17 @@ with npm_artifacts as (
 npm_manifests as (
   select
     `name`,
-    repository__url,
-    repository__type,
+    json_value(repository, '$.url') as manifest_repository_url,
+    json_value(repository, '$.type') as manifest_repository_type,
     concat('https://www.npmjs.com/package/', `name`) as artifact_url
   from {{ ref('stg_npm__manifests') }}
   where
     `name` in (select * from npm_artifacts)
-    and repository__url is not null
+    and json_value(repository, '$.url') is not null
 ),
 
 npm_repository_urls as (
-  {{ parse_npm_git_url('repository__url', 'npm_manifests') }}
+  {{ parse_npm_git_url('manifest_repository_url', 'npm_manifests') }}
 ),
 
 npm_artifact_ownership as (

--- a/warehouse/dbt/models/staging/npm/stg_npm__manifests.sql
+++ b/warehouse/dbt/models/staging/npm/stg_npm__manifests.sql
@@ -1,13 +1,12 @@
 {% set columns = [
-    "name", "version", "description", "keywords", "homepage", "bugs", 
-    "license", "author", "contributors", "funding", "files", "exports", 
-    "main", "browser", "bin", "man", "directories", "repository", 
-    "scripts", "config", "dependencies", "dev_dependencies", 
-    "peer_dependencies", "peer_dependencies_meta", "bundle_dependencies", 
-    "optional_dependencies", "overrides", "engines", "os", "cpu", 
-    "dev_engines", "private", "publish_config", "workspaces", "bugs__url", 
-    "repository__url", "repository__type",  "author__url", "author__name",
-    "author__email"
+  "name", "version", "description", "keywords", "homepage", "bugs", 
+  "license", "author", "contributors", "funding", "files", "exports", 
+  "main", "browser", "bin", "man", "directories", "repository", 
+  "scripts", "config", "dependencies", "dev_dependencies", 
+  "peer_dependencies", "peer_dependencies_meta", "bundle_dependencies", 
+  "optional_dependencies", "overrides", "engines", "os", "cpu", 
+  "dev_engines", "private", "publish_config", "workspaces", 
+  "_dlt_load_id", "_dlt_id"
 ] %}
 
 with source as (


### PR DESCRIPTION
The npm `manifest` fields previously had multiple formats, causing `dlt` to create multiple tables and cluttering the schema with inconsistent columns. This PR addresses the issue by flattening the `manifest` to establish a consistent structure. Additionally, it updates the downstream dbt models to align with the new schema. 