### PR TITLE
Fix the unix timestamp macro for trino

### DIFF
--- a/warehouse/metrics_mesh/macros/to_unix_timestamp.py
+++ b/warehouse/metrics_mesh/macros/to_unix_timestamp.py
@@ -22,6 +22,15 @@ def str_to_unix_timestamp(
                 ),
             )
         )
+    if evaluator.engine_adapter.dialect == "trino":
+        return exp.Anonymous(
+            this="to_unixtime",
+            expressions=[
+                exp.StrToTime(
+                    this=time_exp, format=exp.Literal(this="%Y-%m-%d", is_string=True)
+                )
+            ],
+        )
     return exp.Anonymous(
         this="toUnixTimestamp",
         expressions=[time_exp],


### PR DESCRIPTION
One of the main reasons we need a local trino. Turns out some things we're assuming would work are not working. This should _in theory_ fix the issue with this macro. It doesn't yet fix one of the other issues on the python model for openrank. Looking at that next. 