### PR TITLE
fix: op-atlas replication

### DIFF
--- a/warehouse/oso_dagster/assets/op_atlas.py
+++ b/warehouse/oso_dagster/assets/op_atlas.py
@@ -39,90 +39,116 @@ op_atlas = sql_assets(
         {
             "table": "Application",
             "incremental": incremental("updatedAt"),
+            "defer_table_reflect": True,
         },
         {
             "table": "Badgeholder",
+            "defer_table_reflect": True,
         },
         {
             "table": "Category",
+            "defer_table_reflect": True,
         },
         {
             "table": "FundingReward",
             "incremental": incremental("updatedAt"),
+            "defer_table_reflect": True,
         },
         {
             "table": "FundingRound",
+            "defer_table_reflect": True,
         },
         {
             "table": "GithubProximity",
+            "defer_table_reflect": True,
         },
         {
             "table": "ImpactStatement",
+            "defer_table_reflect": True,
         },
         {
             "table": "ImpactStatementAnswer",
+            "defer_table_reflect": True,
         },
         {
             "table": "Organization",
             "incremental": incremental("updatedAt"),
+            "defer_table_reflect": True,
         },
         {
             "table": "OrganizationSnapshot",
             "incremental": incremental("createdAt"),
+            "defer_table_reflect": True,
         },
         {
             "table": "Project",
             "incremental": incremental("updatedAt"),
+            "defer_table_reflect": True,
         },
         {
             "table": "ProjectContract",
             "incremental": incremental("updatedAt"),
+            "defer_table_reflect": True,
         },
         {
             "table": "ProjectFunding",
             "incremental": incremental("updatedAt"),
+            "defer_table_reflect": True,
         },
         {
             "table": "ProjectLinks",
             "incremental": incremental("updatedAt"),
+            "defer_table_reflect": True,
         },
         {
             "table": "ProjectOrganization",
             "incremental": incremental("updatedAt"),
+            "defer_table_reflect": True,
         },
         {
             "table": "ProjectRepository",
             "incremental": incremental("updatedAt"),
+            "defer_table_reflect": True,
         },
         {
             "table": "ProjectSnapshot",
             "incremental": incremental("createdAt"),
+            "defer_table_reflect": True,
         },
         {
             "table": "RewardClaim",
             "incremental": incremental("updatedAt"),
+            "defer_table_reflect": True,
         },
         {
             "table": "User",
             "incremental": incremental("updatedAt"),
+            "defer_table_reflect": True,
         },
         {
             "table": "UserAddress",
             "incremental": incremental("updatedAt"),
+            "defer_table_reflect": True,
         },
         {
             "table": "UserEmail",
+            "defer_table_reflect": True,
         },
         {
             "table": "UserInteraction",
+            "defer_table_reflect": True,
+
         },
         {
             "table": "UserOrganization",
             "incremental": incremental("updatedAt"),
+            "defer_table_reflect": True,
         },
         {
             "table": "UserProjects",
+            "defer_table_reflect": True,
         },
     ],
     pool_size=5,
+    concurrency_key="op_atlas",
 )

--- a/warehouse/oso_dagster/factories/sql.py
+++ b/warehouse/oso_dagster/factories/sql.py
@@ -97,6 +97,7 @@ def sql_assets(
     environment: str = "production",
     asset_type: str = "source",
     pool_size: t.Optional[int] = None,
+    concurrency_key: t.Optional[str] = None,
 ):
     """A convenience sql asset factory that should handle any basic incremental
     table or or full refresh sql source and configure a destination to the
@@ -115,6 +116,8 @@ def sql_assets(
             "opensource.observer/factory": "sql_dlt",
             "opensource.observer/type": asset_type,
         }
+        if concurrency_key is not None:
+            tags["dagster/concurrency_key"] = concurrency_key
         translator = PrefixedDltTranslator(source_name, tags)
 
         connection_string = secrets.resolve_as_str(source_credential_reference)


### PR DESCRIPTION
* Current user that we have has strict connection limits
* This PR will add a concurrency key to all assets that connect to op-atlas
* Also turns on defer_table_reflect to reduce the number of connections