### PR TITLE
fix: use `metric_name` macro and correct `to_artifact_id` column

### DIFF
--- a/warehouse/metrics_mesh/oso_metrics/key_active_address_count.sql
+++ b/warehouse/metrics_mesh/oso_metrics/key_active_address_count.sql
@@ -3,7 +3,7 @@ select distinct
   events.event_source,
   events.to_artifact_id,
   '' as from_artifact_id,
-  @metric_name('active_addresses') as metric,
+  @metric_name('active_address_count') as metric,
   count(distinct events.from_artifact_id) as amount
 from metrics.events_daily_to_artifact as events
 where event_type = 'CONTRACT_INVOCATION_SUCCESS_DAILY_COUNT'

--- a/warehouse/metrics_mesh/oso_metrics/key_active_contract_count.sql
+++ b/warehouse/metrics_mesh/oso_metrics/key_active_contract_count.sql
@@ -3,7 +3,7 @@ select distinct
   events.event_source,
   events.to_artifact_id,
   '' as from_artifact_id,
-  @metric_name('active_contracts') as metric,
+  @metric_name('active_contract_count') as metric,
   count(distinct events.to_artifact_id) as amount
 from metrics.events_daily_to_artifact as events
 where events.event_type = 'CONTRACT_INVOCATION_SUCCESS_DAILY_COUNT'

--- a/warehouse/metrics_mesh/oso_metrics/key_active_developer_count.sql
+++ b/warehouse/metrics_mesh/oso_metrics/key_active_developer_count.sql
@@ -3,7 +3,7 @@ select distinct
   events.event_source,
   events.to_artifact_id,
   '' as from_artifact_id,
-  @metric_name('active_developers') as metric,
+  @metric_name('active_developer_count') as metric,
   count(distinct events.from_artifact_id) as amount
 from metrics.events_daily_to_artifact as events
 where event_type = 'COMMIT_CODE'

--- a/warehouse/metrics_mesh/oso_metrics/key_commit_count.sql
+++ b/warehouse/metrics_mesh/oso_metrics/key_commit_count.sql
@@ -1,12 +1,9 @@
 select distinct
   now() as metrics_sample_date,
   events.event_source,
-  @metrics_entity_type_col(
-    'to_{entity_type}_id',
-    table_alias := events,
-  ),
+  events.to_artifact_id,
   '' as from_artifact_id,
-  'TOTAL_COMMITS' as metric,
+  @metric_name('commit_count') as metric,
   count(*) as amount
 from metrics.events_daily_to_artifact as events
 where event_type = 'COMMIT_CODE'

--- a/warehouse/metrics_mesh/oso_metrics/key_contributor_active_day_count.sql
+++ b/warehouse/metrics_mesh/oso_metrics/key_contributor_active_day_count.sql
@@ -1,12 +1,9 @@
 select distinct
   now() as metrics_sample_date,
   events.event_source,
-  @metrics_entity_type_col(
-    'to_{entity_type}_id',
-    table_alias := events,
-  ),
+  events.to_artifact_id,
   events.from_artifact_id as from_artifact_id,
-  'CONTRIBUTOR_ACTIVE_DAYS' as metric,
+  @metric_name('contributor_active_day_count') as metric,
   count(distinct events.bucket_day) as amount
 from metrics.events_daily_to_artifact as events
 where event_type in (

--- a/warehouse/metrics_mesh/oso_metrics/key_contributor_count.sql
+++ b/warehouse/metrics_mesh/oso_metrics/key_contributor_count.sql
@@ -1,12 +1,9 @@
 select distinct
   now() as metrics_sample_date,
   events.event_source,
-  @metrics_entity_type_col(
-    'to_{entity_type}_id',
-    table_alias := events,
-  ),
+  events.to_artifact_id,
   '' as from_artifact_id,
-  'CONTRIBUTOR_COUNT' as metric,
+  @metric_name('contributor_count') as metric,
   count(distinct events.from_artifact_id) as amount
 from metrics.events_daily_to_artifact as events
 where event_type in (

--- a/warehouse/metrics_mesh/oso_metrics/key_dependencies_count.sql
+++ b/warehouse/metrics_mesh/oso_metrics/key_dependencies_count.sql
@@ -1,12 +1,9 @@
 select distinct
   now() as metrics_sample_date,
   events.event_source,
-  @metrics_entity_type_col(
-    'to_{entity_type}_id',
-    table_alias := events,
-  ),
+  events.to_artifact_id,
   '' as from_artifact_id,
-  'DEPENDENCY_COUNT' as metric,
+  @metric_name('dependencies_count') as metric,
   count(distinct events.from_artifact_id) as amount
 from metrics.events_daily_to_artifact as events
 where event_type = 'ADD_DEPENDENCY'

--- a/warehouse/metrics_mesh/oso_metrics/key_developer_active_day_count.sql
+++ b/warehouse/metrics_mesh/oso_metrics/key_developer_active_day_count.sql
@@ -1,9 +1,9 @@
 select distinct
   now() as metrics_sample_date,
   events.event_source,
-  events.to_artifact_id as to_artifact_id,
+  events.to_artifact_id,
   events.from_artifact_id as from_artifact_id,
-  'DEVELOPER_ACTIVE_DAYS' as metric,
+  @metric_name('developer_active_day_count') as metric,
   count(distinct events.bucket_day) as amount,
   'COUNT' as unit
 from metrics.events_daily_to_artifact as events

--- a/warehouse/metrics_mesh/oso_metrics/key_developer_count.sql
+++ b/warehouse/metrics_mesh/oso_metrics/key_developer_count.sql
@@ -1,12 +1,9 @@
 select distinct
   now() as metrics_sample_date,
   events.event_source,
-  @metrics_entity_type_col(
-    'to_{entity_type}_id',
-    table_alias := events,
-  ),
+  events.to_artifact_id,
   '' as from_artifact_id,
-  'DEVELOPER_COUNT' as metric,
+  @metric_name('developer_count') as metric,
   count(distinct from_artifact_id) as amount
 from metrics.events_daily_to_artifact as events
 where event_type in (

--- a/warehouse/metrics_mesh/oso_metrics/key_fork_count.sql
+++ b/warehouse/metrics_mesh/oso_metrics/key_fork_count.sql
@@ -1,12 +1,9 @@
 select distinct
   now() as metrics_sample_date,
   events.event_source,
-  @metrics_entity_type_col(
-    'to_{entity_type}_id',
-    table_alias := events,
-  ),
+  events.to_artifact_id,
   '' as from_artifact_id,
-  'FORK_COUNT' as metric,
+  @metric_name('fork_count') as metric_name,
   count(*) as amount
 from metrics.events_daily_to_artifact as events
 where event_type = 'FORKED'

--- a/warehouse/metrics_mesh/oso_metrics/key_funding_received.sql
+++ b/warehouse/metrics_mesh/oso_metrics/key_funding_received.sql
@@ -1,12 +1,9 @@
 select distinct
   now() as metrics_sample_date,
   events.event_source,
-  @metrics_entity_type_col(
-    'to_{entity_type}_id',
-    table_alias := events,
-  ),
+  events.to_artifact_id,
   '' as from_artifact_id,
-  'FUNDING_RECEIVED' as metric,
+  @metric_name('funding_received') as metric,
   sum(events.amount) as amount
 from metrics.events_daily_to_artifact as events
 where event_type = 'CREDIT'

--- a/warehouse/metrics_mesh/oso_metrics/key_gas_fees.sql
+++ b/warehouse/metrics_mesh/oso_metrics/key_gas_fees.sql
@@ -1,12 +1,9 @@
 select distinct
   now() as metrics_sample_date,
   events.event_source,
-  @metrics_entity_type_col(
-    'to_{entity_type}_id',
-    table_alias := events,
-  ),
+  events.to_artifact_id,
   '' as from_artifact_id,
-  'GAS_FEES' as metric,
+  @metric_name('gas_fees') as metric,
   sum(events.amount) as amount
 from metrics.events_daily_to_artifact as events
 where event_type = 'CONTRACT_INVOCATION_DAILY_L2_GAS_USED'

--- a/warehouse/metrics_mesh/oso_metrics/key_issue_count_closed.sql
+++ b/warehouse/metrics_mesh/oso_metrics/key_issue_count_closed.sql
@@ -1,12 +1,9 @@
 select distinct
   now() as metrics_sample_date,
   events.event_source,
-  @metrics_entity_type_col(
-    'to_{entity_type}_id',
-    table_alias := events,
-  ),
+  events.to_artifact_id,
   '' as from_artifact_id,
-  'ISSUES_CLOSED' as metric,
+  @metric_name('issue_count_closed') as metric,
   count(*) as amount
 from metrics.events_daily_to_artifact as events
 where event_type = 'ISSUE_CLOSED'

--- a/warehouse/metrics_mesh/oso_metrics/key_issue_count_opened.sql
+++ b/warehouse/metrics_mesh/oso_metrics/key_issue_count_opened.sql
@@ -1,12 +1,9 @@
 select distinct
   now() as metrics_sample_date,
   events.event_source,
-  @metrics_entity_type_col(
-    'to_{entity_type}_id',
-    table_alias := events,
-  ),
+  events.to_artifact_id,
   '' as from_artifact_id,
-  'ISSUES_OPENED' as metric,
+  @metric_name('issue_count_opened') as metric,
   count(*) as amount
 from metrics.events_daily_to_artifact as events
 where event_type = 'ISSUE_OPENED'

--- a/warehouse/metrics_mesh/oso_metrics/key_last_commit.sql
+++ b/warehouse/metrics_mesh/oso_metrics/key_last_commit.sql
@@ -1,10 +1,7 @@
 select distinct
   now() as metrics_sample_date,
   events.event_source,
-  @metrics_entity_type_col(
-    'to_{entity_type}_id',
-    table_alias := events,
-  ),
+  events.to_artifact_id,
   '' as from_artifact_id,
   @metric_name('last_commit') as metric,
   @to_unix_timestamp(max(bucket_day)) as amount

--- a/warehouse/metrics_mesh/oso_metrics/key_pr_count_merged.sql
+++ b/warehouse/metrics_mesh/oso_metrics/key_pr_count_merged.sql
@@ -1,12 +1,9 @@
 select distinct
   now() as metrics_sample_date,
   events.event_source,
-  @metrics_entity_type_col(
-    'to_{entity_type}_id',
-    table_alias := events,
-  ),
+  events.to_artifact_id,
   '' as from_artifact_id,
-  'PRS_MERGED' as metric,
+  @metric_name('pr_count_merged') as metric,
   count(*) as amount
 from metrics.events_daily_to_artifact as events
 where event_type = 'PULL_REQUEST_MERGED'

--- a/warehouse/metrics_mesh/oso_metrics/key_pr_count_opened.sql
+++ b/warehouse/metrics_mesh/oso_metrics/key_pr_count_opened.sql
@@ -1,12 +1,9 @@
 select distinct
   now() as metrics_sample_date,
   events.event_source,
-  @metrics_entity_type_col(
-    'to_{entity_type}_id',
-    table_alias := events,
-  ),
+  events.to_artifact_id,
   '' as from_artifact_id,
-  'PRS_OPENED' as metric,
+  @metric_name('pr_count_opened') as metric,
   count(*) as amount
 from metrics.events_daily_to_artifact as events
 where event_type = 'PULL_REQUEST_OPENED'

--- a/warehouse/metrics_mesh/oso_metrics/key_pr_time_to_merge.sql
+++ b/warehouse/metrics_mesh/oso_metrics/key_pr_time_to_merge.sql
@@ -1,12 +1,9 @@
 select distinct
   now() as metrics_sample_date,
   event_source,
-  @metrics_entity_type_col(
-    'to_{entity_type}_id',
-    table_alias := issue_event,
-  ),
+  events.to_artifact_id,
   '' as from_artifact_id,
-  'PRS_TIME_TO_MERGE' as metric,
+  @metric_name('pr_time_to_merge') as metric,
   avg(created_delta) as amount
 from metrics.issue_event_time_deltas as issue_event
 where event_type = 'PULL_REQUEST_MERGED'

--- a/warehouse/metrics_mesh/oso_metrics/key_release_count.sql
+++ b/warehouse/metrics_mesh/oso_metrics/key_release_count.sql
@@ -1,12 +1,9 @@
 select distinct
   now() as metrics_sample_date,
   events.event_source,
-  @metrics_entity_type_col(
-    'to_{entity_type}_id',
-    table_alias := events,
-  ),
+  events.to_artifact_id,
   '' as from_artifact_id,
-  'RELEASE_COUNT' as metric,
+  @metric_name('release_count') as metric,
   count(*) as amount
 from metrics.events_daily_to_artifact as events
 where event_type = 'RELEASE_PUBLISHED'

--- a/warehouse/metrics_mesh/oso_metrics/key_repository_count.sql
+++ b/warehouse/metrics_mesh/oso_metrics/key_repository_count.sql
@@ -1,12 +1,9 @@
 select distinct
   now() as metrics_sample_date,
   events.event_source,
-  @metrics_entity_type_col(
-    'to_{entity_type}_id',
-    table_alias := events,
-  ),
+  events.to_artifact_id,
   '' as from_artifact_id,
-  'REPOSITORY_ENGAGEMENT_COUNT' as metric,
+  @metric_name('repository_count') as metric,
   count(distinct events.to_artifact_id) as amount
 from metrics.events_daily_to_artifact as events
 where events.event_type in (

--- a/warehouse/metrics_mesh/oso_metrics/key_star_count.sql
+++ b/warehouse/metrics_mesh/oso_metrics/key_star_count.sql
@@ -1,12 +1,9 @@
 select distinct
   now() as metrics_sample_date,
   events.event_source,
-  @metrics_entity_type_col(
-    'to_{entity_type}_id',
-    table_alias := events,
-  ),
+  events.to_artifact_id,
   '' as from_artifact_id,
-  'STAR_COUNT' as metric,
+  @metric_name('star_count') as metric,
   count(*) as amount
 from metrics.events_daily_to_artifact as events
 where event_type = 'STARRED'

--- a/warehouse/metrics_mesh/oso_metrics/key_time_to_first_response.sql
+++ b/warehouse/metrics_mesh/oso_metrics/key_time_to_first_response.sql
@@ -1,12 +1,9 @@
 select distinct
   now() as metrics_sample_date,
   event_source,
-  @metrics_entity_type_col(
-    'to_{entity_type}_id',
-    table_alias := metrics.issue_event_time_deltas
-  ),
+  events.to_artifact_id,
   '' as from_artifact_id,
-  'TIME_TO_FIRST_RESPONSE' as metric,
+  @metric_name('time_to_first_response') as metric,
   avg(created_delta) as amount
 from metrics.issue_event_time_deltas
 where (

--- a/warehouse/metrics_mesh/oso_metrics/key_transaction_count.sql
+++ b/warehouse/metrics_mesh/oso_metrics/key_transaction_count.sql
@@ -1,12 +1,9 @@
 select distinct
   now() as metrics_sample_date,
   events.event_source,
-  @metrics_entity_type_col(
-    'to_{entity_type}_id',
-    table_alias := events
-  ),
+  events.to_artifact_id,
   '' as from_artifact_id,
-  'TRANSACTION_COUNT' as metric,
+  @metric_name('transaction_count') as metric,
   count(*) as amount
 from metrics.events_daily_to_artifact as events
 where event_type = 'CONTRACT_INVOCATION_SUCCESS_DAILY_COUNT'


### PR DESCRIPTION
This PR closes #2831 by using the `@metric_name` macro in SQLMesh key metric models to dynamically generate the correct metric name based on the type (artifact, project, or collection). It also uses the `to_artifact_id` column to enable the factory to accurately infer the type and generate other type models from the artifact model.