### PR TITLE
Fix some sqlmesh models on trino

### DIFF
--- a/ops/k8s-apps/base/nessie/kustomization.yaml
+++ b/ops/k8s-apps/base/nessie/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: base-nessie
+resources:
+  - nessie.yaml

--- a/ops/k8s-apps/base/nessie/nessie.yaml
+++ b/ops/k8s-apps/base/nessie/nessie.yaml
@@ -1,0 +1,58 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: base-nessie
+  labels:
+    toolkit.fluxcd.io/tenant: apps
+    ops.opensource.observer/environment: base
+    kube-secrets-init.doit-intl.com/enable-mutation: "true"
+    opensource.observer/cert-inject: "enabled"
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: nessie
+  namespace: base-nessie
+spec:
+  interval: 5m
+  url: https://charts.projectnessie.org
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: nessie
+  namespace: base-nessie
+spec:
+  chart:
+    spec:
+      chart: nessie
+      version: "0.102.0"
+      sourceRef:
+        kind: HelmRepository
+        name: nessie
+  interval: 50m
+  install:
+    remediation:
+      retries: 3
+  values:
+    # Configure to trust the local self signed certificate bundle
+    extraEnv:
+      - name: JAVA_TOOL_OPTIONS
+        value: "-Djavax.net.ssl.trustStore=/etc/ssl/k8s-certs/ca-certificates.p12"
+
+    extraVolumeMounts:
+      - name: cluster-self-signed-bundle
+        mountPath: /etc/ssl/k8s-certs
+    
+    extraVolumes:
+      - name: cluster-self-signed-bundle
+        configMap:
+          name: cluster-self-signed-bundle
+          defaultMode: 0644
+          optional: false
+          items:
+            - key: ca-certificates.crt
+              path: ca-certificates.crt
+            - key: ca-certificates.p12
+              path: ca-certificates.p12
+  

--- a/ops/k8s-apps/local/kustomization.yaml
+++ b/ops/k8s-apps/local/kustomization.yaml
@@ -7,4 +7,5 @@ resources:
   - ./hive-psql
   - ./trino-psql
   - ./hive-metastore
+  - ./nessie
   - ./trino

--- a/ops/k8s-apps/local/nessie/custom-helm-values.yaml
+++ b/ops/k8s-apps/local/nessie/custom-helm-values.yaml
@@ -1,0 +1,31 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: local-nessie
+spec:
+  values:
+    catalog:
+      enabled: true
+      iceberg:
+        defaultWarehouse: warehouse
+        warehouses:
+          - name: warehouse
+            location: s3://local-storage/
+      storage:
+        s3:
+          defaultOptions:
+            accessKeySecret:
+              awsAccessKeyId: accessKey
+              awsSecretAccessKey: secretKey
+              name: nessie-minio
+            endpoint: https://minio.local-minio.svc.cluster.local
+            pathStyleAccess: true
+            region: local
+    jdbc:
+      jdbcUrl: jdbc:postgresql://hive-psql-postgresql.local-hive-psql.svc.cluster.local:5432/postgres
+      secret:
+        name: nessie-postgres
+        password: password
+        username: username
+    versionStoreType: JDBC
+

--- a/ops/k8s-apps/local/nessie/kustomization.yaml
+++ b/ops/k8s-apps/local/nessie/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./secrets.yaml
+  - ../../base/nessie
+namespace: local-nessie
+patches:
+  - path: ./custom-helm-values.yaml
+    target:
+      kind: HelmRelease
+    options:
+      allowNameChange: true

--- a/ops/k8s-apps/local/nessie/secrets.yaml
+++ b/ops/k8s-apps/local/nessie/secrets.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: nessie-postgres
+  namespace: local-nessie
+type: Opaque
+data:
+  username: cG9zdGdyZXM=  # base64 encoded value of 'admin'
+  password: cGFzc3dvcmQ=  # base64 encoded value of 'password'
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: nessie-minio
+  namespace: local-nessie
+type: Opaque
+data:
+  accessKey: YWRtaW4=  # base64 encoded value of 'admin'
+  secretKey: cGFzc3dvcmQ=  # base64 encoded value of 'password'

--- a/ops/k8s-apps/local/trino/custom-helm-values.yaml
+++ b/ops/k8s-apps/local/trino/custom-helm-values.yaml
@@ -47,7 +47,15 @@ spec:
         connection-user=postgres
         connection-password=password
       metrics: |
-        connector.name=postgresql
-        connection-url=jdbc:postgresql://trino-psql-postgresql.local-trino-psql.svc.cluster.local:5432/postgres
-        connection-user=postgres
-        connection-password=password
+        connector.name=iceberg
+        fs.native-s3.enabled=true
+        iceberg.catalog.type=rest
+        iceberg.rest-catalog.security=NONE
+        iceberg.rest-catalog.uri=http://local-nessie.local-nessie.svc.cluster.local:19120/iceberg/
+        iceberg.rest-catalog.vended-credentials-enabled=false
+        s3.endpoint=https://minio.local-minio.svc.cluster.local
+        s3.aws-access-key=admin
+        s3.aws-secret-key=password
+        s3.path-style-access=true
+        s3.region=local
+

--- a/ops/k8s-apps/local/trino/custom-helm-values.yaml
+++ b/ops/k8s-apps/local/trino/custom-helm-values.yaml
@@ -48,14 +48,14 @@ spec:
         connection-password=password
       metrics: |
         connector.name=iceberg
-        fs.native-s3.enabled=true
         iceberg.catalog.type=rest
         iceberg.rest-catalog.security=NONE
         iceberg.rest-catalog.uri=http://local-nessie.local-nessie.svc.cluster.local:19120/iceberg/
         iceberg.rest-catalog.vended-credentials-enabled=false
+        fs.native-s3.enabled=true
+        s3.path-style-access=true
+        s3.region=local
         s3.endpoint=https://minio.local-minio.svc.cluster.local
         s3.aws-access-key=admin
         s3.aws-secret-key=password
-        s3.path-style-access=true
-        s3.region=local
 

--- a/warehouse/metrics_mesh/README.md
+++ b/warehouse/metrics_mesh/README.md
@@ -164,7 +164,20 @@ implementation, it takes more resources than simply running with duckdb. For
 this reason alone, we suggest most initial testing to happen on duckdb. However,
 in order to simulate and test this running against trino as it does on the
 production OSO deployment, we need to have things wired properly with
-kubernetes. To initialize everything simply do:
+kubernetes.
+
+### Prerequisites
+
+In addition to having the normal dev tools for running the repo, you will also need:
+
+- [docker](https://www.docker.com/)
+- [kind](https://kind.sigs.k8s.io/)
+
+Please install these before continuing.
+
+### Local Kubernetes Cluster Setup
+
+To initialize everything simply do:
 
 ```bash
 oso ops cluster-setup
@@ -176,6 +189,9 @@ calculation service deployed. This is to test that process works and to ensure
 that the MCS has the proper version deployed. Eventually this can/will be used
 to test the dagster deployment.
 
+_Note: It will probably look like it's stuck at the `Build and publish docker
+image to local registry` step._
+
 Once everything is setup, things should be running in the kind cluster
 `oso-local-test-cluster`. Normally, you'd need to ensure that you forward the
 right ports so that you can access the cluster to run the sqlmesh jobs but the
@@ -183,15 +199,22 @@ convenience functions we created to run sqlmesh ensure that this is done
 automatically. However, before running sqlmesh you will need to initialize the
 data in trino.
 
+### Initialize Trino Data
+
 Much like running against a local duckdb the local trino can also be initialized
 with on the CLI like so:
 
 ```bash
-oso metrics local initialize --local-trino
+oso metrics local initialize --local-trino -m 1000 -d 2
 ```
 
-Once completed, trino will be configured to have the proper source data for
+_Note: It's best not to load too much data into trino for local testing. It won't be as
+fast as sqlmesh with duckdb locally._
+
+Once initialized, trino will be configured to have the proper source data for
 sqlmesh.
+
+### Running `plan` or `run`
 
 Finally, to run `sqlmesh plan` do this:
 
@@ -207,8 +230,12 @@ keyword in the command invocation. So to call `sqlmesh run` you'd simply do:
 oso metrics local sqlmesh --local-trino run
 ```
 
-Please note, you may periodically be logged out of the local kind cluster, just
-run `oso ops cluster-setup` again if that happens.
+### Changing branches or random logouts
+
+Please note, you may periodically be logged out of the local kind cluster or you
+will need to change branches that you'd like the cluster to use. Just run `oso
+ops cluster-setup` again and it will properly update the local cluster. It could
+take a few minutes for the cluster to synchronize to the declared configuration.
 
 ## Metrics Overview
 

--- a/warehouse/metrics_mesh/macros/json_array_length.py
+++ b/warehouse/metrics_mesh/macros/json_array_length.py
@@ -1,0 +1,53 @@
+"""
+
+Attempt that works:
+
+with projects as (
+  select
+    project_id,
+    websites,
+    social,
+    github,
+    npm,
+    blockchain
+  from bigquery.oso.stg_ossd__current_projects
+)
+select * from projects
+cross join unnest(
+cast(
+		json_extract(
+			json_query(
+				json_format(websites), 
+				'lax $[*].url' with array wrapper
+			), '$'
+		) as array<JSON>)
+) as t(web);
+
+
+
+
+"""
+
+from sqlglot import expressions as exp
+from sqlmesh import macro
+from sqlmesh.core.macros import MacroEvaluator
+
+
+@macro()
+def json_array_length(
+    evaluator: MacroEvaluator,
+    array_expression: exp.Expression,
+):
+    """Convert a unix epoch timestamp to a date or timestamp."""
+
+    if evaluator.runtime_stage in ["loading"]:
+        return exp.ArraySize(this=array_expression)
+
+    if evaluator.engine_adapter.dialect == "duckdb":
+        return exp.ArraySize(this=array_expression)
+    elif evaluator.engine_adapter.dialect == "trino":
+        return exp.Anonymous(this="json_array_length", expressions=[array_expression])
+    else:
+        raise NotImplementedError(
+            f"json_array_length not implemented for {evaluator.engine_adapter.dialect}"
+        )

--- a/warehouse/metrics_mesh/macros/json_array_length.py
+++ b/warehouse/metrics_mesh/macros/json_array_length.py
@@ -1,33 +1,3 @@
-"""
-
-Attempt that works:
-
-with projects as (
-  select
-    project_id,
-    websites,
-    social,
-    github,
-    npm,
-    blockchain
-  from bigquery.oso.stg_ossd__current_projects
-)
-select * from projects
-cross join unnest(
-cast(
-		json_extract(
-			json_query(
-				json_format(websites), 
-				'lax $[*].url' with array wrapper
-			), '$'
-		) as array<JSON>)
-) as t(web);
-
-
-
-
-"""
-
 from sqlglot import expressions as exp
 from sqlmesh import macro
 from sqlmesh.core.macros import MacroEvaluator

--- a/warehouse/metrics_mesh/macros/json_extract.py
+++ b/warehouse/metrics_mesh/macros/json_extract.py
@@ -1,0 +1,78 @@
+"""
+
+Attempt that works:
+
+with projects as (
+  select
+    project_id,
+    websites,
+    social,
+    github,
+    npm,
+    blockchain
+  from bigquery.oso.stg_ossd__current_projects
+)
+select * from projects
+cross join unnest(
+cast(
+		json_extract(
+			json_query(
+				json_format(websites), 
+				'lax $[*].url' with array wrapper
+			), '$'
+		) as array<JSON>)
+) as t(web);
+
+
+
+
+"""
+
+from sqlglot import expressions as exp
+from sqlmesh import macro
+from sqlmesh.core.macros import MacroEvaluator
+
+
+@macro()
+def json_extract_from_array(
+    evaluator: MacroEvaluator,
+    json_expression: exp.Expression,
+    key: str,
+):
+    """Convert a unix epoch timestamp to a date or timestamp."""
+
+    if evaluator.runtime_stage in ["loading"]:
+        return exp.Array(this=[])
+
+    if evaluator.engine_adapter.dialect == "duckdb":
+        result = exp.JSONExtract(
+            this=json_expression,
+            expressions=exp.Literal(this=key, is_string=True),
+        )
+    elif evaluator.engine_adapter.dialect == "trino":
+        result = exp.JSONExtract(
+            this=exp.JSONExtract(
+                this=json_expression,
+                expression=exp.Literal(this=f"strict {key}", is_string=True),
+                option=exp.Var(this="WITH UNCONDITIONAL ARRAY WRAPPER"),
+                json_query=True,
+            ),
+            expression=exp.Literal(this="$", is_string=True),
+        )
+    else:
+        raise NotImplementedError(
+            f"from_unix_timestamp not implemented for {evaluator.engine_adapter.dialect}"
+        )
+    return exp.Cast(
+        this=result,
+        to=exp.DataType(
+            this=exp.DataType.Type.ARRAY,
+            expressions=[
+                exp.DataType(
+                    this=exp.DataType.Type.JSON,
+                    nested=False,
+                )
+            ],
+            nested=True,
+        ),
+    )

--- a/warehouse/metrics_mesh/macros/json_extract.py
+++ b/warehouse/metrics_mesh/macros/json_extract.py
@@ -47,7 +47,7 @@ def json_extract_from_array(
     if evaluator.engine_adapter.dialect == "duckdb":
         result = exp.JSONExtract(
             this=json_expression,
-            expressions=exp.Literal(this=key, is_string=True),
+            expression=exp.Literal(this=key, is_string=True),
         )
     elif evaluator.engine_adapter.dialect == "trino":
         result = exp.JSONExtract(

--- a/warehouse/metrics_mesh/models/intermediate/directory/int_artifacts_in_ossd_by_project.sql
+++ b/warehouse/metrics_mesh/models/intermediate/directory/int_artifacts_in_ossd_by_project.sql
@@ -1,6 +1,7 @@
 MODEL (
   name metrics.int_artifacts_in_ossd_by_project,
   kind FULL,
+  dialect duckdb
 );
 
 with projects as (
@@ -17,67 +18,67 @@ with projects as (
 all_websites as (
   select
     projects.project_id,
-    unnest(json_extract_string(websites, '$.*')) as artifact_source_id,
+    json_extract_string(pw.websites, '$') as artifact_source_id,
     'WWW' as artifact_source,
     'WWW' as artifact_namespace,
-    artifact_source_id as artifact_name,
-    artifact_source_id as artifact_url,
+    json_extract_string(pw.websites, '$') as artifact_name,
+    json_extract_string(pw.websites, '$') as artifact_url,
     'WEBSITE' as artifact_type
   from projects
   cross join
-    UNNEST(json_extract(projects.websites, '$[*].url')) as websites
+    UNNEST(@json_extract_from_array(projects.websites, '$[*].url')) as pw(websites)
 ),
 
 all_farcaster as (
   select
     projects.project_id,
-    unnest(json_extract_string(farcaster, '$.*')) as artifact_source_id,
+    json_extract_string(farcaster, '$') as artifact_source_id,
     'FARCASTER' as artifact_source,
     'FARCASTER' as artifact_namespace,
-    artifact_source_id as artifact_url,
+    json_extract_string(farcaster, '$') as artifact_url,
     'SOCIAL_HANDLE' as artifact_type,
     case
       when
-        artifact_source_id like 'https://warpcast.com/%'
-        then SUBSTR(artifact_source_id, 22)
-      else artifact_source_id
+        json_extract_string(farcaster, '$') like 'https://warpcast.com/%'
+        then SUBSTR(json_extract_string(farcaster, '$'), 22)
+      else json_extract_string(farcaster, '$')
     end as artifact_name
   from projects
   cross join
-    UNNEST(json_extract(projects.social, '$.farcaster[*].url')) as farcaster
+    UNNEST(@json_extract_from_array(projects.social, '$.farcaster[*].url')) as ps(farcaster)
 ),
 
 all_twitter as (
   select
     projects.project_id,
-    unnest(json_extract_string(twitter, '$.*')) as artifact_source_id,
+    json_extract_string(twitter, '$') as artifact_source_id,
     'TWITTER' as artifact_source,
     'TWITTER' as artifact_namespace,
-    artifact_source_id as artifact_url,
+    json_extract_string(twitter, '$') as artifact_url,
     'SOCIAL_HANDLE' as artifact_type,
     case
       when
-        artifact_source_id like 'https://twitter.com/%'
-        then SUBSTR(artifact_source_id, 21)
+        json_extract_string(twitter, '$') like 'https://twitter.com/%'
+        then SUBSTR(json_extract_string(twitter, '$'), 21)
       when
-        artifact_source_id like 'https://x.com/%'
-        then SUBSTR(artifact_source_id, 15)
-      else artifact_source_id
+        json_extract_string(twitter, '$') like 'https://x.com/%'
+        then SUBSTR(json_extract_string(twitter, '$'), 15)
+      else json_extract_string(twitter, '$')
     end as artifact_name
   from projects
   cross join
-    UNNEST(json_extract(projects.social, '$.twitter[*].url')) as twitter
+    UNNEST(@json_extract_from_array(projects.social, '$.twitter[*].url')) as ps(twitter)
 ),
 
 github_repos_raw as (
   select
     projects.project_id,
     'GITHUB' as artifact_source,
-    unnest(json_extract_string(github, '$.*')) as artifact_url,
+    json_extract_string(pg.github, '$') as artifact_url,
     'REPOSITORY' as artifact_type
   from projects
   cross join
-    UNNEST(json_extract(projects.github, '$[*].url')) as github
+    UNNEST(@json_extract_from_array(projects.github, '$[*].url')) as pg(github)
 ),
 
 github_repos as (
@@ -107,20 +108,20 @@ all_npm_raw as (
     'NPM' as artifact_source,
     'PACKAGE' as artifact_type,
     projects.project_id,
-    unnest(json_extract_string(npm, '$.*')) as artifact_source_id,
-    artifact_source_id as artifact_url,
+    json_extract_string(pn.npm, '$') as artifact_source_id,
+    json_extract_string(pn.npm, '$') as artifact_url,
     case
       when
-        artifact_source_id like 'https://npmjs.com/package/%'
-        then SUBSTR(artifact_source_id, 27)
+        json_extract_string(pn.npm, '$') like 'https://npmjs.com/package/%'
+        then SUBSTR(json_extract_string(pn.npm, '$'), 27)
       when
-        artifact_source_id like 'https://www.npmjs.com/package/%'
-        then SUBSTR(artifact_source_id, 31)
-      else artifact_source_id
+        json_extract_string(pn.npm, '$') like 'https://www.npmjs.com/package/%'
+        then SUBSTR(json_extract_string(pn.npm, '$'), 31)
+      else json_extract_string(pn.npm, '$')
     end as artifact_name
   from projects
   cross join
-    UNNEST(json_extract(projects.npm, '$[*].url')) as npm
+    UNNEST(@json_extract_from_array(projects.npm, '$[*].url')) as pn(npm)
 ),
 
 all_npm as (
@@ -139,19 +140,19 @@ all_npm as (
 ossd_blockchain as (
   select
     projects.project_id,
-    unnest(json_extract_string(tag, '$.*')) as artifact_type,
-    unnest(json_extract_string(network, '$.*')) as artifact_source,
-    unnest(json_extract_string(blockchains, '$.*.address')) as artifact_source_id,
-    artifact_source as artifact_namespace,
-    artifact_source_id as artifact_name,
-    artifact_source_id as artifact_url
+    json_extract_string(tag, '$') as artifact_type,
+    json_extract_string(network, '$') as artifact_source,
+    json_extract_string(blockchains, '$.address') as artifact_source_id,
+    json_extract_string(network, '$') as artifact_namespace,
+    json_extract_string(blockchains, '$.address') as artifact_name,
+    json_extract_string(blockchains, '$.address') as artifact_url
   from projects
   cross join
-    UNNEST(json_extract(projects.blockchain, '$[*]')) as blockchains
+    UNNEST(@json_extract_from_array(projects.blockchain, '$[*]')) as pb(blockchains)
   cross join
-    UNNEST(json_extract(blockchains, '$.*.networks[*]')) as network
+    UNNEST(@json_extract_from_array(blockchains, '$.networks[*]')) as bn(network)
   cross join
-    UNNEST(json_extract(blockchains, '$.*.tags[*]')) as tag
+    UNNEST(@json_extract_from_array(blockchains, '$.tags[*]')) as bt(tag)
 ),
 
 all_artifacts as (
@@ -226,10 +227,6 @@ all_normalized_artifacts as (
   select distinct
     project_id,
     LOWER(artifact_source_id) as artifact_source_id,
-    {# 
-      artifact_source and artifact_type are considered internal constants hence
-      we apply an UPPER transform
-    #}
     UPPER(artifact_source) as artifact_source,
     UPPER(artifact_type) as artifact_type,
     LOWER(artifact_namespace) as artifact_namespace,

--- a/warehouse/metrics_mesh/models/intermediate/directory/int_projects.sql
+++ b/warehouse/metrics_mesh/models/intermediate/directory/int_projects.sql
@@ -1,7 +1,7 @@
 MODEL (
   name metrics.int_projects,
   description 'All projects',
-  kind FULL,
+  kind FULL
 );
 
 select
@@ -11,10 +11,7 @@ select
   project_name,
   display_name,
   description,
-  ARRAY_LENGTH(github)
-    as github_artifact_count,
-  ARRAY_LENGTH(blockchain)
-    as blockchain_artifact_count,
-  ARRAY_LENGTH(npm)
-    as npm_artifact_count
+  @json_array_length(github) as github_artifact_count,
+  @json_array_length(blockchain) as blockchain_artifact_count,
+  @json_array_length(npm) as npm_artifact_count
 from @oso_source('bigquery.oso.stg_ossd__current_projects')

--- a/warehouse/metrics_tools/local/utils.py
+++ b/warehouse/metrics_tools/local/utils.py
@@ -119,11 +119,11 @@ def initialize_local_postgres(
             host=postgres_host,
             port=postgres_port,
         ),
-        postgres_host="localhost",
-        postgres_db="postgres",
-        postgres_user="postgres",
-        postgres_password="password",
-        postgres_port=5432,
+        postgres_host=postgres_host,
+        postgres_db=postgres_database,
+        postgres_user=postgres_user,
+        postgres_password=postgres_password,
+        postgres_port=postgres_port,
     )
     initialize_local(loader, max_results_per_query, max_days)
 

--- a/warehouse/oso_lets_go/cli.py
+++ b/warehouse/oso_lets_go/cli.py
@@ -127,12 +127,20 @@ def local(ctx: click.Context):
 
     ctx.obj["local_duckdb_path"] = local_duckdb_path
 
-    # By default just use the local duckdb path and add .trino.db to the name
-    local_trino_duckdb_path = os.getenv(
-        "SQLMESH_DUCKDB_LOCAL_TRINO_PATH", f"{local_duckdb_path}.trino.db"
-    )
-    if local_trino_duckdb_path:
-        ctx.obj["local_trino_duckdb_path"] = local_trino_duckdb_path
+    local_trino_duckdb_path = os.getenv("SQLMESH_DUCKDB_LOCAL_TRINO_PATH", None)
+    # If we don't set the local trino path then we add a trino suffix to the filename.
+    if not local_trino_duckdb_path:
+        local_duckdb_dirname = os.path.dirname(local_trino_duckdb_path)
+        local_duckdb_filename = os.path.basename(local_trino_duckdb_path)
+        name, extension = os.path.splitext(local_duckdb_filename)
+        local_trino_duckdb_filename = f"{name}-trino{extension}"
+        local_trino_duckdb_path = os.path.join(
+            local_duckdb_dirname, local_trino_duckdb_filename
+        )
+        logger.info(
+            f"SQLMESH_DUCKDB_LOCAL_TRINO_PATH not set. Using {local_trino_duckdb_path} for local trino state"
+        )
+    ctx.obj["local_trino_duckdb_path"] = local_trino_duckdb_path
 
 
 @local.command()

--- a/warehouse/oso_lets_go/cli.py
+++ b/warehouse/oso_lets_go/cli.py
@@ -180,12 +180,14 @@ def initialize(
 @click.option("--local-trino/--no-local-trino", default=False)
 @click.option("--local-registry-port", default=5001)
 @click.option("--redeploy-image/--no-redeploy-image", default=False)
+@click.option("--timeseries-start", default="2024-12-01")
 @click.pass_context
 def sqlmesh(
     ctx: click.Context,
     local_trino: bool,
     local_registry_port: int,
     redeploy_image: bool,
+    timeseries_start: str,
 ):
     """Proxy to the sqlmesh command that can be used against a local kind
     deployment or a local duckdb"""
@@ -231,6 +233,11 @@ def sqlmesh(
                     "SQLMESH_TRINO_PORT": str(local_port),
                     "SQLMESH_TRINO_CONCURRENT_TASKS": "1",
                     "SQLMESH_MCS_ENABLED": "0",
+                    # We set this variable to ensure that we run the minimal
+                    # amount of data. By default this ensure that we only
+                    # calculate metrics from 2024-12-01. For now this is only
+                    # set for trino but must be explicitly set for duckdb
+                    "SQLMESH_TIMESERIES_METRICS_START": timeseries_start,
                 },
             )
             process.communicate()


### PR DESCRIPTION
Lots of things:

* Adds iceberg to the local trino deployment (turns out because of how sqlmesh works this was necessary)
    * Uses nessie as the metastore (ended up not being so hard to do)
* Adds a `json_extract` macro that can be used in multiple places
* Adds a `json_array_length` because `array_length` doesn't exist on trino (or sqlglot transpiles to the wrong thing).