### PR TITLE
add: timeseries `funding_received` sqlmesh model

### DIFF
--- a/warehouse/metrics_mesh/models/metrics_factories.py
+++ b/warehouse/metrics_mesh/models/metrics_factories.py
@@ -278,6 +278,15 @@ timeseries_metrics(
         #     ),
         #     entity_types=["artifact"],
         # ),
+        "funding_received": MetricQueryDef(
+            ref="funding_received.sql",
+            rolling=RollingConfig(
+                windows=[180],
+                unit="day",
+                cron="@daily",
+            ),
+            entity_types=["artifact", "project", "collection"],
+        ),
     },
     default_dialect="clickhouse",
 )

--- a/warehouse/metrics_mesh/oso_metrics/funding_received.sql
+++ b/warehouse/metrics_mesh/oso_metrics/funding_received.sql
@@ -1,0 +1,14 @@
+select @metrics_sample_date(events.bucket_day) as metrics_sample_date,
+  events.event_source,
+  events.to_artifact_id,
+  '' as from_artifact_id,
+  @metric_name() as metric,
+  SUM(events.amount) as amount
+from metrics.events_daily_to_artifact as events
+where event_type = 'CREDIT'
+  and events.bucket_day BETWEEN @metrics_start('DATE') AND @metrics_end('DATE')
+group by 1,
+  metric,
+  from_artifact_id,
+  to_artifact_id,
+  event_source


### PR DESCRIPTION
This PR closes #2286 by creating a time series model for the funding received over the last `180` days.

> [!NOTE]
> Data is incomplete since it's playground data, so the plot may not be 100% accurate.

We can create visualizations such as the following:

![image](https://github.com/user-attachments/assets/ab29e511-524a-45ed-b532-506bcc826483)

