### PR TITLE
fix: change pull request id type from `INT` to `BIGINT`

### DIFF
--- a/warehouse/metrics_mesh/models/staging/github/stg_github__pull_request_merge_events.sql
+++ b/warehouse/metrics_mesh/models/staging/github/stg_github__pull_request_merge_events.sql
@@ -13,7 +13,7 @@ select distinct
   pre.repo.id as repository_id,
   pre.repo.name as repository_name,
   'PULL_REQUEST_MERGED' as "type",
-  json_extract(pre.payload, '$.pull_request.id')::INT as id,
+  json_extract(pre.payload, '$.pull_request.id')::BIGINT as id,
   strptime(
     json_extract_string(pre.payload, '$.pull_request.merged_at'),
     '%Y-%m-%dT%H:%M:%SZ'


### PR DESCRIPTION
This PR closes #2934 by using `BIGINT` instead of `INT` so the casting does not fail.