### PR TITLE
fix: use correct `defillama` tvl dataset name

### DIFF
--- a/warehouse/oso_dagster/assets/defillama.py
+++ b/warehouse/oso_dagster/assets/defillama.py
@@ -328,7 +328,7 @@ def mk_defillama_config() -> RESTAPIConfig:
             "write_disposition": "replace",
             "parallelized": True,
             "max_table_nesting": 0,
-            "table_name": "defillama/tvl",
+            "table_name": "tvl",
         },
         "resources": [
             {


### PR DESCRIPTION
This PR fixes the `defillama/tvl` asset which had an incorrect name (thanks for pointing it out Carl!).