### PR TITLE
fix: set a key when enumerating default search results in

### DIFF
--- a/apps/frontend/components/widgets/algolia.tsx
+++ b/apps/frontend/components/widgets/algolia.tsx
@@ -54,8 +54,8 @@ function HitsContainer(props: AlgoliaSearchListProps) {
   return (
     <div>
       {isResultsReady &&
-        displayItems.map((hit: any) => (
-          <div key={hit.objectID}>
+        displayItems.map((hit: any, i: number) => (
+          <div key={hit.objectID ?? i}>
             <DataProvider name={PLASMIC_KEY} data={hit}>
               {children}
             </DataProvider>


### PR DESCRIPTION
AlgoliaSearchList

* Previously we wouldn't have a key for the repeated item, which leads to a React warning