### PR TITLE
Refactor trino and mcs into dagster resources 

### DIFF
--- a/warehouse/oso_dagster/assets/sqlmesh.py
+++ b/warehouse/oso_dagster/assets/sqlmesh.py
@@ -45,7 +45,7 @@ def sqlmesh_factory(sqlmesh_infra_config: dict, sqlmesh_config: SQLMeshContextCo
         # Ensure that both trino and the mcs are available
         async with multiple_async_contexts(
             trino=trino.ensure_available(log_override=context.log),
-            mcs=mcs.ensure_available(),
+            mcs=mcs.ensure_available(log_override=context.log),
         ):
             for result in sqlmesh.run(
                 context, environment=environment, plan_options={"skip_tests": True}

--- a/warehouse/oso_dagster/resources/__init__.py
+++ b/warehouse/oso_dagster/resources/__init__.py
@@ -4,3 +4,6 @@ from .bq_dts import *
 from .clickhouse import *
 from .dlt import *
 from .io_manager import *
+from .kube import *
+from .mcs import *
+from .trino import *

--- a/warehouse/oso_dagster/resources/clickhouse.py
+++ b/warehouse/oso_dagster/resources/clickhouse.py
@@ -1,13 +1,11 @@
-import clickhouse_connect
 from contextlib import contextmanager
-from dagster import (
-    ConfigurableResource,
-    resource,
-    ResourceDependency,
-)
+
+import clickhouse_connect
+from dagster import ConfigurableResource, ResourceDependency
 from pydantic import Field
+
+from ..utils import SecretReference, SecretResolver
 from ..utils.common import ensure
-from ..utils import SecretResolver, SecretReference
 
 """
 Note: This code is predominantly copied from the BigQueryResource
@@ -73,14 +71,4 @@ class ClickhouseResource(ConfigurableResource):
         client = clickhouse_connect.get_client(
             host=host, username=username, password=password, secure=True
         )
-        yield client
-
-
-@resource(
-    config_schema=ClickhouseResource.to_config_schema(),
-    description="Dagster resource for connecting to Clickhouse.",
-)
-def clickhouse_resource(context):
-    clickhouse_resource = ClickhouseResource.from_resource_context(context)
-    with clickhouse_resource.get_client() as client:
         yield client

--- a/warehouse/oso_dagster/resources/kube.py
+++ b/warehouse/oso_dagster/resources/kube.py
@@ -1,0 +1,139 @@
+"""
+Kubernetes resource for Dagster.
+
+This can be used to ensure deployments are up and running for the assets that
+might need certain kubernetes resources.
+"""
+
+import inspect
+import logging
+import os
+import typing as t
+from contextlib import asynccontextmanager
+
+from dagster import ConfigurableResource, ResourceDependency
+from kr8s.objects import Deployment, Service
+from pydantic import Field
+
+from ..utils import SecretResolver
+
+logger = logging.getLogger(__name__)
+
+
+class K8sResource(ConfigurableResource):
+    """Resource for interacting with kubernetes. This is more of a convenience
+    utility. However, we encapsulate interactions with k8s resources here to
+    make it easier to mock any k8s interactions in dagster assets if necessary.
+    """
+
+    secrets: ResourceDependency[SecretResolver]
+
+    secret_group_name: str
+
+    service_name: str = Field(
+        default="trino",
+        description="Trino service name",
+    )
+
+    deployment_name: str = Field(
+        default="trino",
+        description="Trino deployment name",
+    )
+
+    port: int = Field(
+        default=8080,
+        description="Trino port",
+    )
+
+    namespace: str = Field(
+        default="default",
+        description="Trino k8s namespace",
+    )
+
+    @asynccontextmanager
+    async def deployment_context(
+        self,
+        name: str,
+        namespace: str,
+        min_replicas: int = 1,
+        log_override: t.Optional[logging.Logger] = None,
+        always_scale_down: bool = False,
+    ):
+        """Ensures a deployment is running with at least `min_replicas` replicas."""
+
+        starting_replicas, _ = await self.ensure_deployment_scale_up(
+            name,
+            namespace,
+            min_replicas,
+        )
+
+        try:
+            yield
+        finally:
+            if always_scale_down:
+                await self.ensure_deployment_scale_down(
+                    name,
+                    namespace,
+                    0,
+                    log_override=log_override,
+                )
+            else:
+                await self.ensure_deployment_scale_down(
+                    name,
+                    namespace,
+                    starting_replicas,
+                    log_override=log_override,
+                )
+
+    async def ensure_deployment_scale_up(
+        self,
+        name: str,
+        namespace: str,
+        min_replicas: int = 1,
+        log_override: t.Optional[logging.Logger] = None,
+    ):
+        """Ensures a deployment is running with at least `min_replicas` replicas."""
+        log = log_override or logger
+        deployment = await Deployment.get(name=name, namespace=namespace)
+
+        starting_replicas = deployment.replicas
+
+        if starting_replicas < min_replicas:
+            log.info(f"Scaling up {name} in {namespace}")
+            result = deployment.scale(min_replicas)
+            if inspect.isawaitable(result):
+                await result
+        return (starting_replicas, deployment.replicas)
+
+    async def ensure_deployment_scale_down(
+        self,
+        name: str,
+        namespace: str,
+        max_replicas: int = 0,
+        log_override: t.Optional[logging.Logger] = None,
+    ):
+        """Ensures a deployment is running with at least `min_replicas` replicas."""
+        log = log_override or logger
+        deployment = await Deployment.get(name=name, namespace=namespace)
+
+        starting_replicas = deployment.replicas
+
+        if starting_replicas > max_replicas:
+            log.info(f"Scaling down {name} in {namespace}")
+            result = deployment.scale(max_replicas)
+            if inspect.isawaitable(result):
+                await result
+        return (starting_replicas, deployment.replicas)
+
+    async def get_service_connection(self, name: str, namespace: str, port_name: str):
+        """Returns the host:port url to the service."""
+
+        if not os.environ.get("KUBERNETES_SERVICE_HOST"):
+            raise Exception("Not running in a k8s cluster")
+
+        service = await Service.get(name=name, namespace=namespace)
+        ports = t.cast(t.List[dict], service.spec.ports)
+        ports_lookup = {port["name"]: port["port"] for port in ports}
+        return f"{service.name}.{service.namespace}.svc.cluster.local", int(
+            ports_lookup[port_name]
+        )

--- a/warehouse/oso_dagster/resources/mcs.py
+++ b/warehouse/oso_dagster/resources/mcs.py
@@ -28,7 +28,7 @@ class MCSResource(ConfigurableResource):
     """Metrics calculation service resource"""
 
     @asynccontextmanager
-    def ensure_available(self):
+    def ensure_available(self, log_override: t.Optional[logging.Logger] = None):
         """Ensure the MCS is available"""
         raise NotImplementedError(
             "ensure_available not implemented on the base MCSResource"
@@ -89,6 +89,7 @@ class MCSRemoteResource(MCSResource):
     """Resource for interacting with a remote MCS"""
 
     base_url: str = Field(
+        default="http://localhost:8080",
         description="URL for the remote MCS",
     )
 

--- a/warehouse/oso_dagster/resources/mcs.py
+++ b/warehouse/oso_dagster/resources/mcs.py
@@ -1,0 +1,104 @@
+"""
+Metrics Calculation Service (MCS) resource for Dagster.
+
+This resource is used to interact with the Metrics Calculation Service (MCS)
+that is used with sqlmesh to compute metrics.
+
+Two implementations are provided:
+
+- MCSK8sResource: interacts with an MCS deployed on Kubernetes
+- MCSRemoteResource: interacts with an MCS deployed independently from dagster
+  (intended for testing)
+"""
+
+import logging
+import typing as t
+from contextlib import asynccontextmanager
+
+from dagster import ConfigurableResource, ResourceDependency
+from pydantic import Field
+
+from ..utils.http import wait_for_ok_async
+from .kube import K8sResource
+
+logger = logging.getLogger(__name__)
+
+
+class MCSResource(ConfigurableResource):
+    """Metrics calculation service resource"""
+
+    @asynccontextmanager
+    def ensure_available(self):
+        """Ensure the MCS is available"""
+        raise NotImplementedError(
+            "ensure_available not implemented on the base MCSResource"
+        )
+
+
+class MCSK8sResource(MCSResource):
+    k8s: ResourceDependency[K8sResource]
+
+    service_name: str = Field(
+        default="mcs",
+        description="MCS service name",
+    )
+
+    service_port_name: str = Field(
+        default="http",
+        description="Trino service port",
+    )
+
+    deployment_name: str = Field(
+        default="mcs",
+        description="MCS deployment name",
+    )
+
+    namespace: str = Field(
+        default="default",
+        description="MCS namespace",
+    )
+
+    connect_timeout: int = Field(
+        default=240,
+        description="Timeout in seconds for waiting for the service to be online",
+    )
+
+    @asynccontextmanager
+    async def ensure_available(self, log_override: t.Optional[logging.Logger] = None):
+        """Ensures that the mcs is deployed and available"""
+        async with self.k8s.deployment_context(
+            name=self.deployment_name,
+            namespace=self.namespace,
+            min_replicas=1,
+            log_override=log_override,
+        ):
+            # Check that the service is online
+            host, port = await self.k8s.get_service_connection(
+                self.service_name, self.namespace, self.service_port_name
+            )
+
+            # Wait for the status endpoint to return 200
+            await wait_for_ok_async(
+                f"http://{host}:{port}/status", timeout=self.connect_timeout
+            )
+
+            yield
+
+
+class MCSRemoteResource(MCSResource):
+    """Resource for interacting with a remote MCS"""
+
+    base_url: str = Field(
+        description="URL for the remote MCS",
+    )
+
+    connect_timeout: int = Field(
+        default=240,
+        description="Timeout in seconds for waiting for the service to be online",
+    )
+
+    @asynccontextmanager
+    async def ensure_available(self, log_override: t.Optional[logging.Logger] = None):
+        """Ensures that the remote mcs is available"""
+        await wait_for_ok_async(f"{self.url}/status", timeout=self.connect_timeout)
+        yield

--- a/warehouse/oso_dagster/resources/trino.py
+++ b/warehouse/oso_dagster/resources/trino.py
@@ -1,0 +1,174 @@
+import logging
+import typing as t
+from contextlib import asynccontextmanager
+
+import trino
+from dagster import ConfigurableResource, ResourceDependency
+from pydantic import Field
+
+from ..utils import SecretResolver
+from ..utils.asynctools import multiple_async_contexts
+from ..utils.http import wait_for_ok_async
+from .kube import K8sResource
+
+module_logger = logging.getLogger(__name__)
+
+
+class TrinoResource(ConfigurableResource):
+    """Base Trino resource"""
+
+    secrets: ResourceDependency[SecretResolver]
+
+    secret_group_name: str
+
+    user: str = Field(  # noqa: F811
+        default="dagster",
+        description="Trino user",
+    )
+
+    def get_client(self):
+        raise NotImplementedError(
+            "get_client not implemented on the base TrinoResource"
+        )
+
+    @asynccontextmanager
+    def async_get_client(self, log_override: t.Optional[logging.Logger] = None):
+        raise NotImplementedError(
+            "get_client not implemented on the base TrinoResource"
+        )
+
+    @asynccontextmanager
+    def ensure_available(self, log_override: t.Optional[logging.Logger] = None):
+        raise NotImplementedError(
+            "ensure_available not implemented on the base TrinoResource"
+        )
+
+
+class TrinoK8sResource(TrinoResource):
+    """Resource for interacting with Trino deployed on kubernetes. By default
+    trino isn't running. The `get_client` context manager on this resource will
+    start trino and stop it when the context manager exits.
+
+    Examples:
+
+        To use as a synchronous context:
+        .. code-block:: python
+
+            @asset
+            def tables(trino: TrinoResource):
+                with trino.get_client() as client:
+                    client.query(...)
+
+            defs = Definitions(
+                assets=[tables], resources={
+                    "trino": ClickhouseResource()
+                }
+            )
+
+        To use as an asynchronous context (this is useful if you have multiple async contexts to use):
+
+        .. code-block:: python
+
+            @asset
+            async def tables(trino: TrinoResource):
+                async with trino.async_get_client() as client:
+                    # Do something with the client (the client is synchronous)
+                    client.query(...)
+
+            defs = Definitions(
+                assets=[tables], resources={
+                    "trino": ClickhouseResource()
+                }
+            )
+
+    """
+
+    k8s: ResourceDependency[K8sResource]
+
+    service_name: str = Field(
+        default="trino",
+        description="Trino service name",
+    )
+
+    service_port_name: str = Field(
+        default="http",
+        description="Trino service port",
+    )
+
+    coordinator_deployment_name: str = Field(
+        default="trino-coordinator",
+        description="Trino deployment name",
+    )
+
+    worker_deployment_name: str = Field(
+        default="trino-worker",
+        description="Trino worker deployment name",
+    )
+
+    namespace: str = Field(
+        default="default",
+        description="Trino k8s namespace",
+    )
+
+    catalog: str = Field(
+        default="hive",
+        description="Trino catalog",
+    )
+
+    connection_schema: str = Field(
+        default="default",
+        description="Trino schema",
+    )
+
+    @asynccontextmanager
+    async def get_client(self, log_override: t.Optional[logging.Logger] = None):
+        logger = log_override or module_logger
+        # Bring both the coordinator and worker online if they aren't already
+
+        async with self.ensure_available(log_override=log_override):
+            # Wait for the status endpoint to return 200
+            host, port = await self.k8s.get_service_connection(
+                self.service_name, self.namespace, self.service_port_name
+            )
+            logger.info(f"Wait for trino to be online at http://{host}:{port}/")
+
+            await wait_for_ok_async(
+                f"http://{host}:{port}/", timeout=self.deploy_timeout
+            )
+            yield trino.dbapi.connect(
+                host=host,
+                port=port,
+                user=self.user,
+                catalog=self.catalog,
+                schema=self.connection_schema,
+            )
+
+    @asynccontextmanager
+    async def ensure_available(self, log_override: t.Optional[logging.Logger] = None):
+        """Ensures that the trino is deployed and available"""
+        logger = log_override or module_logger
+        async with multiple_async_contexts(
+            coordinator=self.k8s.deployment_context(
+                name=self.coordinator_deployment_name,
+                namespace=self.namespace,
+                min_replicas=1,
+                log_override=log_override,
+            ),
+            worker=self.k8s.deployment_context(
+                name=self.worker_deployment_name,
+                namespace=self.namespace,
+                min_replicas=1,
+                log_override=log_override,
+            ),
+        ):
+            # Check that the service is online
+            host, port = await self.k8s.get_service_connection(
+                self.service_name, self.namespace, self.service_port_name
+            )
+            url = f"http://{host}:{port}/"
+
+            logger.info(f"Wait for trino to be online at {url}")
+            # Wait for the status endpoint to return 200
+            await wait_for_ok_async(url, timeout=self.connect_timeout)
+
+            yield

--- a/warehouse/oso_dagster/utils/asynctools.py
+++ b/warehouse/oso_dagster/utils/asynctools.py
@@ -1,5 +1,6 @@
 import asyncio
 import typing as t
+from contextlib import asynccontextmanager
 
 
 def safe_async_run[T](coro: t.Coroutine[t.Any, t.Any, T]) -> T:
@@ -11,3 +12,54 @@ def safe_async_run[T](coro: t.Coroutine[t.Any, t.Any, T]) -> T:
     if loop is None:
         return asyncio.run(coro)
     return loop.run_until_complete(coro)
+
+
+@asynccontextmanager
+async def multiple_async_contexts(
+    **context_managers: t.AsyncContextManager[t.Any],
+) -> t.AsyncGenerator[t.Dict[str, t.Any], t.Any]:
+    """Runs multiple async context managers in parallel
+
+    This ensures that all context managers are entered and yields everything in
+    a single dictionary of all the context vars. The dictionary's keys are the
+    names passed into the keyword arguments of this function
+
+    Example:
+
+        .. code-block:: python::
+
+            async with multiple_async_contexts(
+                a=asynccontextmanager_a(),
+                b=asynccontextmanager_b(),
+            ) as context:
+                context_for_a = context["a"]
+                context_for_b = context["b"]
+
+    """
+
+    assert context_managers, "At least one context manager must be provided"
+
+    async def enter(name: str, cm: t.AsyncContextManager[t.Any]) -> t.Any:
+        context = await cm.__aenter__()
+        print("WAT THE HELL")
+        return (name, context)
+
+    context_entrances: t.List[t.Awaitable[t.Any]] = [
+        enter(name, cm) for name, cm in context_managers.items()
+    ]
+    results = await asyncio.gather(*context_entrances)
+    context_dict = {name: context for name, context in results}
+    try:
+        yield context_dict
+    except Exception as e:
+        context_exits = [
+            cm.__aexit__(type(e), e, e.__traceback__)
+            for cm in context_managers.values()
+        ]
+        await asyncio.gather(*context_exits)
+        raise e
+    else:
+        context_exits = [
+            cm.__aexit__(None, None, None) for cm in context_managers.values()
+        ]
+        await asyncio.gather(*context_exits)

--- a/warehouse/oso_dagster/utils/http.py
+++ b/warehouse/oso_dagster/utils/http.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 import time
 from pathlib import Path
@@ -5,6 +6,7 @@ from typing import Type, cast
 from urllib.parse import ParseResult, parse_qsl, urlparse
 
 import hishel
+import httpx
 import requests
 from redis import Redis
 
@@ -77,4 +79,17 @@ def wait_for_ok(url: str, timeout: int = 60):
             return
         except requests.exceptions.RequestException:
             time.sleep(1)
-    raise Exception(f"Failed to connect to {url} after {timeout} seconds")
+    raise TimeoutError(f"Failed to connect to {url} after {timeout} seconds")
+
+
+async def wait_for_ok_async(url: str, timeout: int = 60):
+    start = time.time()
+    async with httpx.AsyncClient() as client:
+        while time.time() - start < timeout:
+            try:
+                response = await client.get(url)
+                response.raise_for_status()
+                return
+            except httpx.RequestError:
+                await asyncio.sleep(1)
+    raise TimeoutError(f"Failed to connect to {url} after {timeout} seconds")

--- a/warehouse/oso_dagster/utils/test_asynctools.py
+++ b/warehouse/oso_dagster/utils/test_asynctools.py
@@ -1,0 +1,19 @@
+from contextlib import asynccontextmanager
+
+import pytest
+from oso_dagster.utils.asynctools import multiple_async_contexts
+
+
+@asynccontextmanager
+async def fake_context_manager(ret_val: str):
+    yield ret_val
+
+
+@pytest.mark.asyncio
+async def test_multiple_async_contexts():
+    async with multiple_async_contexts(
+        t1=fake_context_manager("t1"),
+        t2=fake_context_manager("t2"),
+    ) as context_vars:
+        assert context_vars["t1"] == "t1"
+        assert context_vars["t2"] == "t2"


### PR DESCRIPTION
Part of #2479 

Did some refactoring because we actually need to share some resources like trino among a couple different assets. Technically if two things shared the trino resource at once this would actually cause a problem but we should solve that at a later time with something like resource reservations using some kind of kubernetes operator that tracks resource reservations for given deployments (this way we can keep costs low by only turning on these services when necessary). 