### PR TITLE
Use the correct trino health check endpoint

### DIFF
--- a/warehouse/oso_dagster/definitions.py
+++ b/warehouse/oso_dagster/definitions.py
@@ -97,7 +97,7 @@ def load_definitions():
         ),
     ]
 
-    # If we aren't running in k8s, we need to a dummy k8s resource that will
+    # If we aren't running in k8s, we need to use a dummy k8s resource that will
     # error if we attempt to use it
     if not global_config.enable_k8s:
         logger.info("Loading fake k8s resources")

--- a/warehouse/oso_dagster/resources/trino.py
+++ b/warehouse/oso_dagster/resources/trino.py
@@ -18,7 +18,9 @@ class TrinoResource(ConfigurableResource):
     """Base Trino resource"""
 
     @asynccontextmanager
-    def get_client(self, log_override: t.Optional[logging.Logger] = None) -> t.AsyncGenerator[Connection, None]:
+    def get_client(
+        self, log_override: t.Optional[logging.Logger] = None
+    ) -> t.AsyncGenerator[Connection, None]:
         raise NotImplementedError(
             "get_client not implemented on the base TrinoResource"
         )
@@ -105,7 +107,7 @@ class TrinoK8sResource(TrinoResource):
         default="default",
         description="Trino schema",
     )
-    
+
     connect_timeout: int = Field(
         default=240,
         description="Timeout in seconds for waiting for the service to be online",
@@ -156,7 +158,7 @@ class TrinoK8sResource(TrinoResource):
             host, port = await self.k8s.get_service_connection(
                 self.service_name, self.namespace, self.service_port_name
             )
-            url = f"http://{host}:{port}/"
+            url = f"http://{host}:{port}/v1/status"
 
             logger.info(f"Wait for trino to be online at {url}")
             # Wait for the status endpoint to return 200

--- a/warehouse/oso_dagster/resources/trino.py
+++ b/warehouse/oso_dagster/resources/trino.py
@@ -158,11 +158,12 @@ class TrinoK8sResource(TrinoResource):
             host, port = await self.k8s.get_service_connection(
                 self.service_name, self.namespace, self.service_port_name
             )
-            url = f"http://{host}:{port}/v1/status"
+            # see: https://github.com/trinodb/trino/issues/14663
+            health_check_url = f"http://{host}:{port}/v1/status"
 
-            logger.info(f"Wait for trino to be online at {url}")
+            logger.info(f"Wait for trino to be online at {health_check_url}")
             # Wait for the status endpoint to return 200
-            await wait_for_ok_async(url, timeout=self.connect_timeout)
+            await wait_for_ok_async(health_check_url, timeout=self.connect_timeout)
 
             yield
 
@@ -194,6 +195,7 @@ class TrinoRemoteResource(TrinoResource):
         logger = log_override or module_logger
 
         logger.info("Wait for trino to be online")
-        await wait_for_ok_async(self.url, timeout=self.connect_timeout)
+        health_check_url = f"{self.url}/v1/status"
+        await wait_for_ok_async(health_check_url, timeout=self.connect_timeout)
 
         yield


### PR DESCRIPTION
We were previously using the root of the server but that was never actually a known good endpoint. I got this from here: https://github.com/trinodb/trino/issues/14663