### PR TITLE
fix: remove github and blockchain events from `oso initialize`

### DIFF
--- a/warehouse/metrics_tools/local/utils.py
+++ b/warehouse/metrics_tools/local/utils.py
@@ -1,6 +1,7 @@
 import logging
 
 import duckdb
+
 from .config import RowRestriction, TableMappingConfig, TableMappingDestination
 
 logger = logging.getLogger(__name__)
@@ -31,8 +32,6 @@ TABLE_MAPPING: TableMappingConfig = {
     ### TODO start: remove oso_playground dependency
     "opensource-observer.oso_playground.stg_deps_dev__dependencies": "bigquery.oso.stg_deps_dev__dependencies",
     "opensource-observer.oso_playground.stg_deps_dev__packages": "bigquery.oso.stg_deps_dev__packages",
-    "opensource-observer.oso_playground.stg_github__events": "bigquery.oso.stg_github__events",
-    "opensource-observer.oso_playground.int_events__blockchain": "bigquery.oso.int_events__blockchain",
     ### TODO end
     "opensource-observer.ossd.collections": "bigquery.ossd.collections",
     "opensource-observer.ossd.projects": "bigquery.ossd.projects",


### PR DESCRIPTION
* We are indexing the universe already in sqlmesh/Trino, so no need to pull this data from dbt