### PR TITLE
fix: use `async` config instead of `sync` resources

### DIFF
--- a/warehouse/oso_dagster/utils/http.py
+++ b/warehouse/oso_dagster/utils/http.py
@@ -66,7 +66,7 @@ def get_sync_http_cache_storage(cache_uri: str) -> hishel.BaseStorage:
 def get_async_http_cache_storage(cache_uri: str) -> hishel.AsyncBaseStorage:
     parsed_uri = urlparse(cache_uri)
 
-    factory = FACTORIES["sync"][parsed_uri.scheme]
+    factory = FACTORIES["async"][parsed_uri.scheme]
     return cast(hishel.AsyncBaseStorage, factory(parsed_uri))
 
 


### PR DESCRIPTION
This PR fixes the fact that the `async` transport was configured to use the `sync` resources, probably a typo! It caused assets requiring `async` transports to fail.

```
TypeError: Expected subclass of `AsyncBaseStorage` but got `RedisStorage`
  File "/usr/local/lib/python3.12/dist-packages/dlt/extract/utils.py", line 212, in run
    item = await gen.__anext__()
           ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/app/warehouse/oso_dagster/utils/dlt.py", line 97, in _wrapper
    await future for future in asyncio.as_completed(group_coroutines)
    ^^^^^^^^^^^^
  File "/usr/lib/python3.12/asyncio/tasks.py", line 631, in _wait_for_one
    return f.result()  # May raise f.exception().
           ^^^^^^^^^^
  File "/usr/src/app/warehouse/oso_dagster/dlt_sources/github_repos/__init__.py", line 288, in get_sbom_for_repo
    sbom = await self._gh.rest.dependency_graph.async_export_sbom(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/githubkit/versions/v2022_11_28/rest/dependency_graph.py", line 169, in async_export_sbom
    return await self._github.arequest(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/githubkit/core.py", line 571, in arequest
    raw_resp = await self._arequest(
               ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/githubkit/core.py", line 314, in _arequest
    self.get_async_client() as client,
    ^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/contextlib.py", line 210, in __aenter__
    return await anext(self.gen)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/githubkit/core.py", line 259, in get_async_client
    client = self._create_async_client()
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/app/warehouse/oso_dagster/dlt_sources/github_repos/__init__.py", line 120, in _create_async_client
    transport = hishel.AsyncCacheTransport(
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/hishel/_async/_transports.py", line 68, in __init__
    raise TypeError(f"Expected subclass of `AsyncBaseStorage` but got `{storage.__class__.__name__}`")
```