### PR TITLE
fix!: replace rolling windows

### DIFF
--- a/warehouse/metrics_tools/definition.py
+++ b/warehouse/metrics_tools/definition.py
@@ -163,15 +163,18 @@ class MetricQueryDef:
         raw_sql = self.raw_sql(queries_dir)
 
         dialect = self.dialect or default_dialect
-        return t.cast(
-            t.List[exp.Expression],
-            list(
-                filter(
-                    lambda a: a is not None,
-                    sqlglot.parse(raw_sql, dialect=dialect),
-                )
-            ),
-        )
+        try:
+            return t.cast(
+                t.List[exp.Expression],
+                list(
+                    filter(
+                        lambda a: a is not None,
+                        sqlglot.parse(raw_sql, dialect=dialect),
+                    )
+                ),
+            )
+        except Exception as e:
+            raise Exception(f"Failed to parse SQL for {self.ref} with error {e}") from e
 
     @contextmanager
     def query_vars(

--- a/warehouse/metrics_tools/definition.py
+++ b/warehouse/metrics_tools/definition.py
@@ -57,6 +57,7 @@ class PeerMetricDependencyRef(t.TypedDict):
     slots: t.NotRequired[int]
     start: t.NotRequired[TimeLike]
     end: t.NotRequired[TimeLike]
+    dialect: t.NotRequired[str]
 
 
 class MetricModelRef(t.TypedDict):
@@ -347,6 +348,8 @@ class MetricQuery:
                         unit=self._source.rolling.get("unit"),
                         cron=self._source.rolling.get("cron"),
                     )
+                    if self._source.dialect:
+                        ref["dialect"] = self._source.dialect
                     model_batch_size = self._source.rolling.get("model_batch_size")
                     slots = self._source.rolling.get("slots")
                     if model_batch_size:
@@ -355,22 +358,24 @@ class MetricQuery:
                         ref["slots"] = slots
                     refs.append(ref)
             for time_aggregation in self._source.time_aggregations or []:
-                refs.append(
-                    PeerMetricDependencyRef(
-                        name=name,
-                        entity_type=entity,
-                        time_aggregation=time_aggregation,
-                    )
+                ref = PeerMetricDependencyRef(
+                    name=name,
+                    entity_type=entity,
+                    time_aggregation=time_aggregation,
                 )
+                if self._source.dialect:
+                    ref["dialect"] = self._source.dialect
+                refs.append(ref)
             # if we actually enabled over all time, we'll compute that as well
             if self._source.over_all_time:
-                refs.append(
-                    PeerMetricDependencyRef(
-                        name=name,
-                        entity_type=entity,
-                        time_aggregation="over_all_time",
-                    )
+                ref = PeerMetricDependencyRef(
+                    name=name,
+                    entity_type=entity,
+                    time_aggregation="over_all_time",
                 )
+                if self._source.dialect:
+                    ref["dialect"] = self._source.dialect
+                refs.append(ref)
         return refs
 
     @property

--- a/warehouse/metrics_tools/factory/constants.py
+++ b/warehouse/metrics_tools/factory/constants.py
@@ -6,7 +6,20 @@ TIME_AGGREGATION_TO_CRON = {
     "daily": "@daily",
     "monthly": "@monthly",
     "weekly": "@weekly",
+    "quarterly": "@monthly",
+    "biannually": "@monthly",
+    "yearly": "@yearly",
 }
+
+TIME_AGGREGATION_TO_END = {
+    "daily": "1 day ago",
+    "monthly": "1 month ago",
+    "weekly": "1 week ago",
+    "quarterly": "3 months ago",
+    "biannually": "6 months ago",
+    "yearly": "1 year ago",
+}
+
 METRICS_COLUMNS_BY_ENTITY: t.Dict[str, t.Dict[str, exp.DataType]] = {
     "artifact": {
         "metrics_sample_date": exp.DataType.build("DATE", dialect="duckdb"),

--- a/warehouse/metrics_tools/factory/factory.py
+++ b/warehouse/metrics_tools/factory/factory.py
@@ -212,10 +212,13 @@ class TimeseriesMetrics:
                 ],
             )
 
+            vars = query._source.vars or {}
+
             try:
                 rendered_query = transformer.transform(
                     [query.query_expression],
                     dialect=query._source.dialect or self.default_dialect,
+                    debug=vars.get("debug", 0) == 1,
                 )
             except Exception as e:
                 logger.error(f"Failed to render query {query.table_name(ref)}: {e}")
@@ -726,7 +729,7 @@ class TimeseriesMetrics:
         # Apparently expressions also cannot be serialized.
         del config["rendered_query"]
         config["rendered_query_str"] = query_config["rendered_query"].sql(
-            dialect="duckdb"
+            dialect=query_config["dialect"] or self.default_dialect,
         )
         return config
 

--- a/warehouse/metrics_tools/factory/proxy/proxies.py
+++ b/warehouse/metrics_tools/factory/proxy/proxies.py
@@ -41,7 +41,13 @@ def generated_query(
             "@TO_UNIX_TIMESTAMP": to_unix_timestamp,
         },
     ):
-        result = evaluator.transform(parse_one(rendered_query_str))
+        dialect = ref.get(
+            "dialect", evaluator.dialect or evaluator.engine_adapter.dialect
+        )
+        parse_args = {}
+        if dialect:
+            parse_args["dialect"] = dialect
+        result = evaluator.transform(parse_one(rendered_query_str, **parse_args))
     return result
 
 

--- a/warehouse/metrics_tools/intermediate.py
+++ b/warehouse/metrics_tools/intermediate.py
@@ -141,6 +141,7 @@ def run_intermediate_macro_evaluator(
     for int_expression in intermediate_evaluation:
         restored = int_expression.transform(restore_intermediate)
         if "debug" in variables:
-            print(restored.sql(dialect="duckdb"))
+            print("debugging intermediate macro evaluation")
+            print(restored.sql(dialect=variables.get("debug_dialect", "duckdb")))
         final.append(restored)
     return final

--- a/warehouse/metrics_tools/intermediate.py
+++ b/warehouse/metrics_tools/intermediate.py
@@ -8,11 +8,12 @@ from sqlmesh.core.dialect import MacroFunc, MacroVar, parse, parse_one
 from sqlmesh.core.macros import MacroEvaluator, MacroRegistry, RuntimeStage, macro
 
 
-def fake_engine_adapter() -> EngineAdapter:
+def fake_engine_adapter(dialect: str) -> EngineAdapter:
     """Return a fake engine adapter for testing purposes."""
     from sqlmesh.core.engine_adapter.duckdb import DuckDBEngineAdapter
 
     engine_adapter = DuckDBEngineAdapter(lambda: duckdb.connect())
+    engine_adapter.dialect = dialect
     return engine_adapter
 
 
@@ -23,6 +24,7 @@ def run_macro_evaluator(
     runtime_stage: RuntimeStage = RuntimeStage.LOADING,
     engine_adapter: t.Optional[EngineAdapter] = None,
     default_catalog: t.Optional[str] = None,
+    dialect: str = "duckdb",
 ):
     if isinstance(query, str):
         parsed = parse(query)
@@ -46,7 +48,7 @@ def run_macro_evaluator(
     if engine_adapter:
         evaluator.locals["engine_adapter"] = engine_adapter
     else:
-        evaluator.locals["engine_adapter"] = fake_engine_adapter()
+        evaluator.locals["engine_adapter"] = fake_engine_adapter(dialect)
 
     result: t.List[exp.Expression] = []
     for part in parsed:
@@ -125,10 +127,13 @@ def run_intermediate_macro_evaluator(
         if not node.this.startswith("$$INTERMEDIATE"):
             return node
         if node.this == "$$INTERMEDIATE_MACRO_VAR":
+            print("restoring macro var???")
             return MacroVar(this=node.expressions[0].this)
         elif node.this == "$$INTERMEDIATE_MACRO_FUNC":
+            print("restoring macro func???")
             # Restore all recursive expressions
             recursed_transform = node.expressions[0].transform(restore_intermediate)
+            print(recursed_transform.sql(dialect="duckdb"))
             return MacroFunc(this=recursed_transform)
         else:
             raise Exception(f"Unknown anonymous intermediate reference `{node.this}`")
@@ -137,5 +142,8 @@ def run_intermediate_macro_evaluator(
         intermediate_evaluation = [intermediate_evaluation]
     final: t.List[exp.Expression] = []
     for int_expression in intermediate_evaluation:
-        final.append(int_expression.transform(restore_intermediate))
+        restored = int_expression.transform(restore_intermediate)
+        if "debug" in variables:
+            print(restored.sql(dialect="duckdb"))
+        final.append(restored)
     return final

--- a/warehouse/metrics_tools/intermediate.py
+++ b/warehouse/metrics_tools/intermediate.py
@@ -127,13 +127,10 @@ def run_intermediate_macro_evaluator(
         if not node.this.startswith("$$INTERMEDIATE"):
             return node
         if node.this == "$$INTERMEDIATE_MACRO_VAR":
-            print("restoring macro var???")
             return MacroVar(this=node.expressions[0].this)
         elif node.this == "$$INTERMEDIATE_MACRO_FUNC":
-            print("restoring macro func???")
             # Restore all recursive expressions
             recursed_transform = node.expressions[0].transform(restore_intermediate)
-            print(recursed_transform.sql(dialect="duckdb"))
             return MacroFunc(this=recursed_transform)
         else:
             raise Exception(f"Unknown anonymous intermediate reference `{node.this}`")

--- a/warehouse/metrics_tools/macros/macros.py
+++ b/warehouse/metrics_tools/macros/macros.py
@@ -16,6 +16,8 @@ from sqlmesh.core.macros import MacroEvaluator
 def relative_window_sample_date(
     evaluator: MacroEvaluator,
     base: exp.Expression,
+    window: exp.Expression,
+    unit: str | exp.Expression,
     relative_index: exp.Expression,
 ):
     """Gets the rolling window sample date of a different table. For now this is
@@ -29,23 +31,9 @@ def relative_window_sample_date(
     be the `@metrics_end` date.
     """
 
-    if time_aggregation := evaluator.locals.get("time_aggregation"):
-        if time_aggregation == "over_all_time":
-            raise Exception("Cannot use relative_window_sample_date over all time")
-        converted_relative_index = exp_to_int(relative_index)
-        return time_aggregation_bucket(
-            evaluator,
-            base,
-            time_aggregation,
-            converted_relative_index,
-        )
-
-    window = evaluator.locals.get("rolling_window", "")
-    unit = evaluator.locals.get("rolling_unit", "")
-
-    if not window or not unit:
+    if evaluator.locals.get("time_aggregation"):
         raise Exception(
-            "relative_window_sample_date requires a rolling_window and rolling_unit"
+            "relative_window_sample_date cannot be used in time_aggregation mode"
         )
 
     if isinstance(unit, exp.Literal):

--- a/warehouse/metrics_tools/runner.py
+++ b/warehouse/metrics_tools/runner.py
@@ -103,6 +103,7 @@ def render_metrics_query(
     engine_adapter: t.Optional[EngineAdapter] = None,
     additional_macros: t.Optional[MacroRegistry] = None,
     runtime_stage: RuntimeStage = RuntimeStage.EVALUATING,
+    dialect: str = "duckdb",
 ):
     variables = variables or {}
 
@@ -132,6 +133,7 @@ def render_metrics_query(
         variables=variables,
         engine_adapter=engine_adapter,
         runtime_stage=runtime_stage,
+        dialect=dialect,
     )
     return evaluated_query
 

--- a/warehouse/metrics_tools/transformer/transformer.py
+++ b/warehouse/metrics_tools/transformer/transformer.py
@@ -17,9 +17,11 @@ class SQLTransformer:
     transforms: t.List[Transform]
     disable_qualify: bool = False
 
-    def transform(self, query: str | t.List[exp.Expression]):
+    def transform(
+        self, query: str | t.List[exp.Expression], dialect: str | None = None
+    ):
         if isinstance(query, str):
-            transformed = parse(query)
+            transformed = parse(query, default_dialect=dialect)
         else:
             transformed = query
         # Qualify all
@@ -29,4 +31,7 @@ class SQLTransformer:
 
         for transform in self.transforms:
             transformed = transform(transformed)
+            # print("transformed")
+            # for expr in transformed:
+            #     print(expr.sql(dialect="trino"))
         return transformed

--- a/warehouse/metrics_tools/transformer/transformer.py
+++ b/warehouse/metrics_tools/transformer/transformer.py
@@ -18,7 +18,10 @@ class SQLTransformer:
     disable_qualify: bool = False
 
     def transform(
-        self, query: str | t.List[exp.Expression], dialect: str | None = None
+        self,
+        query: str | t.List[exp.Expression],
+        dialect: str | None = None,
+        debug: bool = False,
     ):
         if isinstance(query, str):
             transformed = parse(query, default_dialect=dialect)
@@ -31,7 +34,8 @@ class SQLTransformer:
 
         for transform in self.transforms:
             transformed = transform(transformed)
-            # print("transformed")
-            # for expr in transformed:
-            #     print(expr.sql(dialect="trino"))
+            if debug:
+                print("debugging transformation")
+                for expr in transformed:
+                    print(expr.sql(dialect="trino"))
         return transformed

--- a/warehouse/metrics_tools/utils/glot.py
+++ b/warehouse/metrics_tools/utils/glot.py
@@ -46,6 +46,14 @@ def exp_literal_to_py_literal(glot_literal: exp.Expression) -> t.Any:
     return glot_literal.this
 
 
+def exp_to_int(glot_expression: exp.Expression) -> int:
+    if isinstance(glot_expression, exp.Literal):
+        return int(glot_expression.this)
+    elif isinstance(glot_expression, exp.Neg):
+        return int(glot_expression.this.this) * -1
+    raise ValueError(f"Invalid expression type: {glot_expression}")
+
+
 def str_or_expressions(query: str | t.List[exp.Expression]) -> t.List[exp.Expression]:
     if not isinstance(query, list):
         return parse(query)

--- a/warehouse/oso_lets_go/cli.py
+++ b/warehouse/oso_lets_go/cli.py
@@ -153,9 +153,10 @@ def render(
             chosen_metric["ref"],
             variables=parsed_vars,
             runtime_stage=RuntimeStage.EVALUATING,
+            dialect=dialect,
         )
         print("")
-        print("### FULL RENDERING")
+        print(f"### FULL RENDERING ({dialect})")
         print(expr[0].sql(dialect=dialect, pretty=True))
 
 

--- a/warehouse/oso_sqlmesh/config.py
+++ b/warehouse/oso_sqlmesh/config.py
@@ -20,6 +20,10 @@ from sqlmesh.core.config.connection import (
 dotenv.load_dotenv()
 
 config = Config(
+    default_test_connection=DuckDBConnectionConfig(
+        concurrent_tasks=1,
+        database=os.environ.get("SQLMESH_DUCKDB_LOCAL_PATH"),
+    ),
     model_defaults=ModelDefaultsConfig(dialect="duckdb", start="2024-08-01"),
     gateways={
         "local": GatewayConfig(

--- a/warehouse/oso_sqlmesh/config.py
+++ b/warehouse/oso_sqlmesh/config.py
@@ -20,11 +20,15 @@ from sqlmesh.core.config.connection import (
 dotenv.load_dotenv()
 
 config = Config(
-    default_test_connection=DuckDBConnectionConfig(
-        concurrent_tasks=1,
-        database=os.environ.get("SQLMESH_DUCKDB_LOCAL_PATH"),
+    default_test_connection=(
+        DuckDBConnectionConfig(
+            concurrent_tasks=1,
+            database=os.environ.get("SQLMESH_DUCKDB_LOCAL_PATH"),
+        )
+        if os.environ.get("SQLMESH_DEBUG_TESTS")
+        else None
     ),
-    model_defaults=ModelDefaultsConfig(dialect="duckdb", start="2024-08-01"),
+    model_defaults=ModelDefaultsConfig(dialect="trino", start="2024-08-01"),
     gateways={
         "local": GatewayConfig(
             connection=DuckDBConnectionConfig(

--- a/warehouse/oso_sqlmesh/models/intermediate/events/int_events_aux_issues.sql
+++ b/warehouse/oso_sqlmesh/models/intermediate/events/int_events_aux_issues.sql
@@ -8,7 +8,8 @@ MODEL (
   start '2015-01-01',
   cron '@daily',
   partitioned_by (DAY("time"), "event_type"),
-  grain (time, event_type, event_source, from_artifact_id, to_artifact_id)
+  grain (time, event_type, event_source, from_artifact_id, to_artifact_id),
+  dialect duckdb
 );
 
 WITH github_comments AS (

--- a/warehouse/oso_sqlmesh/models/metrics_factories.py
+++ b/warehouse/oso_sqlmesh/models/metrics_factories.py
@@ -490,7 +490,6 @@ timeseries_metrics(
                     "PULL_REQUEST_OPENED",
                     "PULL_REQUEST_MERGED",
                 ],
-                "debug": 1,
             },
             time_aggregations=["monthly", "quarterly", "biannually", "yearly"],
             entity_types=["artifact", "project", "collection"],

--- a/warehouse/oso_sqlmesh/models/metrics_factories.py
+++ b/warehouse/oso_sqlmesh/models/metrics_factories.py
@@ -9,6 +9,7 @@ from metrics_tools.factory import MetricQueryDef, timeseries_metrics
 load_dotenv()
 
 timeseries_metrics(
+    default_dialect="trino",
     start=os.environ.get("SQLMESH_TIMESERIES_METRICS_START", "2015-01-01"),
     schema="oso",
     model_prefix="timeseries",
@@ -538,5 +539,4 @@ timeseries_metrics(
             ],
         ),
     },
-    default_dialect="clickhouse",
 )

--- a/warehouse/oso_sqlmesh/models/metrics_factories.py
+++ b/warehouse/oso_sqlmesh/models/metrics_factories.py
@@ -2,7 +2,7 @@ import os
 
 from dotenv import load_dotenv
 from metrics_tools.definition import MetricMetadata
-from metrics_tools.factory import MetricQueryDef, RollingConfig, timeseries_metrics
+from metrics_tools.factory import MetricQueryDef, timeseries_metrics
 
 # Annoyingly sqlmesh doesn't load things in an expected order but we want to be
 # able to override the start date for local testing and things
@@ -34,12 +34,14 @@ timeseries_metrics(
         # `oso.timeseries_stars_to_{entity_type}_{time_aggregation}`
         "stars": MetricQueryDef(
             ref="code/stars.sql",
-            time_aggregations=["daily", "weekly", "monthly"],
-            rolling=RollingConfig(
-                windows=[30, 90, 180],
-                unit="day",
-                cron="@daily",
-            ),
+            time_aggregations=[
+                "daily",
+                "weekly",
+                "monthly",
+                "quarterly",
+                "biannually",
+                "yearly",
+            ],
             entity_types=["artifact", "project", "collection"],
             over_all_time=True,
             metadata=MetricMetadata(
@@ -50,13 +52,14 @@ timeseries_metrics(
         ),
         "commits": MetricQueryDef(
             ref="code/commits.sql",
-            time_aggregations=["daily", "weekly", "monthly"],
-            rolling=RollingConfig(
-                windows=[180],
-                unit="day",
-                cron="@daily",
-                slots=8,
-            ),
+            time_aggregations=[
+                "daily",
+                "weekly",
+                "monthly",
+                "quarterly",
+                "biannually",
+                "yearly",
+            ],
             over_all_time=True,
             metadata=MetricMetadata(
                 display_name="Commits",
@@ -76,7 +79,14 @@ timeseries_metrics(
         ),
         "releases": MetricQueryDef(
             ref="code/releases.sql",
-            time_aggregations=["daily", "weekly", "monthly"],
+            time_aggregations=[
+                "daily",
+                "weekly",
+                "monthly",
+                "quarterly",
+                "biannually",
+                "yearly",
+            ],
             over_all_time=True,
             metadata=MetricMetadata(
                 display_name="Releases",
@@ -86,7 +96,14 @@ timeseries_metrics(
         ),
         "forks": MetricQueryDef(
             ref="code/forks.sql",
-            time_aggregations=["daily", "weekly", "monthly"],
+            time_aggregations=[
+                "daily",
+                "weekly",
+                "monthly",
+                "quarterly",
+                "biannually",
+                "yearly",
+            ],
             over_all_time=True,
             metadata=MetricMetadata(
                 display_name="Forks",
@@ -96,7 +113,14 @@ timeseries_metrics(
         ),
         "repositories": MetricQueryDef(
             ref="code/repositories.sql",
-            time_aggregations=["daily", "weekly", "monthly"],
+            time_aggregations=[
+                "daily",
+                "weekly",
+                "monthly",
+                "quarterly",
+                "biannually",
+                "yearly",
+            ],
             over_all_time=True,
             metadata=MetricMetadata(
                 display_name="Repositories",
@@ -106,7 +130,14 @@ timeseries_metrics(
         ),
         "active_contracts": MetricQueryDef(
             ref="blockchain/active_contracts.sql",
-            time_aggregations=["daily", "weekly", "monthly"],
+            time_aggregations=[
+                "daily",
+                "weekly",
+                "monthly",
+                "quarterly",
+                "biannually",
+                "yearly",
+            ],
             over_all_time=True,
             metadata=MetricMetadata(
                 display_name="Active Contracts",
@@ -116,7 +147,14 @@ timeseries_metrics(
         ),
         "contributors": MetricQueryDef(
             ref="code/contributors.sql",
-            time_aggregations=["daily", "weekly", "monthly"],
+            time_aggregations=[
+                "daily",
+                "weekly",
+                "monthly",
+                "quarterly",
+                "biannually",
+                "yearly",
+            ],
             over_all_time=True,
             metadata=MetricMetadata(
                 display_name="Contributors",
@@ -126,7 +164,14 @@ timeseries_metrics(
         ),
         "active_developers": MetricQueryDef(
             ref="code/active_developers.sql",
-            time_aggregations=["daily", "weekly", "monthly"],
+            time_aggregations=[
+                "daily",
+                "weekly",
+                "monthly",
+                "quarterly",
+                "biannually",
+                "yearly",
+            ],
             over_all_time=True,
             metadata=MetricMetadata(
                 display_name="Active Developers",
@@ -145,12 +190,12 @@ timeseries_metrics(
             vars={
                 "activity_event_types": ["COMMIT_CODE"],
             },
-            rolling=RollingConfig(
-                windows=[30, 90, 180],
-                unit="day",
-                cron="@daily",  # This determines how often this is calculated
-                slots=32,
-            ),
+            time_aggregations=[
+                "monthly",
+                "quarterly",
+                "biannually",
+                "yearly",
+            ],
             entity_types=["artifact", "project", "collection"],
             is_intermediate=True,
             additional_tags=["data_category:code"],
@@ -165,13 +210,12 @@ timeseries_metrics(
                     "PULL_REQUEST_MERGED",
                 ],
             },
-            rolling=RollingConfig(
-                windows=[30, 90, 180],
-                unit="day",
-                cron="@daily",  # This determines how often this is calculated
-                model_batch_size=90,
-                slots=32,
-            ),
+            time_aggregations=[
+                "monthly",
+                "quarterly",
+                "biannually",
+                "yearly",
+            ],
             entity_types=["artifact", "project", "collection"],
             is_intermediate=True,
             additional_tags=["data_category:code"],
@@ -181,12 +225,12 @@ timeseries_metrics(
             vars={
                 "full_time_ratio": 10 / 30,
             },
-            rolling=RollingConfig(
-                windows=[30, 90, 180],
-                unit="day",
-                cron="@monthly",
-                slots=32,
-            ),
+            time_aggregations=[
+                "monthly",
+                "quarterly",
+                "biannually",
+                "yearly",
+            ],
             metadata=MetricMetadata(
                 display_name="Developer Classifications",
                 description="Metrics related to developer activity classifications",
@@ -204,12 +248,12 @@ timeseries_metrics(
                     "PULL_REQUEST_MERGED",
                 ],
             },
-            rolling=RollingConfig(
-                windows=[30, 90, 180],
-                unit="day",
-                cron="@monthly",
-                slots=32,
-            ),
+            time_aggregations=[
+                "monthly",
+                "quarterly",
+                "biannually",
+                "yearly",
+            ],
             metadata=MetricMetadata(
                 display_name="Contributor Classifications",
                 description="Metrics related to contributor activity classifications",
@@ -231,12 +275,12 @@ timeseries_metrics(
         # ),
         "change_in_developer_activity": MetricQueryDef(
             ref="code/change_in_developers.sql",
-            rolling=RollingConfig(
-                windows=[30, 90, 180],
-                unit="day",
-                cron="@monthly",
-                slots=32,
-            ),
+            time_aggregations=[
+                "monthly",
+                "quarterly",
+                "biannually",
+                "yearly",
+            ],
             metadata=MetricMetadata(
                 display_name="Change in Developer Activity",
                 description="Metrics related to change in developer activity",
@@ -245,13 +289,14 @@ timeseries_metrics(
         ),
         "opened_pull_requests": MetricQueryDef(
             ref="code/prs_opened.sql",
-            time_aggregations=["daily", "weekly", "monthly"],
-            rolling=RollingConfig(
-                windows=[180],
-                unit="day",
-                cron="@daily",
-                slots=8,
-            ),
+            time_aggregations=[
+                "daily",
+                "weekly",
+                "monthly",
+                "quarterly",
+                "biannually",
+                "yearly",
+            ],
             entity_types=["artifact", "project", "collection"],
             over_all_time=True,
             metadata=MetricMetadata(
@@ -262,13 +307,14 @@ timeseries_metrics(
         ),
         "merged_pull_requests": MetricQueryDef(
             ref="code/prs_merged.sql",
-            time_aggregations=["daily", "weekly", "monthly"],
-            rolling=RollingConfig(
-                windows=[180],
-                unit="day",
-                cron="@daily",
-                slots=8,
-            ),
+            time_aggregations=[
+                "daily",
+                "weekly",
+                "monthly",
+                "quarterly",
+                "biannually",
+                "yearly",
+            ],
             entity_types=["artifact", "project", "collection"],
             over_all_time=True,
             metadata=MetricMetadata(
@@ -279,13 +325,14 @@ timeseries_metrics(
         ),
         "opened_issues": MetricQueryDef(
             ref="code/issues_opened.sql",
-            time_aggregations=["daily", "weekly", "monthly"],
-            rolling=RollingConfig(
-                windows=[180],
-                unit="day",
-                cron="@daily",
-                slots=8,
-            ),
+            time_aggregations=[
+                "daily",
+                "weekly",
+                "monthly",
+                "quarterly",
+                "biannually",
+                "yearly",
+            ],
             entity_types=["artifact", "project", "collection"],
             over_all_time=True,
             metadata=MetricMetadata(
@@ -296,13 +343,14 @@ timeseries_metrics(
         ),
         "closed_issues": MetricQueryDef(
             ref="code/issues_closed.sql",
-            time_aggregations=["daily", "weekly", "monthly"],
-            rolling=RollingConfig(
-                windows=[180],
-                unit="day",
-                cron="@daily",
-                slots=8,
-            ),
+            time_aggregations=[
+                "daily",
+                "weekly",
+                "monthly",
+                "quarterly",
+                "biannually",
+                "yearly",
+            ],
             entity_types=["artifact", "project", "collection"],
             over_all_time=True,
             metadata=MetricMetadata(
@@ -313,12 +361,10 @@ timeseries_metrics(
         ),
         "avg_prs_time_to_merge": MetricQueryDef(
             ref="code/prs_time_to_merge.sql",
-            rolling=RollingConfig(
-                windows=[90, 180],
-                unit="day",
-                cron="@daily",
-                slots=8,
-            ),
+            time_aggregations=[
+                "quarterly",
+                "biannually",
+            ],
             entity_types=["artifact", "project", "collection"],
             over_all_time=True,
             metadata=MetricMetadata(
@@ -329,12 +375,10 @@ timeseries_metrics(
         ),
         "avg_time_to_first_response": MetricQueryDef(
             ref="code/time_to_first_response.sql",
-            rolling=RollingConfig(
-                windows=[90, 180],
-                unit="day",
-                cron="@daily",
-                slots=8,
-            ),
+            time_aggregations=[
+                "quarterly",
+                "biannually",
+            ],
             entity_types=["artifact", "project", "collection"],
             over_all_time=True,
             metadata=MetricMetadata(
@@ -348,13 +392,14 @@ timeseries_metrics(
             vars={
                 "activity_event_types": ["CONTRACT_INVOCATION"],
             },
-            rolling=RollingConfig(
-                windows=[30, 90, 180],
-                unit="day",
-                cron="@daily",
-                slots=32,
-            ),
-            time_aggregations=["daily", "monthly"],
+            time_aggregations=[
+                "daily",
+                "weekly",
+                "monthly",
+                "quarterly",
+                "biannually",
+                "yearly",
+            ],
             over_all_time=True,
             metadata=MetricMetadata(
                 display_name="Active Addresses Aggregation",
@@ -364,13 +409,14 @@ timeseries_metrics(
         ),
         "gas_fees": MetricQueryDef(
             ref="blockchain/gas_fees.sql",
-            time_aggregations=["daily", "weekly", "monthly"],
-            rolling=RollingConfig(
-                windows=[30, 90, 180],
-                unit="day",
-                cron="@daily",
-                slots=16,
-            ),
+            time_aggregations=[
+                "daily",
+                "weekly",
+                "monthly",
+                "quarterly",
+                "biannually",
+                "yearly",
+            ],
             entity_types=["artifact", "project", "collection"],
             over_all_time=True,
             metadata=MetricMetadata(
@@ -381,13 +427,14 @@ timeseries_metrics(
         ),
         "transactions": MetricQueryDef(
             ref="blockchain/transactions.sql",
-            time_aggregations=["daily", "weekly", "monthly"],
-            rolling=RollingConfig(
-                windows=[30, 90, 180],
-                unit="day",
-                cron="@daily",
-                slots=32,
-            ),
+            time_aggregations=[
+                "daily",
+                "weekly",
+                "monthly",
+                "quarterly",
+                "biannually",
+                "yearly",
+            ],
             entity_types=["artifact", "project", "collection"],
             over_all_time=True,
             metadata=MetricMetadata(
@@ -398,13 +445,14 @@ timeseries_metrics(
         ),
         "contract_invocations": MetricQueryDef(
             ref="blockchain/contract_invocations.sql",
-            time_aggregations=["daily", "weekly", "monthly"],
-            rolling=RollingConfig(
-                windows=[30, 90, 180],
-                unit="day",
-                cron="@daily",
-                slots=32,
-            ),
+            time_aggregations=[
+                "daily",
+                "weekly",
+                "monthly",
+                "quarterly",
+                "biannually",
+                "yearly",
+            ],
             entity_types=["artifact", "project", "collection"],
             over_all_time=True,
             metadata=MetricMetadata(
@@ -415,7 +463,14 @@ timeseries_metrics(
         ),
         "defillama_tvl": MetricQueryDef(
             ref="blockchain/defillama_tvl.sql",
-            time_aggregations=["daily", "weekly", "monthly"],
+            time_aggregations=[
+                "daily",
+                "weekly",
+                "monthly",
+                "quarterly",
+                "biannually",
+                "yearly",
+            ],
             incremental=False,
             entity_types=["artifact", "project", "collection"],
             over_all_time=True,
@@ -434,13 +489,9 @@ timeseries_metrics(
                     "PULL_REQUEST_OPENED",
                     "PULL_REQUEST_MERGED",
                 ],
+                "debug": 1,
             },
-            rolling=RollingConfig(
-                windows=[30, 90, 180],
-                unit="day",
-                cron="@monthly",
-                slots=32,
-            ),
+            time_aggregations=["monthly", "quarterly", "biannually", "yearly"],
             entity_types=["artifact", "project", "collection"],
             metadata=MetricMetadata(
                 display_name="Contributors Lifecycle",
@@ -450,13 +501,14 @@ timeseries_metrics(
         ),
         "funding_received": MetricQueryDef(
             ref="funding/funding_received.sql",
-            time_aggregations=["daily", "weekly", "monthly"],
-            rolling=RollingConfig(
-                windows=[180],
-                unit="day",
-                cron="@daily",
-                slots=8,
-            ),
+            time_aggregations=[
+                "daily",
+                "weekly",
+                "monthly",
+                "quarterly",
+                "biannually",
+                "yearly",
+            ],
             entity_types=["artifact", "project", "collection"],
             over_all_time=True,
             metadata=MetricMetadata(
@@ -467,13 +519,14 @@ timeseries_metrics(
         ),
         "dependencies": MetricQueryDef(
             ref="deps/dependencies.sql",
-            time_aggregations=["daily", "weekly", "monthly"],
-            rolling=RollingConfig(
-                windows=[180],
-                unit="day",
-                cron="@daily",
-                slots=16,
-            ),
+            time_aggregations=[
+                "daily",
+                "weekly",
+                "monthly",
+                "quarterly",
+                "biannually",
+                "yearly",
+            ],
             entity_types=["artifact", "project", "collection"],
             over_all_time=True,
             metadata=MetricMetadata(

--- a/warehouse/oso_sqlmesh/models/staging/github/stg_github__comments.sql
+++ b/warehouse/oso_sqlmesh/models/staging/github/stg_github__comments.sql
@@ -6,6 +6,7 @@ MODEL (
     batch_concurrency 3,
     lookback 7
   ),
+  dialect "duckdb",
   start @github_incremental_start,
   partitioned_by DAY(event_time),
 );

--- a/warehouse/oso_sqlmesh/models/staging/github/stg_github__issues.sql
+++ b/warehouse/oso_sqlmesh/models/staging/github/stg_github__issues.sql
@@ -8,11 +8,12 @@ MODEL (
   ),
   start @github_incremental_start,
   partitioned_by DAY(event_time),
+  dialect duckdb,
 );
 
 WITH issue_events AS (
   SELECT
-    *
+  *
   FROM oso.stg_github__events AS ghe
   WHERE
     ghe.type = 'IssuesEvent'

--- a/warehouse/oso_sqlmesh/models/staging/github/stg_github__pull_request_merge_events.sql
+++ b/warehouse/oso_sqlmesh/models/staging/github/stg_github__pull_request_merge_events.sql
@@ -1,6 +1,7 @@
 MODEL (
   name oso.stg_github__pull_request_merge_events,
-  kind FULL
+  kind FULL,
+  dialect duckdb,
 );
 
 WITH pull_request_events AS (

--- a/warehouse/oso_sqlmesh/models/staging/github/stg_github__pull_requests.sql
+++ b/warehouse/oso_sqlmesh/models/staging/github/stg_github__pull_requests.sql
@@ -7,6 +7,7 @@ MODEL (
     batch_concurrency 3,
     lookback 7
   ),
+  dialect "duckdb",
   start @github_incremental_start,
   partitioned_by DAY(event_time),
 );

--- a/warehouse/oso_sqlmesh/oso_metrics/code/contributor_activity_classification.sql
+++ b/warehouse/oso_sqlmesh/oso_metrics/code/contributor_activity_classification.sql
@@ -154,7 +154,7 @@ with
             and last_event.last_event
             <= DATE_ADD(
               'DAY', 
-              -1 * @metrics_sample_interval_length(active.metrics_sample_date, 'day'),
+              (-1 * @metrics_sample_interval_length(active.metrics_sample_date, 'day')),
               @metrics_start('DATE')
             )
         group by

--- a/warehouse/oso_sqlmesh/oso_metrics/code/contributor_activity_classification.sql
+++ b/warehouse/oso_sqlmesh/oso_metrics/code/contributor_activity_classification.sql
@@ -12,7 +12,7 @@ with
         -- from_artifact_id,
         -- to_artifact_id
         select
-            `time`,
+            "time",
             event_source,
             from_artifact_id,
             @metrics_entity_type_col(
@@ -34,7 +34,7 @@ with
                 'to_{entity_type}_id', table_alias := fo, include_column_alias := true
             )
         from first_of_activity_to_entity as fo
-        where `time` between @metrics_start('DATE') and @metrics_end('DATE')
+        where "fo"."time" between @metrics_start('DATE') and @metrics_end('DATE')
     ),
     new_contributors as (
         -- Only new contributors. we do this by joining on the filtered first of events
@@ -152,7 +152,11 @@ with
         where
             last_event.last_event is not null
             and last_event.last_event
-            <= @metrics_start('DATE') - interval @metrics_sample_interval_length(active.metrics_sample_date, 'day') day
+            <= DATE_ADD(
+              'DAY', 
+              -1 * @metrics_sample_interval_length(active.metrics_sample_date, 'day'),
+              @metrics_start('DATE')
+            )
         group by
             metric,
             @metrics_entity_type_col('to_{entity_type}_id', table_alias := active),

--- a/warehouse/oso_sqlmesh/oso_metrics/code/developer_activity_classification.sql
+++ b/warehouse/oso_sqlmesh/oso_metrics/code/developer_activity_classification.sql
@@ -10,11 +10,9 @@ select active.metrics_sample_date,
   COUNT(DISTINCT active.from_artifact_id) as amount
 from @metrics_peer_ref(
     developer_active_days,
-    window := @rolling_window,
-    unit := @rolling_unit
+    time_aggregation := @time_aggregation,
   ) as active
-where active.amount / @rolling_window >= @full_time_ratio
-  and active.metrics_sample_date = @metrics_end('DATE')
+where active.amount / @metrics_sample_interval_length(active.metrics_sample_date, 'day') >= @full_time_ratio
 group by metric,
   from_artifact_id,
   @metrics_entity_type_col(
@@ -36,11 +34,9 @@ select active.metrics_sample_date,
   COUNT(DISTINCT active.from_artifact_id) as amount
 from @metrics_peer_ref(
     developer_active_days,
-    window := @rolling_window,
-    unit := @rolling_unit
+    time_aggregation := @time_aggregation,
   ) as active
-where active.amount / @rolling_window < @full_time_ratio
-  and active.metrics_sample_date = @metrics_end('DATE')
+where active.amount / @metrics_sample_interval_length(active.metrics_sample_date, 'day') < @full_time_ratio
 group by metric,
   from_artifact_id,
   @metrics_entity_type_col('to_{entity_type}_id', table_alias := active),
@@ -59,10 +55,8 @@ select active.metrics_sample_date,
   COUNT(DISTINCT active.from_artifact_id) as amount
 from @metrics_peer_ref(
     developer_active_days,
-    window := @rolling_window,
-    unit := @rolling_unit
+    time_aggregation := @time_aggregation,
   ) as active
-where active.metrics_sample_date = @metrics_end('DATE')
 group by metric,
   from_artifact_id,
   @metrics_entity_type_col('to_{entity_type}_id', table_alias := active),

--- a/warehouse/oso_sqlmesh/oso_metrics/code/prs_time_to_merge.sql
+++ b/warehouse/oso_sqlmesh/oso_metrics/code/prs_time_to_merge.sql
@@ -8,5 +8,5 @@ select
 from oso.int_issue_event_time_deltas
 where
     event_type = 'PULL_REQUEST_MERGED'
-    and `time` between @metrics_start('DATE') and @metrics_end('DATE')
+    and "time" between @metrics_start('DATE') and @metrics_end('DATE')
 group by 1, metric, from_artifact_id, to_artifact_id, event_source,

--- a/warehouse/oso_sqlmesh/oso_metrics/code/time_to_first_response.sql
+++ b/warehouse/oso_sqlmesh/oso_metrics/code/time_to_first_response.sql
@@ -1,5 +1,5 @@
 select
-    @metrics_sample_date(time) as metrics_sample_date,
+    @metrics_sample_date("time") as metrics_sample_date,
     event_source,
     to_artifact_id,
     '' as from_artifact_id,
@@ -14,5 +14,5 @@ where
             and comments = 1
         )
     )
-    and `time` between @metrics_start('DATE') and @metrics_end('DATE')
+    and time between @metrics_start('DATE') and @metrics_end('DATE')
 group by 1, metric, from_artifact_id, to_artifact_id, event_source,

--- a/warehouse/oso_sqlmesh/tests/test_developer_active_days_over_window.yml
+++ b/warehouse/oso_sqlmesh/tests/test_developer_active_days_over_window.yml
@@ -1,8 +1,8 @@
-test_developer_active_days_to_artifact_over_30_day_window_with_cumulative_active_days:
+test_developer_active_days_to_artifact_monthly_with_cumulative_active_days:
   # Tests rolling count of active days when the user is active 4 of the 5 days
   # in the test interval
   gateway: local
-  model: oso.developer_active_days_to_artifact_over_30_day_window
+  model: oso.developer_active_days_to_artifact_monthly
   vars:
     start: 2024-01-01
     end: 2024-01-05
@@ -34,38 +34,20 @@ test_developer_active_days_to_artifact_over_30_day_window_with_cumulative_active
         bucket_day: 2024-01-04
         amount: 20
   outputs:
-    partial: true
     query:
       partial: true
       rows:
       - to_artifact_id: repo_0
         from_artifact_id: dev_0
         metrics_sample_date: 2024-01-01
-        amount: 1
-      - to_artifact_id: repo_0
-        from_artifact_id: dev_0
-        metrics_sample_date: 2024-01-02
-        amount: 2
-      - to_artifact_id: repo_0
-        from_artifact_id: dev_0
-        metrics_sample_date: 2024-01-03
-        amount: 3
-      - to_artifact_id: repo_0
-        from_artifact_id: dev_0
-        metrics_sample_date: 2024-01-04
-        amount: 4
-      - to_artifact_id: repo_0
-        from_artifact_id: dev_0
-        metrics_sample_date: 2024-01-05
         amount: 4
 
-test_developer_active_days_to_artifact_over_30_day_window_with_1_active_day:
-  # Tests rolling count of active days when the user is active 1 in the test interval
+test_developer_active_days_to_artifact_monthly_with_1_active_day:
   gateway: local
-  model: oso.developer_active_days_to_artifact_over_30_day_window
+  model: oso.developer_active_days_to_artifact_monthly
   vars:
     start: 2024-01-01
-    end: 2024-01-03
+    end: 2024-01-31
   inputs:
     oso.int_events_daily__github:
       rows:
@@ -75,20 +57,17 @@ test_developer_active_days_to_artifact_over_30_day_window_with_1_active_day:
         event_type: COMMIT_CODE
         bucket_day: 2024-01-01
         amount: 10
+      - to_artifact_id: repo_0
+        from_artifact_id: dev_0
+        event_source: SOURCE_PROVIDER
+        event_type: COMMIT_CODE
+        bucket_day: 2024-01-02
+        amount: 10
   outputs:
-    partial: true
     query:
       partial: true
       rows:
       - to_artifact_id: repo_0
         from_artifact_id: dev_0
         metrics_sample_date: 2024-01-01
-        amount: 1
-      - to_artifact_id: repo_0
-        from_artifact_id: dev_0
-        metrics_sample_date: 2024-01-02
-        amount: 1
-      - to_artifact_id: repo_0
-        from_artifact_id: dev_0
-        metrics_sample_date: 2024-01-03
-        amount: 1
+        amount: 2

--- a/warehouse/oso_sqlmesh/tests/test_developer_classification_over_window.yml
+++ b/warehouse/oso_sqlmesh/tests/test_developer_classification_over_window.yml
@@ -1,13 +1,13 @@
-test_developer_classifications_to_artifact_over_30_day_window_full_time_devs:
+test_developer_classifications_to_artifact_monthly_full_time_devs:
   # Tests rolling count of active days when the user is active 4 of the 5 days
   # in the test interval
   gateway: local
-  model: oso.developer_classifications_to_artifact_over_30_day_window
+  model: oso.developer_classifications_to_artifact_monthly
   vars:
     start: 2024-01-01
-    end: 2024-01-01
+    end: 2024-01-31
   inputs:
-    oso.developer_active_days_to_artifact_over_30_day_window:
+    oso.developer_active_days_to_artifact_monthly:
       rows:
       - to_artifact_id: repo_0
         from_artifact_id: dev_0
@@ -22,18 +22,17 @@ test_developer_classifications_to_artifact_over_30_day_window_full_time_devs:
         metric: developer_active_days
         amount: 30
   outputs:
-    partial: true
     query:
       partial: true
       rows:
       - metrics_sample_date: 2024-01-01
         to_artifact_id: repo_0
         from_artifact_id: ""
-        metric: full_time_developers_over_30_day_window
+        metric: full_time_developers_monthly
         amount: 2
       - metrics_sample_date: 2024-01-01
         to_artifact_id: repo_0
         from_artifact_id: ""
-        metric: active_developers_over_30_day_window
+        metric: active_developers_monthly
         amount: 2
 


### PR DESCRIPTION
Replaces the rolling windows with larger time buckets. Some things to note, we should not display the last of a given time bucket because it won't be completed. I tried a way to prevent it calculating unnecessarily but unfortunately that seems to bug out on tests. I think it's best to just skip any "unfinished" results that might appear when we render on the frontend. 