### PR TITLE
fix: filter out `none` coroutines

### DIFF
--- a/warehouse/oso_dagster/utils/dlt.py
+++ b/warehouse/oso_dagster/utils/dlt.py
@@ -83,7 +83,9 @@ def dlt_parallelize(config: ParallelizeConfig):
             log = context.log if context else logger
 
             tasks: List[Coroutine[Any, Any, R]] = [
-                task() for task in fn(*args, **kwargs)
+                coro
+                for coro in (task() for task in fn(*args, **kwargs))
+                if coro is not None
             ]
             batches_list = list(batched(tasks, config.chunk_size))
 


### PR DESCRIPTION
githubkit yields `None` values for the coroutines (sboms that fail), we need to filter these out since we cannot `await` None values.