### PR TITLE
fix: filter intermediate dependency events by `artifacts_v1`

### DIFF
--- a/warehouse/dbt/models/intermediate/events/int_events__dependencies.sql
+++ b/warehouse/dbt/models/intermediate/events/int_events__dependencies.sql
@@ -19,7 +19,7 @@ with snapshots as (
 
 artifacts as (
   select artifact_name
-  from {{ ref('artifacts_v1') }}
+  from {{ ref('int_all_artifacts') }}
   where artifact_source = "NPM"
 ),
 


### PR DESCRIPTION
This PR closes #2521 by only tracking events for dependencies present in `artifacts_v1`.