### PR TITLE
fix: update `parse_npm_git_url` macro for improved URL parsing

### DIFF
--- a/warehouse/dbt/macros/models/parse_npm_git_url.sql
+++ b/warehouse/dbt/macros/models/parse_npm_git_url.sql
@@ -1,49 +1,69 @@
 {% macro parse_npm_git_url(key, source) %}
 
-  select
-    *,
+  with parsed_data as (
+    select
+      *,
 
-    case
-      when regexp_contains({{ key }}, r'^git\+ssh://') then 
-        regexp_replace({{ key }}, r'^git\+ssh://([^@]+)@', 'https://')
-      when regexp_contains({{ key }}, r'^git@') then 
-        regexp_replace({{ key }}, r'^git@(.*?):', 'https://\\1/')
-      when regexp_contains({{ key }}, r'^git\+https://') then 
-        regexp_replace({{ key }}, r'^git\+', '')
-      when regexp_contains({{ key }}, r'^https?://') then 
-        {{ key }}
-      when regexp_contains({{ key }}, r'^[^:/]+\.[^:/]+/') then 
-        concat('https://', {{ key }})
-      else null
-    end as remote_url,
-
-    regexp_extract(
       case
-        when regexp_contains({{ key }}, r'\.git$') then 
-          regexp_replace({{ key }}, r'\.git$', '')
-        else {{ key }}
-      end,
-      r'/([^/]+)$'
-    ) as remote_name,
-
-    regexp_extract(
-      case
+        when regexp_contains({{ key }}, r'#') then 
+          regexp_replace({{ key }}, r'#.*$', '')
+        when regexp_contains({{ key }}, r'^git\+ssh://') then 
+          regexp_replace({{ key }}, r'^git\+ssh://([^@]+)@', 'https://')
         when regexp_contains({{ key }}, r'^git@') then 
           regexp_replace({{ key }}, r'^git@(.*?):', 'https://\\1/')
-        when regexp_contains({{ key }}, r'^git\+ssh://') then 
-          regexp_replace({{ key }}, r'^git\+ssh://', 'https://')
-        else {{ key }}
-      end,
-      r'https?:\/\/[^\/]+\/([^\/]+)\/[^\/]+$'
-    ) as remote_namespace,
+        when regexp_contains({{ key }}, r'^git\+https://') then 
+          regexp_replace({{ key }}, r'^git\+', '')
+        when regexp_contains({{ key }}, r'^https?://') then 
+          {{ key }}
+        when regexp_contains({{ key }}, r'^[^:/]+\.[^:/]+/') then 
+          concat('https://', {{ key }})
+        else null
+      end as remote_url,
 
-    case
-      when regexp_contains({{ key }}, r'github\.com') then 'GITHUB'
-      when regexp_contains({{ key }}, r'gitlab\.com') then 'GITLAB'
-      when regexp_contains({{ key }}, r'bitbucket\.org') then 'BITBUCKET'
-      else 'OTHER'
-    end as remote_source_id
+      regexp_extract(
+        case
+          when regexp_contains({{ key }}, r'#') then 
+            regexp_replace({{ key }}, r'#.*$', '')
+          when regexp_contains({{ key }}, r'\.git$') then 
+            regexp_replace({{ key }}, r'\.git$', '')
+          else {{ key }}
+        end,
+        r'/([^/]+)(?:\.git)?$'
+      ) as remote_name,
 
-  from {{ source }}
+      regexp_extract(
+        case
+          when regexp_contains({{ key }}, r'#') then 
+            regexp_replace({{ key }}, r'#.*$', '')
+          when regexp_contains({{ key }}, r'^git@') then 
+            regexp_replace({{ key }}, r'^git@(.*?):', 'https://\\1/')
+          when regexp_contains({{ key }}, r'^git\+ssh://') then 
+            regexp_replace({{ key }}, r'^git\+ssh://', 'https://')
+          else {{ key }}
+        end,
+        r'https?:\/\/[^\/]+\/([^\/]+)\/[^\/]+'
+      ) as remote_namespace,
+
+      case
+        when regexp_contains({{ key }}, r'github\.com') then 'GITHUB'
+        when regexp_contains({{ key }}, r'gitlab\.com') then 'GITLAB'
+        when regexp_contains({{ key }}, r'bitbucket\.org') then 'BITBUCKET'
+        else 'OTHER'
+      end as remote_source_id
+
+    from {{ source }}
+  ),
+
+  final_data as (
+    select
+      * except(remote_url),
+      case
+        when regexp_contains(remote_url, r'\.git$') then remote_url
+        else concat(remote_url, '.git')
+      end as remote_url
+    from parsed_data
+  )
+
+  select * from final_data
 
 {% endmacro %}


### PR DESCRIPTION
This PR addresses edge cases found when extracting information from `npm` Git URLs to ensure consistency.

- Git URLs that include a `#revision` at the end.  
- Git URLs containing `/blob/...` or `/tree/...` instead of the absolute URL.  
- Git URLs that omit the `.git` suffix.  

These cases have been handled to standardize URL processing across the board.  
