### PR TITLE
fix: hide internal `process` functions for `dlt_parallelize`

### DIFF
--- a/warehouse/oso_dagster/dlt_sources/github_repos/__init__.py
+++ b/warehouse/oso_dagster/dlt_sources/github_repos/__init__.py
@@ -411,10 +411,6 @@ def oss_directory_github_sbom_resource(
     rate_limit_max_retry: int = 5,
     server_error_max_rety: int = 3,
     http_cache: t.Optional[str] = None,
-    _chunk_resource_update: t.Optional[t.Callable[..., None]] = None,
-    _chunk_retrieve_failed: t.Optional[
-        t.Callable[[], t.Generator[t.Any, None, None]]
-    ] = None,
 ):
     """Retrieve SBOM information for GitHub repositories"""
 


### PR DESCRIPTION
This PR makes providing `_chunk_resource_update` and `_chunk_retrieve_failed` less verbose and hides them when using `dlt_parallelize`, so that the consumer doesn't have to declare them in the function signature. It also adds comments and examples to the `process_chunked_resource` function, with explanations of the current tweaks.