### PR TITLE
add: increase `k8s` resources limits

### DIFF
--- a/warehouse/oso_dagster/assets/eas_optimism.py
+++ b/warehouse/oso_dagster/assets/eas_optimism.py
@@ -65,7 +65,7 @@ K8S_CONFIG = {
     "container_config": {
         "resources": {
             "requests": {"cpu": "2000m", "memory": "3584Mi"},
-            "limits": {"memory": "3584Mi"},
+            "limits": {"memory": "7168Mi"},
         },
     },
     "pod_spec_config": {

--- a/warehouse/oso_dagster/assets/open_collective.py
+++ b/warehouse/oso_dagster/assets/open_collective.py
@@ -209,7 +209,7 @@ K8S_CONFIG = {
     "container_config": {
         "resources": {
             "requests": {"cpu": "2000m", "memory": "3584Mi"},
-            "limits": {"memory": "3584Mi"},
+            "limits": {"memory": "7168Mi"},
         },
     },
     "pod_spec_config": {


### PR DESCRIPTION
OpenCollective and EAS jobs have been getting `OOMKilled` errors. This PR addresses this by giving them a higher limit.