### PR TITLE
feat: `oso` web model `reference` tables

### DIFF
--- a/warehouse/docker/trino/seed/sqlmesh.sql
+++ b/warehouse/docker/trino/seed/sqlmesh.sql
@@ -1,0 +1,54 @@
+CREATE SCHEMA IF NOT EXISTS bigquery.sqlmesh;
+
+CREATE TABLE IF NOT EXISTS bigquery.sqlmesh.rendered_models (
+    model_name varchar,
+    rendered_sql varchar,
+    rendered_at timestamp(6) with time zone,
+    _dlt_load_id varchar,
+    _dlt_id varchar
+);
+
+INSERT INTO
+    bigquery.sqlmesh.rendered_models (
+        model_name,
+        rendered_sql,
+        rendered_at,
+        _dlt_load_id,
+        _dlt_id
+    )
+VALUES
+    (
+        'stg_github__distinct_main_commits',
+        'WITH "deduped_commits" AS (SELECT * FROM github_commits WHERE 1=1)',
+        TIMESTAMP '2025-03-27 22:03:29.163110 UTC',
+        '1743109399.194649',
+        'aSe/ejttoOfiGA'
+    ),
+    (
+        'int_all_artifacts',
+        'WITH "onchain_artifacts" AS (SELECT * FROM deployers WHERE 1=1)',
+        TIMESTAMP '2025-03-27 22:03:34.629756 UTC',
+        '1743109399.194649',
+        'OU72RpbQ0bJgAQ'
+    ),
+    (
+        'int_contracts_transactions_weekly',
+        'SELECT DATE_TRUNC(''WEEK'', "traces"."dt") AS "week" FROM traces WHERE 1=1',
+        TIMESTAMP '2025-03-27 22:03:33.118413 UTC',
+        '1743109399.194649',
+        'z66vGMH5WnmO/g'
+    ),
+    (
+        'int_derived_contracts_sort_weights',
+        'SELECT UPPER("derived_contracts"."chain") FROM derived_contracts WHERE 1=1',
+        TIMESTAMP '2025-03-27 22:03:32.967688 UTC',
+        '1743109399.194649',
+        'GY6hZ5Ir6NhESw'
+    ),
+    (
+        'int_superchain_s7_onchain_metrics_by_project',
+        'WITH "base_events" AS (SELECT * FROM events WHERE 1=1)',
+        TIMESTAMP '2025-03-27 22:03:38.551416 UTC',
+        '1743109399.194649',
+        'WjrTD49+rmJhkA'
+    );

--- a/warehouse/metrics_tools/factory/constants.py
+++ b/warehouse/metrics_tools/factory/constants.py
@@ -38,4 +38,6 @@ METRIC_METADATA_COLUMNS: t.Dict[str, exp.DataType] = {
     "display_name": exp.DataType.build("STRING", dialect="duckdb"),
     "description": exp.DataType.build("STRING", dialect="duckdb"),
     "metric": exp.DataType.build("STRING", dialect="duckdb"),
+    "sql_source_path": exp.DataType.build("STRING", dialect="duckdb"),
+    "rendered_sql": exp.DataType.build("STRING[]", dialect="duckdb"),
 }

--- a/warehouse/metrics_tools/factory/factory.py
+++ b/warehouse/metrics_tools/factory/factory.py
@@ -424,6 +424,16 @@ class TimeseriesMetrics:
                 locals={
                     "metric": metric_key,
                     "metadata": asdict(metric_value.metadata),
+                    "sql_source_path": metric_value.ref,
+                    "rendered_sql": [
+                        query_data["rendered_query"].sql(
+                            dialect="presto",
+                            pretty=True,
+                            normalize=True,
+                        )
+                        for query_name, query_data in self._rendered_queries.items()
+                        if query_name.startswith(metric_key)
+                    ],
                 },
                 name=f"oso.metrics_metadata_{metric_key}",
                 is_sql=True,

--- a/warehouse/metrics_tools/local/utils.py
+++ b/warehouse/metrics_tools/local/utils.py
@@ -75,6 +75,7 @@ TABLE_MAPPING: TableMappingConfig = {
         table="bigquery.optimism_superchain_4337_account_abstraction_data.enriched_entrypoint_traces_v2",
     ),
     "opensource-observer.defillama.tvl_events": "bigquery.defillama.tvl_events",
+    "opensource-observer.sqlmesh.rendered_models": "bigquery.sqlmesh.rendered_models",
 }
 
 

--- a/warehouse/oso_dagster/assets/sqlmesh_render.py
+++ b/warehouse/oso_dagster/assets/sqlmesh_render.py
@@ -1,0 +1,91 @@
+from datetime import datetime
+
+import dlt
+import sqlglot as sql
+from dagster import AssetExecutionContext
+from dagster_sqlmesh import SQLMeshResource
+from sqlglot import exp
+
+from ..factories import dlt_factory
+
+
+@dlt.resource(
+    primary_key="model_name",
+    name="rendered_models",
+    write_disposition="merge",
+)
+def get_rendered_models(
+    context: AssetExecutionContext,
+    sqlmesh: SQLMeshResource,
+    environment: str,
+):
+    """
+    Fetches and renders SQLMesh models.
+
+    Args:
+        context (AssetExecutionContext): The asset execution context
+        sqlmesh (SQLMeshResource): The SQLMesh resource
+        environment (str): The environment to render models for
+
+    Yields:
+        Dict: Information about each rendered model
+    """
+    controller = sqlmesh.get_controller(log_override=context.log)
+
+    with controller.instance(environment, "model_renderer") as mesh:
+        models = mesh.models()
+        context.log.info(f"Found {len(models)} models in the SQLMesh context")
+
+        for name, model in models.items():
+            try:
+                context.log.debug(f"Rendering model: {name}")
+                rendered_sql = mesh.context.render(model).sql(
+                    dialect="presto",
+                    pretty=True,
+                    normalize=True,
+                )
+                expr = sql.parse_one(name)
+
+                if not isinstance(expr, exp.Column) and not isinstance(
+                    expr.this, exp.Identifier
+                ):
+                    raise ValueError(f"Invalid model name: {name}")
+
+                yield {
+                    "model_name": expr.this.this,
+                    "rendered_sql": rendered_sql,
+                    "rendered_at": datetime.now(),
+                }
+
+            except Exception as e:
+                context.log.error(f"Error rendering model {name}: {str(e)}")
+
+
+@dlt_factory(
+    key_prefix="sqlmesh",
+    name="rendered_models",
+    compute_kind="sqlmesh",
+)
+def sqlmesh_render_models(
+    context: AssetExecutionContext,
+    sqlmesh: SQLMeshResource,
+    sqlmesh_infra_config: dict,
+):
+    """
+    Asset factory for rendering SQLMesh models.
+
+    Args:
+        context (AssetExecutionContext): The asset execution context
+        sqlmesh (SQLMeshResource): The SQLMesh resource
+        sqlmesh_infra_config (dict): Configuration for SQLMesh
+
+    Yields:
+        Resource: The get_rendered_models resource with rendered models
+    """
+    environment = sqlmesh_infra_config.get("environment", "dev")
+
+    yield get_rendered_models(
+        context=context,
+        sqlmesh=sqlmesh,
+        environment=environment,
+    )

--- a/warehouse/oso_sqlmesh/models/marts/metrics/metrics_v0.sql
+++ b/warehouse/oso_sqlmesh/models/marts/metrics/metrics_v0.sql
@@ -42,7 +42,9 @@ WITH unioned_metric_names AS (
   SELECT
     metric,
     display_name,
-    description
+    description,
+    sql_source_path,
+    rendered_sql,
   FROM oso.metrics_metadata
 ), metrics_v0_no_casting AS (
   SELECT
@@ -52,8 +54,8 @@ WITH unioned_metric_names AS (
     t.metric AS metric_name,
     COALESCE(m.display_name, t.metric) AS display_name,
     COALESCE(m.description, 'TODO') AS description,
-    NULL AS raw_definition,
-    'TODO' AS definition_ref,
+    COALESCE(m.rendered_sql, []) AS rendered_sql,
+    COALESCE(m.sql_source_path, 'TODO') AS sql_source_path,
     'UNKNOWN' AS aggregation_function
   FROM all_timeseries_metric_names AS t
   LEFT JOIN all_metrics_metadata AS m
@@ -66,7 +68,7 @@ SELECT
   metric_name::VARCHAR,
   display_name::VARCHAR,
   description::VARCHAR,
-  raw_definition::VARCHAR,
-  definition_ref::VARCHAR,
+  rendered_sql::ARRAY<VARCHAR>,
+  sql_source_path::VARCHAR,
   aggregation_function::VARCHAR
 FROM metrics_v0_no_casting

--- a/warehouse/oso_sqlmesh/models/marts/sqlmesh/models_v0.sql
+++ b/warehouse/oso_sqlmesh/models/marts/sqlmesh/models_v0.sql
@@ -1,5 +1,5 @@
 MODEL (
-  name oso._sqlmesh__rendered_models,
+  name oso.models_v0,
   kind FULL,
   tags (
     'export',

--- a/warehouse/oso_sqlmesh/models/marts/sqlmesh/rendered_models.sql
+++ b/warehouse/oso_sqlmesh/models/marts/sqlmesh/rendered_models.sql
@@ -11,7 +11,7 @@ MODEL (
 
 WITH all_timeseries_metrics_by_project AS (
   SELECT
-    @oso_id('OSO', 'oso', model_name) AS model_id,
+    @oso_id('OSO', 'sqlmesh', model_name) AS model_id,
     model_name as name,
     rendered_sql as sql,
     rendered_at,

--- a/warehouse/oso_sqlmesh/models/marts/sqlmesh/rendered_models.sql
+++ b/warehouse/oso_sqlmesh/models/marts/sqlmesh/rendered_models.sql
@@ -1,0 +1,25 @@
+MODEL (
+  name oso.rendered_models,
+  kind FULL,
+  tags (
+    'export',
+    'model_type:full',
+    'model_category:sqlmesh',
+    'model_stage:mart'
+  )
+);
+
+WITH all_timeseries_metrics_by_project AS (
+  SELECT
+    @oso_id('OSO', 'oso', model_name) AS model_id,
+    model_name as name,
+    rendered_sql as sql,
+    rendered_at,
+  FROM oso.stg_sqlmesh__rendered_models
+)
+SELECT
+    model_id::TEXT,
+    name::TEXT,
+    sql::TEXT,
+    rendered_at::TIMESTAMP
+FROM all_timeseries_metrics_by_project

--- a/warehouse/oso_sqlmesh/models/marts/sqlmesh/rendered_models.sql
+++ b/warehouse/oso_sqlmesh/models/marts/sqlmesh/rendered_models.sql
@@ -1,5 +1,5 @@
 MODEL (
-  name oso.rendered_models,
+  name oso._sqlmesh__rendered_models,
   kind FULL,
   tags (
     'export',

--- a/warehouse/oso_sqlmesh/models/staging/sqlmesh/stg_sqlmesh__rendered_models.sql
+++ b/warehouse/oso_sqlmesh/models/staging/sqlmesh/stg_sqlmesh__rendered_models.sql
@@ -1,0 +1,12 @@
+MODEL (
+  name oso.stg_sqlmesh__rendered_models,
+  description '',
+  dialect trino,
+  kind FULL
+);
+
+SELECT
+  models.model_name,
+  models.rendered_sql,
+  models.rendered_at,
+FROM @oso_source('bigquery.sqlmesh.rendered_models') AS models

--- a/warehouse/oso_sqlmesh/models/staging/sqlmesh/stg_sqlmesh__rendered_models.sql
+++ b/warehouse/oso_sqlmesh/models/staging/sqlmesh/stg_sqlmesh__rendered_models.sql
@@ -1,6 +1,6 @@
 MODEL (
   name oso.stg_sqlmesh__rendered_models,
-  description '',
+  description 'Formatted SQLMesh source SQL for all models',
   dialect trino,
   kind FULL
 );


### PR DESCRIPTION
This PR closes #3078 by introducing two new columns: `rendered_sql` and `sql_source_path` for the `metrics_factories` assets.

The former is an array of the pretty-printed rendered `sql` queries. Each `MetricQueryDef`'s `time_aggregations`/`rolling`/`entity_types`/... adds a rendered query to this array. The idea is to have a page for e.g. `stars`, which has all grouped queries and some plots and metrics.

The latter is the path to the `sql` model source relative to the `SQLMesh` project root. This will be useful to link to GitHub itself.

It also introduces a new dagster asset, `sqlmesh/rendered_models` which exports all rendered models, and a SQLMesh staging model for these models and a mart so we can consume them via Clickhouse.

- [x] Aggregate and render all `metrics_factories` sql definitions with their corresponding paths
- [x] Create a `dagster` asset that renders all non-`metrics_factories` assets using `dagster-sqlmesh`
- [ ] Export these to ClickHouse
- [ ] Create the frontend route (e.g. `/models/:model`, which displays either all similar `metrics_factories` models, e.g. `/models/stars`, or the specialized model itself, e.g. `/models/int_projects_to_projects`)