### PR TITLE
fix: trino metadata `performance` issues

### DIFF
--- a/warehouse/metrics_mesh/models/marts/metrics/metrics_v0.sql
+++ b/warehouse/metrics_mesh/models/marts/metrics/metrics_v0.sql
@@ -7,14 +7,6 @@ MODEL (
   )
 );
 
-@DEF(MAX_STAGE_OVERRIDE, 550);
-
--- TODO(jabolo): Remove Trino session logic once #3117 lands
-@IF(
-  @OR(@gateway = 'trino', @gateway = 'local-trino'),
-  SET SESSION query_max_stage_count = @MAX_STAGE_OVERRIDE
-);
-
 WITH unioned_metric_names AS (
   SELECT *
   FROM metrics.int_metric_names_from_artifact
@@ -55,7 +47,7 @@ WITH unioned_metric_names AS (
     'TODO' AS definition_ref,
     'UNKNOWN' AS aggregation_function
   FROM all_timeseries_metric_names t
-  LEFT JOIN all_metrics_metadata m ON t.metric = m.metric
+  LEFT JOIN all_metrics_metadata m ON t.metric LIKE '%' || m.metric || '%'
 )
 SELECT
   metric_id::TEXT,
@@ -68,9 +60,3 @@ SELECT
   definition_ref::TEXT,
   aggregation_function::TEXT
 FROM metrics_v0_no_casting;
-
--- TODO(jabolo): Remove Trino session logic once #3117 lands
-@IF(
-  @OR(@gateway = 'trino', @gateway = 'local-trino'),
-  RESET SESSION query_max_stage_count
-);

--- a/warehouse/metrics_tools/factory/proxy/proxies.py
+++ b/warehouse/metrics_tools/factory/proxy/proxies.py
@@ -114,31 +114,16 @@ def join_all_of_entity_type(
 def map_metadata_to_metric(
     evaluator: MacroEvaluator,
 ):
-    db = t.cast(str, evaluator.var("db"))
-    table = t.cast(str, evaluator.var("table"))
+    metric = t.cast(str, evaluator.var("metric"))
     metadata = t.cast(t.Dict[str, t.Any], evaluator.var("metadata"))
 
     description = metadata["description"]
     display_name = metadata["display_name"]
 
-    metrics_alias = exp.Concat(
-        expressions=[
-            exp.to_column("event_source"),
-            exp.Literal(this="_", is_string=True),
-            exp.to_column("metric"),
-        ],
-        safe=False,
-        coalesce=False,
-    ).as_("metric")
-
-    return (
-        exp.select(
-            exp.Literal(this=display_name, is_string=True).as_("display_name"),
-            exp.Literal(this=description, is_string=True).as_("description"),
-            metrics_alias,
-        )
-        .from_(sql.to_table(f"{db}.{table}"))
-        .distinct()
+    return exp.select(
+        exp.Literal(this=display_name, is_string=True).as_("display_name"),
+        exp.Literal(this=description, is_string=True).as_("description"),
+        exp.Literal(this=metric, is_string=True).as_("metric"),
     )
 
 


### PR DESCRIPTION
This PR updates the way in which we generate metadata to make it more performant. Instead of creating one table for each rendered query (`timeseries`/`rolling`/`key metrics` etc.), we generate one intermediate metadata table per metric factory definition (e.g. stars, commits which will _later_ expand downstream to `timeseries`/`rolling`/`key metrics` stars, commits etc.). These are joined downstream on `metrics_v0` joining on `%` + `metric` + `%`, since metrics are in the form of `event_source` + `metric` + `suffix`.

This will **finally** allow us to set metadata in the metric factory which the frontend will consume easily, for a better UX. Related to #3117.