### PR TITLE
More key metrics fixes

### DIFF
--- a/warehouse/metrics_mesh/macros/to_unix_timestamp.py
+++ b/warehouse/metrics_mesh/macros/to_unix_timestamp.py
@@ -35,3 +35,22 @@ def str_to_unix_timestamp(
         this="toUnixTimestamp",
         expressions=[time_exp],
     )
+
+
+def to_unix_timestamp(
+    evaluator: MacroEvaluator,
+    time_exp: exp.Expression,
+):
+    from sqlmesh.core.dialect import parse_one
+
+    if evaluator.runtime_stage in ["loading", "creating"]:
+        return parse_one("1::double", dialect="trino")
+
+    if evaluator.engine_adapter.dialect == "duckdb":
+        return exp.TimeToUnix(this=time_exp)
+    if evaluator.engine_adapter.dialect == "trino":
+        return exp.Anonymous(this="to_unixtime", expressions=[time_exp])
+    return exp.Anonymous(
+        this="toUnixTimestamp",
+        expressions=[time_exp],
+    )

--- a/warehouse/metrics_mesh/models/metrics_factories.py
+++ b/warehouse/metrics_mesh/models/metrics_factories.py
@@ -296,19 +296,19 @@ timeseries_metrics(
         ),
         "key_active_address_count": MetricQueryDef(
             ref="key_active_address_count.sql",
-            entity_types=["artifact"],
+            entity_types=["artifact", "project", "collection"],
         ),
         "key_active_contract_count": MetricQueryDef(
             ref="key_active_contract_count.sql",
-            entity_types=["artifact"],
+            entity_types=["artifact", "project", "collection"],
         ),
         "key_active_developer_count": MetricQueryDef(
             ref="key_active_developer_count.sql",
-            entity_types=["artifact"],
+            entity_types=["artifact", "project", "collection"],
         ),
         "key_comment_count": MetricQueryDef(
             ref="key_comment_count.sql",
-            entity_types=["artifact"],
+            entity_types=["artifact", "project", "collection"],
         ),
         "key_commit_count": MetricQueryDef(
             ref="key_commit_count.sql",

--- a/warehouse/metrics_mesh/oso_metrics/key_active_address_count.sql
+++ b/warehouse/metrics_mesh/oso_metrics/key_active_address_count.sql
@@ -1,12 +1,9 @@
 select distinct
   now() as metrics_sample_date,
   events.event_source,
-  @metrics_entity_type_col(
-    'to_{entity_type}_id',
-    table_alias := events,
-  ),
+  events.to_artifact_id,
   '' as from_artifact_id,
-  'ACTIVE_ADDRESSES' as metric,
+  @metric_name('active_addresses') as metric,
   count(distinct events.from_artifact_id) as amount
 from metrics.events_daily_to_artifact as events
 where event_type = 'CONTRACT_INVOCATION_SUCCESS_DAILY_COUNT'

--- a/warehouse/metrics_mesh/oso_metrics/key_active_contract_count.sql
+++ b/warehouse/metrics_mesh/oso_metrics/key_active_contract_count.sql
@@ -1,12 +1,9 @@
 select distinct
   now() as metrics_sample_date,
   events.event_source,
-  @metrics_entity_type_col(
-    'to_{entity_type}_id',
-    table_alias := events,
-  ),
+  events.to_artifact_id,
   '' as from_artifact_id,
-  'ACTIVE_CONTRACTS' as metric,
+  @metric_name('active_contracts') as metric,
   count(distinct events.to_artifact_id) as amount
 from metrics.events_daily_to_artifact as events
 where events.event_type = 'CONTRACT_INVOCATION_SUCCESS_DAILY_COUNT'

--- a/warehouse/metrics_mesh/oso_metrics/key_active_developer_count.sql
+++ b/warehouse/metrics_mesh/oso_metrics/key_active_developer_count.sql
@@ -1,12 +1,9 @@
 select distinct
   now() as metrics_sample_date,
   events.event_source,
-  @metrics_entity_type_col(
-    'to_{entity_type}_id',
-    table_alias := events,
-  ),
+  events.to_artifact_id,
   '' as from_artifact_id,
-  'ACTIVE_DEVELOPERS' as metric,
+  @metric_name('active_developers') as metric,
   count(distinct events.from_artifact_id) as amount
 from metrics.events_daily_to_artifact as events
 where event_type = 'COMMIT_CODE'

--- a/warehouse/metrics_mesh/oso_metrics/key_comment_count.sql
+++ b/warehouse/metrics_mesh/oso_metrics/key_comment_count.sql
@@ -1,12 +1,9 @@
 select distinct
   now() as metrics_sample_date,
   events.event_source,
-  @metrics_entity_type_col(
-    'to_{entity_type}_id',
-    table_alias := events,
-  ),
+  events.to_artifact_id,
   '' as from_artifact_id,
-  'COMMENT_COUNT' as metric,
+  @metric_name('comment_count') as metric,
   count(*) as amount
 from metrics.events_daily_to_artifact as events
 where event_type in (

--- a/warehouse/metrics_mesh/oso_metrics/key_developer_active_day_count.sql
+++ b/warehouse/metrics_mesh/oso_metrics/key_developer_active_day_count.sql
@@ -1,10 +1,7 @@
 select distinct
   now() as metrics_sample_date,
   events.event_source,
-  @metrics_entity_type_col(
-    'to_{entity_type}_id',
-    table_alias := events,
-  ),
+  events.to_artifact_id as to_artifact_id,
   events.from_artifact_id as from_artifact_id,
   'DEVELOPER_ACTIVE_DAYS' as metric,
   count(distinct events.bucket_day) as amount,

--- a/warehouse/metrics_mesh/oso_metrics/key_first_commit.sql
+++ b/warehouse/metrics_mesh/oso_metrics/key_first_commit.sql
@@ -1,17 +1,10 @@
 select distinct
   now() as metrics_sample_date,
   events.event_source,
-  @metrics_entity_type_col(
-    'to_{entity_type}_id',
-    table_alias := events,
-  ),
+  events.to_artifact_id,
   '' as from_artifact_id,
-  'FIRST_COMMIT' as metric,
-  @str_to_unix_timestamp(
-    split_part(
-      cast(min(bucket_day) as string), ' ', 1
-    ),
-  ) as amount
+  @metric_name('first_commit') as metric,
+  @to_unix_timestamp(min(events.bucket_day)) as amount
 from metrics.events_daily_to_artifact as events
 where event_type = 'COMMIT_CODE'
 group by 2, 3

--- a/warehouse/metrics_mesh/oso_metrics/key_last_commit.sql
+++ b/warehouse/metrics_mesh/oso_metrics/key_last_commit.sql
@@ -6,12 +6,8 @@ select distinct
     table_alias := events,
   ),
   '' as from_artifact_id,
-  'LAST_COMMIT' as metric,
-  @str_to_unix_timestamp(
-    split_part(
-      cast(max(bucket_day) as string), ' ', 1
-    )
-  ) as amount
+  @metric_name('last_commit') as metric,
+  @to_unix_timestamp(max(bucket_day)) as amount
 from metrics.events_daily_to_artifact as events
 where event_type = 'COMMIT_CODE'
 group by 2, 3

--- a/warehouse/metrics_tools/factory/factory.py
+++ b/warehouse/metrics_tools/factory/factory.py
@@ -492,10 +492,6 @@ class TimeseriesMetrics:
         columns = constants.METRICS_COLUMNS_BY_ENTITY[ref["entity_type"]]
         config = self.serializable_config(query_config)
 
-        depends_on = set()
-        for dep in dependencies:
-            depends_on.add(f"{self.catalog}.{dep}")
-
         grain = [
             "metric",
             f"to_{ref['entity_type']}_id",
@@ -520,7 +516,6 @@ class TimeseriesMetrics:
             locals=config,
             override_module_path=override_module_path,
             override_path=override_path,
-            depends_on=depends_on,
         )(generated_query)
 
     def serializable_config(self, query_config: MetricQueryConfig):

--- a/warehouse/metrics_tools/factory/proxy/proxies.py
+++ b/warehouse/metrics_tools/factory/proxy/proxies.py
@@ -3,7 +3,10 @@ from datetime import datetime
 
 import pandas as pd
 import sqlglot as sql
-from metrics_mesh.macros.to_unix_timestamp import str_to_unix_timestamp
+from metrics_mesh.macros.to_unix_timestamp import (
+    str_to_unix_timestamp,
+    to_unix_timestamp,
+)
 from metrics_tools.definition import PeerMetricDependencyRef
 from metrics_tools.factory.generated import generated_rolling_query
 from metrics_tools.factory.utils import metric_ref_evaluator_context
@@ -29,6 +32,7 @@ def generated_query(
             "@METRICS_START": metrics_start,
             "@METRICS_END": metrics_end,
             "@STR_TO_UNIX_TIMESTAMP": str_to_unix_timestamp,
+            "@TO_UNIX_TIMESTAMP": to_unix_timestamp,
         },
     ):
         result = evaluator.transform(parse_one(rendered_query_str))


### PR DESCRIPTION
@Jabolol I made some changes I was almost certain we had discussed for the original PR and I must have completely forgot to follow up on, but you can take a look at the examples here. I removed some of the use of `metrics_entity_type_col` and just use `events.to_artifact_id` and now I can use some of the automagic. 

That being said, we still definitely need some of local trino runner cause these things are hard to catch. I'll write up an issue for it.