### PR TITLE
Fix timeseries_events_aux_issues_by_artifact_v0.sql to include `comments` column

### DIFF
--- a/warehouse/dbt/models/marts/events/timeseries_events_aux_issues_by_artifact_v0.sql
+++ b/warehouse/dbt/models/marts/events/timeseries_events_aux_issues_by_artifact_v0.sql
@@ -16,5 +16,6 @@ select
   issue_number,
   created_at,
   merged_at,
-  closed_at
+  closed_at,
+  comments
 from {{ ref('int_events_aux_issues') }}


### PR DESCRIPTION
Adds the comments column (apologies I missed this)