### PR TITLE
fix: increase trino `stage` limit temporarily

### DIFF
--- a/warehouse/metrics_mesh/models/marts/metrics/metrics_v0.sql
+++ b/warehouse/metrics_mesh/models/marts/metrics/metrics_v0.sql
@@ -1,10 +1,16 @@
 MODEL (
   name metrics.metrics_v0,
   kind FULL,
+  dialect trino,
   tags (
     'export'
   )
 );
+
+@DEF(MAX_STAGE_OVERRIDE, 550);
+
+-- TODO(jabolo): Remove Trino session logic once #3117 lands
+SET SESSION query_max_stage_count = @MAX_STAGE_OVERRIDE;
 
 WITH unioned_metric_names AS (
   SELECT *
@@ -58,4 +64,6 @@ SELECT
   raw_definition::TEXT,
   definition_ref::TEXT,
   aggregation_function::TEXT
-FROM metrics_v0_no_casting
+FROM metrics_v0_no_casting;
+
+RESET SESSION query_max_stage_count;


### PR DESCRIPTION
This PR increases Trino's stage limit temporarily. This should be reverted once #3117 lands.