### PR TITLE
fix: remove `metric` from KeyMetricsBy* models in API

### DIFF
--- a/apps/hasura-clickhouse/oso_subgraph/connector/oso_clickhouse/configuration.json
+++ b/apps/hasura-clickhouse/oso_subgraph/connector/oso_clickhouse/configuration.json
@@ -213,7 +213,6 @@
         "columns": {
           "amount": "Float64",
           "artifact_id": "String",
-          "metric": "String",
           "metric_id": "String",
           "sample_date": "Date",
           "unit": "String"
@@ -229,7 +228,6 @@
         "columns": {
           "amount": "Float64",
           "collection_id": "String",
-          "metric": "String",
           "metric_id": "String",
           "sample_date": "Date",
           "unit": "String"
@@ -244,7 +242,6 @@
         "kind": "definition",
         "columns": {
           "amount": "Float64",
-          "metric": "String",
           "metric_id": "String",
           "project_id": "String",
           "sample_date": "Date",

--- a/apps/hasura-clickhouse/oso_subgraph/metadata/KeyMetricsByArtifactV0.hml
+++ b/apps/hasura-clickhouse/oso_subgraph/metadata/KeyMetricsByArtifactV0.hml
@@ -8,8 +8,6 @@ definition:
       type: Float64!
     - name: artifactId
       type: String!
-    - name: metric
-      type: String!
     - name: metricId
       type: String!
     - name: sampleDate
@@ -29,9 +27,6 @@ definition:
         artifactId:
           column:
             name: artifact_id
-        metric:
-          column:
-            name: metric
         metricId:
           column:
             name: metric_id
@@ -53,7 +48,6 @@ definition:
         allowedFields:
           - amount
           - artifactId
-          - metric
           - metricId
           - sampleDate
           - unit
@@ -62,7 +56,6 @@ definition:
         allowedFields:
           - amount
           - artifactId
-          - metric
           - metricId
           - sampleDate
           - unit
@@ -79,8 +72,6 @@ definition:
         - fieldName: amount
           booleanExpressionType: Float64BoolExp
         - fieldName: artifactId
-          booleanExpressionType: StringBoolExp
-        - fieldName: metric
           booleanExpressionType: StringBoolExp
         - fieldName: metricId
           booleanExpressionType: StringBoolExp
@@ -109,8 +100,6 @@ definition:
           aggregateExpression: Float64AggExp
         - fieldName: artifactId
           aggregateExpression: StringAggExp
-        - fieldName: metric
-          aggregateExpression: StringAggExp
         - fieldName: metricId
           aggregateExpression: StringAggExp
         - fieldName: sampleDate
@@ -134,8 +123,6 @@ definition:
         - fieldName: amount
           orderByExpression: Float64OrderByExp
         - fieldName: artifactId
-          orderByExpression: StringOrderByExp
-        - fieldName: metric
           orderByExpression: StringOrderByExp
         - fieldName: metricId
           orderByExpression: StringOrderByExp

--- a/apps/hasura-clickhouse/oso_subgraph/metadata/KeyMetricsByCollectionV0.hml
+++ b/apps/hasura-clickhouse/oso_subgraph/metadata/KeyMetricsByCollectionV0.hml
@@ -8,8 +8,6 @@ definition:
       type: Float64!
     - name: collectionId
       type: String!
-    - name: metric
-      type: String!
     - name: metricId
       type: String!
     - name: sampleDate
@@ -29,9 +27,6 @@ definition:
         collectionId:
           column:
             name: collection_id
-        metric:
-          column:
-            name: metric
         metricId:
           column:
             name: metric_id
@@ -53,7 +48,6 @@ definition:
         allowedFields:
           - amount
           - collectionId
-          - metric
           - metricId
           - sampleDate
           - unit
@@ -62,7 +56,6 @@ definition:
         allowedFields:
           - amount
           - collectionId
-          - metric
           - metricId
           - sampleDate
           - unit
@@ -79,8 +72,6 @@ definition:
         - fieldName: amount
           booleanExpressionType: Float64BoolExp
         - fieldName: collectionId
-          booleanExpressionType: StringBoolExp
-        - fieldName: metric
           booleanExpressionType: StringBoolExp
         - fieldName: metricId
           booleanExpressionType: StringBoolExp
@@ -109,8 +100,6 @@ definition:
           aggregateExpression: Float64AggExp
         - fieldName: collectionId
           aggregateExpression: StringAggExp
-        - fieldName: metric
-          aggregateExpression: StringAggExp
         - fieldName: metricId
           aggregateExpression: StringAggExp
         - fieldName: sampleDate
@@ -134,8 +123,6 @@ definition:
         - fieldName: amount
           orderByExpression: Float64OrderByExp
         - fieldName: collectionId
-          orderByExpression: StringOrderByExp
-        - fieldName: metric
           orderByExpression: StringOrderByExp
         - fieldName: metricId
           orderByExpression: StringOrderByExp

--- a/apps/hasura-clickhouse/oso_subgraph/metadata/KeyMetricsByProjectV0.hml
+++ b/apps/hasura-clickhouse/oso_subgraph/metadata/KeyMetricsByProjectV0.hml
@@ -6,8 +6,6 @@ definition:
   fields:
     - name: amount
       type: Float64!
-    - name: metric
-      type: String!
     - name: metricId
       type: String!
     - name: projectId
@@ -26,9 +24,6 @@ definition:
         amount:
           column:
             name: amount
-        metric:
-          column:
-            name: metric
         metricId:
           column:
             name: metric_id
@@ -52,7 +47,6 @@ definition:
       output:
         allowedFields:
           - amount
-          - metric
           - metricId
           - projectId
           - sampleDate
@@ -61,7 +55,6 @@ definition:
       output:
         allowedFields:
           - amount
-          - metric
           - metricId
           - projectId
           - sampleDate
@@ -78,8 +71,6 @@ definition:
       comparableFields:
         - fieldName: amount
           booleanExpressionType: Float64BoolExp
-        - fieldName: metric
-          booleanExpressionType: StringBoolExp
         - fieldName: metricId
           booleanExpressionType: StringBoolExp
         - fieldName: projectId
@@ -107,8 +98,6 @@ definition:
       aggregatableFields:
         - fieldName: amount
           aggregateExpression: Float64AggExp
-        - fieldName: metric
-          aggregateExpression: StringAggExp
         - fieldName: metricId
           aggregateExpression: StringAggExp
         - fieldName: projectId
@@ -133,8 +122,6 @@ definition:
       orderableFields:
         - fieldName: amount
           orderByExpression: Float64OrderByExp
-        - fieldName: metric
-          orderByExpression: StringOrderByExp
         - fieldName: metricId
           orderByExpression: StringOrderByExp
         - fieldName: projectId

--- a/apps/hasura-clickhouse/oso_subgraph/metadata/oso_clickhouse.hml
+++ b/apps/hasura-clickhouse/oso_subgraph/metadata/oso_clickhouse.hml
@@ -874,10 +874,6 @@ definition:
               type:
                 type: named
                 name: String
-            metric:
-              type:
-                type: named
-                name: String
             metric_id:
               type:
                 type: named
@@ -901,10 +897,6 @@ definition:
               type:
                 type: named
                 name: String
-            metric:
-              type:
-                type: named
-                name: String
             metric_id:
               type:
                 type: named
@@ -924,10 +916,6 @@ definition:
               type:
                 type: named
                 name: Float64
-            metric:
-              type:
-                type: named
-                name: String
             metric_id:
               type:
                 type: named


### PR DESCRIPTION
* Latest sqlmesh models removed the column.
* This is just the API refresh to reflect that change