### PR TITLE
fix: filter metadata table names `correctly`

### DIFF
--- a/warehouse/metrics_tools/factory/proxy/proxies.py
+++ b/warehouse/metrics_tools/factory/proxy/proxies.py
@@ -159,7 +159,7 @@ def aggregate_metadata(
 
     pattern = re.compile(r"^[^.]+\.[^.]+\.[^.]+$")
 
-    def is_valid_metadata_table(model_name):
+    def is_valid_metadata_table(model_name: str):
         return pattern.match(model_name) and model_name.split(".")[2].strip(
             '"'
         ).startswith("metrics_metadata_")


### PR DESCRIPTION
Previously we filtered metadata table names in a hardcoded manner, making an assumption about the source catalog name. This caused production to fail. This PR addresses that problem by computing the metadata table name dynamically. Closes #3114 