### PR TITLE
add: expose `key_metrics` in `metrics_v0`

### DIFF
--- a/warehouse/metrics_mesh/models/intermediate/metrics/int_key_metric_names_from_artifact.sql
+++ b/warehouse/metrics_mesh/models/intermediate/metrics/int_key_metric_names_from_artifact.sql
@@ -1,0 +1,8 @@
+MODEL (
+  name metrics.int_key_metric_names_from_artifact,
+  kind FULL
+);
+
+SELECT DISTINCT
+  metric
+FROM metrics.key_metrics_to_artifact

--- a/warehouse/metrics_mesh/models/intermediate/metrics/int_key_metric_names_from_collection.sql
+++ b/warehouse/metrics_mesh/models/intermediate/metrics/int_key_metric_names_from_collection.sql
@@ -1,0 +1,8 @@
+MODEL (
+  name metrics.int_key_metric_names_from_collection,
+  kind FULL
+);
+
+SELECT DISTINCT
+  metric
+FROM metrics.key_metrics_to_collection

--- a/warehouse/metrics_mesh/models/intermediate/metrics/int_key_metric_names_from_project.sql
+++ b/warehouse/metrics_mesh/models/intermediate/metrics/int_key_metric_names_from_project.sql
@@ -1,0 +1,8 @@
+MODEL (
+  name metrics.int_key_metric_names_from_project,
+  kind FULL
+);
+
+SELECT DISTINCT
+  metric
+FROM metrics.key_metrics_to_project

--- a/warehouse/metrics_mesh/models/marts/metrics/metrics_v0.sql
+++ b/warehouse/metrics_mesh/models/marts/metrics/metrics_v0.sql
@@ -15,6 +15,15 @@ WITH unioned_metric_names AS (
   UNION ALL
   SELECT *
   FROM metrics.int_metric_names_from_collection
+  UNION ALL
+  SELECT *
+  FROM metrics.int_key_metric_names_from_artifact
+  UNION ALL
+  SELECT *
+  FROM metrics.int_key_metric_names_from_project
+  UNION ALL
+  SELECT *
+  FROM metrics.int_key_metric_names_from_collection
 ), all_timeseries_metric_names AS (
   SELECT DISTINCT
     metric


### PR DESCRIPTION
This PR closes #3052 by adding the missing metrics to `metrics_v0`. Populating description/display_name etc is being tracked on #3055.

<img width="1623" alt="image" src="https://github.com/user-attachments/assets/dc52a2b9-4374-4e73-9b45-0fe28ef46c1a" />
