### PR TITLE
fix: SQLMesh `BigQuery` multiple file import

### DIFF
--- a/warehouse/oso_dagster/resources/sqlmesh.py
+++ b/warehouse/oso_dagster/resources/sqlmesh.py
@@ -322,11 +322,15 @@ class DuckDB2BigQuerySQLMeshExporter(SQLMeshExporter):
         self,
         prefix: str | t.List[str],
         *,
+        source_catalog: str,
+        source_schema: str,
         project_id: str,
         dataset_id: str,
         bucket_name: str,
     ):
         self._prefix = prefix
+        self._source_catalog = source_catalog
+        self._source_schema = source_schema
         self._project_id = project_id
         self._dataset_id = dataset_id
         self._bucket_name = bucket_name
@@ -381,8 +385,8 @@ class DuckDB2BigQuerySQLMeshExporter(SQLMeshExporter):
                             Source(
                                 exporter=exporter,
                                 table=TableReference(
-                                    catalog_name="oso",
-                                    schema_name="metrics__dev",
+                                    catalog_name=self._source_catalog,
+                                    schema_name=self._source_schema,
                                     table_name=table_name,
                                 ),
                             ),


### PR DESCRIPTION
This PR modifies the functionality of the SQLMesh BigQuery importer to allow for multiple files in a GCS folder.

It was designed to only allow the absolute bucket path to one file, which has been updated to resolve all `parquet` files and import them.