### PR TITLE
feat: improve dlt `chunked` resource robustness

### DIFF
--- a/warehouse/oso_dagster/assets/ossd.py
+++ b/warehouse/oso_dagster/assets/ossd.py
@@ -215,7 +215,7 @@ def repositories(
             f"Fetching repositories for {len(valid_urls)} unique GitHub URLs"
         )
 
-        return valid_urls[:320]
+        return valid_urls
 
     return process_chunked_resource(
         ChunkedResourceConfig(

--- a/warehouse/oso_dagster/definitions.py
+++ b/warehouse/oso_dagster/definitions.py
@@ -50,6 +50,7 @@ from .utils import (
     GCPSecretResolver,
     LocalSecretResolver,
     LogAlertManager,
+    setup_chunked_state_cleanup_sensor,
 )
 
 logger = logging.getLogger(__name__)
@@ -240,6 +241,12 @@ def load_definitions():
     )
 
     asset_factories = asset_factories + alerts
+
+    chunked_state_cleanup_sensor = setup_chunked_state_cleanup_sensor(
+        global_config.gcs_bucket,
+    )
+
+    asset_factories = asset_factories + chunked_state_cleanup_sensor
 
     all_schedules = schedules + get_partitioned_schedules(asset_factories)
 


### PR DESCRIPTION
This PR closes #3352 by splitting the `process_chunked_resource` steps into two separate processes. Now, the main process acts as a wrapper that handles error recovery and state management in GCS. The new addition is a sensor that automatically deletes outdated files from previous runs after a **48-hour grace period** to keep storage clean.  

It also adds a custom retry policy for `ossd` assets, since spot instances need more retries than the default limit of **3**.  

On top of that, there are some performance improvements like replacing `to_string_fn` with `to_serializable_fn`, which removes an extra layer of indirection, reduces storage usage, and speeds things up.