### PR TITLE
Add partitioning to metrics timeseries tables

### DIFF
--- a/warehouse/metrics_mesh/models/marts/metrics/key_metrics_by_artifact_v0.sql
+++ b/warehouse/metrics_mesh/models/marts/metrics/key_metrics_by_artifact_v0.sql
@@ -1,7 +1,7 @@
 MODEL (
   name metrics.key_metrics_by_artifact_v0,
   kind FULL,
-  partitioned_by 'sample_date',
+  partitioned_by sample_date,
   tags (
   'export'
   ),

--- a/warehouse/metrics_mesh/models/marts/metrics/key_metrics_by_artifact_v0.sql
+++ b/warehouse/metrics_mesh/models/marts/metrics/key_metrics_by_artifact_v0.sql
@@ -1,6 +1,7 @@
 MODEL (
   name metrics.key_metrics_by_artifact_v0,
   kind FULL,
+  partitioned_by 'sample_date',
   tags (
   'export'
   ),

--- a/warehouse/metrics_mesh/models/marts/metrics/key_metrics_by_collection_v0.sql
+++ b/warehouse/metrics_mesh/models/marts/metrics/key_metrics_by_collection_v0.sql
@@ -1,7 +1,7 @@
 MODEL (
   name metrics.key_metrics_by_collection_v0,
   kind FULL,
-  partitioned_by 'sample_date',
+  partitioned_by sample_date,
   tags (
   'export'
   ),

--- a/warehouse/metrics_mesh/models/marts/metrics/key_metrics_by_collection_v0.sql
+++ b/warehouse/metrics_mesh/models/marts/metrics/key_metrics_by_collection_v0.sql
@@ -1,6 +1,7 @@
 MODEL (
   name metrics.key_metrics_by_collection_v0,
   kind FULL,
+  partitioned_by 'sample_date',
   tags (
   'export'
   ),

--- a/warehouse/metrics_mesh/models/marts/metrics/key_metrics_by_project_v0.sql
+++ b/warehouse/metrics_mesh/models/marts/metrics/key_metrics_by_project_v0.sql
@@ -1,6 +1,7 @@
 MODEL (
   name metrics.key_metrics_by_project_v0,
   kind FULL,
+  partitioned_by 'sample_date',
   tags (
   'export'
   ),

--- a/warehouse/metrics_mesh/models/marts/metrics/key_metrics_by_project_v0.sql
+++ b/warehouse/metrics_mesh/models/marts/metrics/key_metrics_by_project_v0.sql
@@ -1,7 +1,7 @@
 MODEL (
   name metrics.key_metrics_by_project_v0,
   kind FULL,
-  partitioned_by 'sample_date',
+  partitioned_by sample_date,
   tags (
   'export'
   ),

--- a/warehouse/metrics_mesh/models/marts/metrics/timeseries_metrics_by_artifact_v0.sql
+++ b/warehouse/metrics_mesh/models/marts/metrics/timeseries_metrics_by_artifact_v0.sql
@@ -1,7 +1,7 @@
 MODEL (
   name metrics.timeseries_metrics_by_artifact_v0,
   kind FULL,
-  partitioned_by 'sample_date',
+  partitioned_by sample_date,
   tags (
     'export'
   )

--- a/warehouse/metrics_mesh/models/marts/metrics/timeseries_metrics_by_artifact_v0.sql
+++ b/warehouse/metrics_mesh/models/marts/metrics/timeseries_metrics_by_artifact_v0.sql
@@ -1,6 +1,7 @@
 MODEL (
   name metrics.timeseries_metrics_by_artifact_v0,
   kind FULL,
+  partitioned_by 'sample_date',
   tags (
     'export'
   )

--- a/warehouse/metrics_mesh/models/marts/metrics/timeseries_metrics_by_collection_v0.sql
+++ b/warehouse/metrics_mesh/models/marts/metrics/timeseries_metrics_by_collection_v0.sql
@@ -1,6 +1,7 @@
 MODEL (
   name metrics.timeseries_metrics_by_collection_v0,
   kind FULL,
+  partitioned_by 'sample_date',
   tags (
     'export'
   )

--- a/warehouse/metrics_mesh/models/marts/metrics/timeseries_metrics_by_collection_v0.sql
+++ b/warehouse/metrics_mesh/models/marts/metrics/timeseries_metrics_by_collection_v0.sql
@@ -1,7 +1,7 @@
 MODEL (
   name metrics.timeseries_metrics_by_collection_v0,
   kind FULL,
-  partitioned_by 'sample_date',
+  partitioned_by sample_date,
   tags (
     'export'
   )

--- a/warehouse/metrics_mesh/models/marts/metrics/timeseries_metrics_by_project_v0.sql
+++ b/warehouse/metrics_mesh/models/marts/metrics/timeseries_metrics_by_project_v0.sql
@@ -1,7 +1,7 @@
 MODEL (
   name metrics.timeseries_metrics_by_project_v0,
   kind FULL,
-  partitioned_by 'sample_date',
+  partitioned_by sample_date,
   tags (
     'export'
   )

--- a/warehouse/metrics_mesh/models/marts/metrics/timeseries_metrics_by_project_v0.sql
+++ b/warehouse/metrics_mesh/models/marts/metrics/timeseries_metrics_by_project_v0.sql
@@ -1,6 +1,7 @@
 MODEL (
   name metrics.timeseries_metrics_by_project_v0,
   kind FULL,
+  partitioned_by 'sample_date',
   tags (
     'export'
   )


### PR DESCRIPTION
This should improve DX (speed and costs) when tinkering with these tables as an user, specially on the `artifact` level.

I didn't include `cluster_by` in the PR as that might affect random queries' performance. I think this is something that could be added once query patterns are clear!