### PR TITLE
add: `Trino` -> `DuckDB` SQLMesh exporter

### DIFF
--- a/warehouse/oso_dagster/definitions.py
+++ b/warehouse/oso_dagster/definitions.py
@@ -11,7 +11,11 @@ from dotenv import load_dotenv
 from metrics_tools.utils.logging import setup_module_logging
 from oso_dagster.resources.bq import BigQueryImporterResource
 from oso_dagster.resources.clickhouse import ClickhouseImporterResource
-from oso_dagster.resources.duckdb import DuckDBExporterResource, DuckDBResource
+from oso_dagster.resources.duckdb import (
+    DuckDBExporterResource,
+    DuckDBImporterResource,
+    DuckDBResource,
+)
 from oso_dagster.resources.storage import (
     GCSTimeOrderedStorageResource,
     TimeOrderedStorageResource,
@@ -168,6 +172,11 @@ def load_definitions():
         ),
         time_ordered_storage=time_ordered_storage,
     )
+    duckdb_importer = DuckDBImporterResource(
+        duckdb=DuckDBResource(
+            database_path=global_config.local_duckdb_path,
+        )
+    )
 
     sqlmesh_infra_config = {
         "environment": "prod",
@@ -194,6 +203,7 @@ def load_definitions():
         clickhouse_importer=clickhouse_importer,
         bigquery_importer=bigquery_importer,
         duckdb_exporter=duckdb_exporter,
+        duckdb_importer=duckdb_importer,
         time_ordered_storage=time_ordered_storage,
     )
 
@@ -248,6 +258,7 @@ def load_definitions():
         "clickhouse_importer": clickhouse_importer,
         "bigquery_importer": bigquery_importer,
         "duckdb_exporter": duckdb_exporter,
+        "duckdb_importer": duckdb_importer,
         "time_ordered_storage": time_ordered_storage,
     }
     for target in global_config.dbt_manifests:

--- a/warehouse/oso_dagster/resources/duckdb.py
+++ b/warehouse/oso_dagster/resources/duckdb.py
@@ -3,7 +3,7 @@ from contextlib import contextmanager
 
 import duckdb
 from dagster import ConfigurableResource, ResourceDependency
-from metrics_tools.transfer.duckdb import DuckDBExporter
+from metrics_tools.transfer.duckdb import DuckDBExporter, DuckDBImporter
 from oso_dagster.resources.storage import GCSTimeOrderedStorageResource
 from pydantic import Field
 
@@ -40,5 +40,20 @@ class DuckDBExporterResource(ConfigurableResource):
         """Provides the DuckDB connection for queries."""
         with self.time_ordered_storage.get(export_prefix) as storage:
             with self.duckdb.get_connection() as conn:
-                exporter = DuckDBExporter(storage, conn, gcs_bucket_name=gcs_bucket_name)
+                exporter = DuckDBExporter(
+                    storage, conn, gcs_bucket_name=gcs_bucket_name
+                )
                 yield exporter
+
+
+class DuckDBImporterResource(ConfigurableResource):
+    """Resource for providing a DuckDBImporter instance."""
+
+    duckdb: ResourceDependency[DuckDBResource]
+
+    @contextmanager
+    def get(self):
+        """Provides the DuckDB connection for queries."""
+        with self.duckdb.get_connection() as conn:
+            importer = DuckDBImporter(conn)
+            yield importer


### PR DESCRIPTION
This PR closes #2347 by implementing the `Trino` -> `DuckDB` SQLMesh exporter. It is not exposed yet in the configuration, since we do not use `MotherDuck`, but it is as easy as:

1. Authenticate with MotherDuck, e.g. [via an `auth_token`](https://motherduck.com/docs/getting-started/connect-query-from-python/installation-authentication/#using-an-access-token), and add a new `env` variable, e.g. `MOTHERDUCK_CONN_URI`
2. Add the following `config` to the existing `sqlmesh_exporter` variable in `warehouse/oso_dagster/definitions.py`
```diff
        sqlmesh_exporter = [
            Trino2ClickhouseSQLMeshExporter(
                ["clickhouse_metrics"],
                destination_catalog="clickhouse",
                destination_schema="default",
                source_catalog="metrics",
                source_schema="metrics",
            ),
            Trino2BigQuerySQLMeshExporter(
                ["bigquery_metrics"],
                project_id=project_id,
                dataset_id="metrics",
                source_catalog="metrics",
                source_schema="metrics",
            ),
+           Trino2DuckDBSQLMeshExporter(
+               ["duckdb_metrics"],
+               source_catalog="metrics",
+               source_schema="metrics",
+               destination_catalog="duckdb",
+               destination_schema="metrics",
+           ),
        ]
```
3. Modify the `duck_db` importer variable to use the MotherDuck URI:
```diff
    duckdb_importer = DuckDBImporterResource(
        duckdb=DuckDBResource(
-           database_path=global_config.local_duckdb_path,
+           database_path=global_config.motherduck_conn_uri,
        )
    )
```
