### PR TITLE
Fix trino resource

### DIFF
--- a/warehouse/oso_dagster/resources/trino.py
+++ b/warehouse/oso_dagster/resources/trino.py
@@ -115,18 +115,11 @@ class TrinoK8sResource(TrinoResource):
 
     @asynccontextmanager
     async def get_client(self, log_override: t.Optional[logging.Logger] = None):
-        logger = log_override or module_logger
         # Bring both the coordinator and worker online if they aren't already
-
         async with self.ensure_available(log_override=log_override):
             # Wait for the status endpoint to return 200
             host, port = await self.k8s.get_service_connection(
                 self.service_name, self.namespace, self.service_port_name
-            )
-            logger.info(f"Wait for trino to be online at http://{host}:{port}/")
-
-            await wait_for_ok_async(
-                f"http://{host}:{port}/", timeout=self.deploy_timeout
             )
             yield trino.dbapi.connect(
                 host=host,

--- a/warehouse/oso_dagster/resources/trino.py
+++ b/warehouse/oso_dagster/resources/trino.py
@@ -171,11 +171,7 @@ class TrinoRemoteResource(TrinoResource):
 
     @asynccontextmanager
     async def get_client(self, log_override: t.Optional[logging.Logger] = None):
-        logger = log_override or module_logger
         async with self.ensure_available(log_override=log_override):
-            await wait_for_ok_async(self.url, timeout=self.connect_timeout)
-
-            logger.info("Connecting to trino")
             yield trino.dbapi.connect(
                 host=self.url,
                 user=self.user,


### PR DESCRIPTION
Frustratingly, the dagster objects for resources have no type checking for their attributes so I missed this purely out of missing it from a previous refactor. This is hopefully it but the only way to test is on production at the moment. 