### PR TITLE
Chore: remove CPU limits for dagster pods and change memory limit/requests

### DIFF
--- a/ops/k8s-apps/production/dagster/custom-helm-values.yaml
+++ b/ops/k8s-apps/production/dagster/custom-helm-values.yaml
@@ -36,7 +36,6 @@ spec:
             value: "1"
         resources:
           limits:
-            cpu: 1000m
             memory: 768Mi
           requests:
             cpu: 500m
@@ -48,7 +47,6 @@ spec:
             value: "1"
         resources:
           limits:
-            cpu: 1000m
             memory: 768Mi
           requests:
             cpu: 500m
@@ -69,10 +67,9 @@ spec:
               containerConfig:
                 resources:
                   limits:
-                    cpu: 1000m
                     memory: 2048Mi
                   requests:
-                    cpu: 500m
+                    cpu: 700m
                     memory: 1024Mi
         
     sqlmesh:

--- a/warehouse/oso_dagster/assets/clickhouse_dbt_marts.py
+++ b/warehouse/oso_dagster/assets/clickhouse_dbt_marts.py
@@ -107,7 +107,6 @@ def all_clickhouse_dbt_mart_assets(
                                                 "memory": "1536Mi",
                                             },
                                             "limits": {
-                                                "cpu": "1000m",
                                                 "memory": "1536Mi",
                                             },
                                         },

--- a/warehouse/oso_dagster/assets/eas_optimism.py
+++ b/warehouse/oso_dagster/assets/eas_optimism.py
@@ -65,7 +65,7 @@ K8S_CONFIG = {
     "container_config": {
         "resources": {
             "requests": {"cpu": "2000m", "memory": "3584Mi"},
-            "limits": {"cpu": "2000m", "memory": "3584Mi"},
+            "limits": {"memory": "3584Mi"},
         },
     },
     "pod_spec_config": {

--- a/warehouse/oso_dagster/assets/open_collective.py
+++ b/warehouse/oso_dagster/assets/open_collective.py
@@ -209,7 +209,7 @@ K8S_CONFIG = {
     "container_config": {
         "resources": {
             "requests": {"cpu": "2000m", "memory": "3584Mi"},
-            "limits": {"cpu": "2000m", "memory": "3584Mi"},
+            "limits": {"memory": "3584Mi"},
         },
     },
     "pod_spec_config": {

--- a/warehouse/oso_dagster/factories/alerts.py
+++ b/warehouse/oso_dagster/factories/alerts.py
@@ -31,10 +31,10 @@ ALERTS_JOB_CONFIG = {
             "resources": {
                 "requests": {
                     "cpu": "500m",
-                    "memory": "768Mi",
+                    "memory": "1024Mi",
                 },
                 "limits": {
-                    "memory": "1536Mi",
+                    "memory": "2048Mi",
                 },
             },
         },

--- a/warehouse/oso_dagster/factories/alerts.py
+++ b/warehouse/oso_dagster/factories/alerts.py
@@ -34,7 +34,6 @@ ALERTS_JOB_CONFIG = {
                     "memory": "768Mi",
                 },
                 "limits": {
-                    "cpu": "500m",
                     "memory": "1536Mi",
                 },
             },

--- a/warehouse/oso_dagster/factories/goldsky/assets.py
+++ b/warehouse/oso_dagster/factories/goldsky/assets.py
@@ -1082,7 +1082,7 @@ def goldsky_asset(
             "container_config": {
                 "resources": {
                     "requests": {"cpu": "2000m", "memory": "3584Mi"},
-                    "limits": {"cpu": "2000m", "memory": "3584Mi"},
+                    "limits": {"memory": "3584Mi"},
                 },
             },
             "pod_spec_config": {


### PR DESCRIPTION
Removed CPU limits for dagster pods.

Changed memory limit/requests for the alerts jobs because it was constantly failing with `OOMKilled`. Might need to investigate why it started happening, by guess it is related to the changes in the dagster definitions.