### PR TITLE
Adds metrics_tools and oso_dagster loggers to dagster logs on the UI

### DIFF
--- a/ops/k8s-apps/base/dagster/dagster.yaml
+++ b/ops/k8s-apps/base/dagster/dagster.yaml
@@ -34,6 +34,10 @@ spec:
       # log
       pythonLogs:
         pythonLogLevel: "INFO"
+        # Include internal python libraries in the dagster logs.
+        managedPythonLoggers:
+          - metrics_tools
+          - oso_dagster
       nameOverride: "dagster"
       ingress:
         enabled: true


### PR DESCRIPTION
@Jabolol I think this should resolve the issue for logging. If the docs are correct for the dagster helm chart this will mean our internal modules are now being logged. 