### PR TITLE
fix: use updated 4337 source models

### DIFF
--- a/apps/docs/docs/integrate/datasets/index.mdx
+++ b/apps/docs/docs/integrate/datasets/index.mdx
@@ -491,7 +491,7 @@ For example, to get all transactions to the 4337 EntryPoint contracts for all OP
   color={"blue"}
   target={"_blank"}
   link={
-    "https://console.cloud.google.com/bigquery/analytics-hub/exchanges/projects/87806073973/locations/us/dataExchanges/open_source_observer_190181416ae/listings/superchain_4337_account_abstraction_data"
+    "https://bit.ly/superchain-4337"
   }
   children={"Subscribe on BigQuery"}
 />{" "}
@@ -507,7 +507,7 @@ select
   chain,
   paymaster,
   approx_count_distinct(userophash) as user_ops
-from `optimism_superchain_4337_account_abstraction_data.useroperationevent_logs_v1`
+from `optimism_superchain_4337_account_abstraction_data.useroperationevent_logs_v2`
 where dt > '2025-02-01'
 group by 1,2
 order by 3 desc

--- a/warehouse/metrics_tools/local/utils.py
+++ b/warehouse/metrics_tools/local/utils.py
@@ -62,19 +62,19 @@ TABLE_MAPPING: TableMappingConfig = {
         ),
         table="bigquery.optimism_superchain_raw_onchain_data.traces",
     ),
-    "opensource-observer.optimism_superchain_4337_account_abstraction_data.useroperationevent_logs_v1": TableMappingDestination(
+    "opensource-observer.optimism_superchain_4337_account_abstraction_data.useroperationevent_logs_v2": TableMappingDestination(
         row_restriction=RowRestriction(
             time_column="dt",
             wheres=["chain_id = 252"],
         ),
-        table="bigquery.optimism_superchain_4337_account_abstraction_data.useroperationevent_logs_v1",
+        table="bigquery.optimism_superchain_4337_account_abstraction_data.useroperationevent_logs_v2",
     ),
-    "opensource-observer.optimism_superchain_4337_account_abstraction_data.enriched_entrypoint_traces_v1": TableMappingDestination(
+    "opensource-observer.optimism_superchain_4337_account_abstraction_data.enriched_entrypoint_traces_v2": TableMappingDestination(
         row_restriction=RowRestriction(
             time_column="dt",
             wheres=["chain_id = 252"],
         ),
-        table="bigquery.optimism_superchain_4337_account_abstraction_data.enriched_entrypoint_traces_v1",
+        table="bigquery.optimism_superchain_4337_account_abstraction_data.enriched_entrypoint_traces_v2"
     ),
 }
 

--- a/warehouse/oso_sqlmesh/models/staging/superchain/stg_superchain__4337_traces.sql
+++ b/warehouse/oso_sqlmesh/models/staging/superchain/stg_superchain__4337_traces.sql
@@ -16,27 +16,33 @@ MODEL (
     userop_hash,
     from_address,
     to_address,
-    sender_address,
-    paymaster_address,
+    bundler_address,
+    userop_paymaster,
     method_id
   )
 );
 
 SELECT
+  @chain_name(chain) AS chain,
   @from_unix_timestamp(block_timestamp) AS block_timestamp,
   transaction_hash,
   userop_hash,
+  method_id,
   from_address,
   to_address,
-  userop_sender AS sender_address,
+  bundler_address AS bundler_address,
   userop_paymaster AS paymaster_address,
   useropevent_actualgascost::BIGINT AS userop_gas_price,
   useropevent_actualgasused::BIGINT AS userop_gas_used,
-  value::BIGINT AS value,
-  method_id,
-  @chain_name(chain) AS chain
+  CASE 
+    WHEN input != '0x' THEN 0
+    ELSE CAST(
+      ('0x' || SUBSTRING(userop_calldata, 75, 64))::DECIMAL(38,0) / 1e18 
+      AS DECIMAL(38,18)
+    )
+  END AS value
 FROM @oso_source(
-  'bigquery.optimism_superchain_4337_account_abstraction_data.enriched_entrypoint_traces_v1'
+  'bigquery.optimism_superchain_4337_account_abstraction_data.enriched_entrypoint_traces_v2'
 )
 WHERE
   network = 'mainnet'
@@ -44,4 +50,6 @@ WHERE
   AND trace_type IN ('call', 'create', 'create2')
   AND call_type <> 'staticcall'
   AND useropevent_success = TRUE
+  AND is_from_sender = TRUE
+  AND userop_idx = 1
   AND /* Bigquery requires we specify partitions to filter for this data source */ dt BETWEEN @start_dt AND @end_dt

--- a/warehouse/oso_sqlmesh/models/staging/superchain/stg_superchain__4337_traces.sql
+++ b/warehouse/oso_sqlmesh/models/staging/superchain/stg_superchain__4337_traces.sql
@@ -34,13 +34,12 @@ SELECT
   userop_paymaster AS paymaster_address,
   useropevent_actualgascost::BIGINT AS userop_gas_price,
   useropevent_actualgasused::BIGINT AS userop_gas_used,
-  CASE 
-    WHEN input != '0x' THEN 0
-    ELSE CAST(
-      ('0x' || SUBSTRING(userop_calldata, 75, 64))::DECIMAL(38,0) / 1e18 
-      AS DECIMAL(38,18)
-    )
-  END AS value
+  CAST(
+    CASE WHEN input != '0x' 
+      THEN 0 
+      ELSE CAST(CONCAT('0x', SUBSTRING(userop_calldata, 75, 64)) AS DECIMAL(38,0)) / CAST(1e18 AS DECIMAL(38,18))
+    END AS DECIMAL(38,18)
+  ) AS value
 FROM @oso_source(
   'bigquery.optimism_superchain_4337_account_abstraction_data.enriched_entrypoint_traces_v2'
 )

--- a/warehouse/oso_sqlmesh/models/staging/superchain/stg_superchain__4337_userop_logs.sql
+++ b/warehouse/oso_sqlmesh/models/staging/superchain/stg_superchain__4337_userop_logs.sql
@@ -23,6 +23,7 @@ MODEL (
 SELECT
   @from_unix_timestamp(block_timestamp) AS block_timestamp,
   transaction_hash,
+  log_index,
   userophash AS userop_hash,
   sender AS sender_address,
   paymaster AS paymaster_address,
@@ -31,7 +32,7 @@ SELECT
   actualgasused::DECIMAL(38, 0) AS userop_gas_used,
   @chain_name(chain) AS chain
 FROM @oso_source(
-  'bigquery.optimism_superchain_4337_account_abstraction_data.useroperationevent_logs_v1'
+  'bigquery.optimism_superchain_4337_account_abstraction_data.useroperationevent_logs_v2'
 )
 WHERE
   network = 'mainnet'

--- a/warehouse/oso_sqlmesh/models/staging/superchain/stg_superchain__4337_userop_logs.sql
+++ b/warehouse/oso_sqlmesh/models/staging/superchain/stg_superchain__4337_userop_logs.sql
@@ -28,8 +28,8 @@ SELECT
   sender AS sender_address,
   paymaster AS paymaster_address,
   contract_address,
-  actualgascost::DECIMAL(38, 0) AS userop_gas_price,
-  actualgasused::DECIMAL(38, 0) AS userop_gas_used,
+  actualgascost::BIGINT AS userop_gas_price,
+  actualgasused::BIGINT AS userop_gas_used,
   @chain_name(chain) AS chain
 FROM @oso_source(
   'bigquery.optimism_superchain_4337_account_abstraction_data.useroperationevent_logs_v2'


### PR DESCRIPTION
@ravenac95 this PR includes the following changes:

- increments the sources in utils.py to v2
- updates the source in the logs staging model
- updates the source in the enriched traces model AND implements [Kofi's logic](https://github.com/Jam516/superchain-4337/blob/main/models/userops/superchain_4337_userops.sql)

The key thing to review for dialect compatibility is this field. Kofi had it as:

```
case WHEN input != '0x' THEN 0
    else SAFE.PARSE_NUMERIC('0x' || SUBSTRING(userop_calldata, 75, 64))/1e18 
    end as value
```

and my implementation is:

```
CAST(
    CASE WHEN input != '0x' 
      THEN 0 
      ELSE CAST(CONCAT('0x', SUBSTRING(userop_calldata, 75, 64)) AS DECIMAL(38,0)) / CAST(1e18 AS DECIMAL(38,18))
    END AS DECIMAL(38,18)
  ) AS value
```