### PR TITLE
feat: ModelPage route

### DIFF
--- a/apps/frontend/app/models/[...name]/error.tsx
+++ b/apps/frontend/app/models/[...name]/error.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import { redirect } from "next/navigation";
+import { useEffect } from "react";
+import { logger } from "../../../lib/logger";
+
+const REDIRECT_URL = "/retry";
+
+type ErrorPageProps = {
+  error: Error & { digest?: string };
+  reset: () => void;
+};
+
+export default function Error(props: ErrorPageProps) {
+  const { error } = props;
+  useEffect(() => {
+    logger.error(error);
+  }, [error]);
+
+  redirect(REDIRECT_URL);
+}

--- a/apps/frontend/app/models/[...name]/page.tsx
+++ b/apps/frontend/app/models/[...name]/page.tsx
@@ -1,0 +1,90 @@
+import { notFound } from "next/navigation";
+import { cache } from "react";
+import { PlasmicComponent } from "@plasmicapp/loader-nextjs";
+import { PLASMIC } from "../../../plasmic-init";
+import { PlasmicClientRootProvider } from "../../../plasmic-init-client";
+import { cachedGetModelByName } from "../../../lib/clickhouse/cached-queries";
+import { logger } from "../../../lib/logger";
+import { catchallPathToString } from "../../../lib/paths";
+
+const PLASMIC_COMPONENT = "ModelPage";
+//export const dynamic = STATIC_EXPORT ? "force-static" : "force-dynamic";
+//export const dynamic = "force-static";
+export const dynamic = "force-dynamic";
+export const dynamicParams = true;
+export const revalidate = false; // 3600 = 1 hour
+// TODO: This cannot be empty due to this bug
+// https://github.com/vercel/next.js/issues/61213
+const STATIC_EXPORT_SLUGS: string[] = ["models_v0"];
+export async function generateStaticParams() {
+  return STATIC_EXPORT_SLUGS.map((s) => ({
+    name: [s],
+  }));
+}
+
+const cachedFetchComponent = cache(async (componentName: string) => {
+  try {
+    const plasmicData = await PLASMIC.fetchComponentData(componentName);
+    return plasmicData;
+  } catch (e) {
+    logger.warn(e);
+    return null;
+  }
+});
+
+/**
+ * This SSR route allows us to fetch the project from the database
+ * on the first HTTP request, which should be faster than fetching it client-side
+ */
+
+type ModelPagePath = {
+  name: string[];
+};
+
+type ModelPageProps = {
+  params: ModelPagePath;
+};
+
+export default async function ModelPage(props: ModelPageProps) {
+  const { params } = props;
+  if (!params.name || !Array.isArray(params.name) || params.name.length < 1) {
+    logger.warn("Invalid model page path", params);
+    notFound();
+  }
+
+  // Get project metadata from the database
+  const name = catchallPathToString(params.name);
+  const modelArray = await cachedGetModelByName({
+    modelName: name,
+  });
+  if (!Array.isArray(modelArray) || modelArray.length < 1) {
+    logger.warn(`Cannot find model (name=${name})`);
+    notFound();
+  }
+  const model = modelArray[0];
+
+  //console.log("!!!");
+  //console.log(model);
+
+  // Get Plasmic component
+  const plasmicData = await cachedFetchComponent(PLASMIC_COMPONENT);
+  if (!plasmicData) {
+    logger.warn(`Unable to get componentName=${PLASMIC_COMPONENT}`);
+    notFound();
+  }
+  const compMeta = plasmicData.entryCompMetas[0];
+
+  return (
+    <PlasmicClientRootProvider
+      prefetchedData={plasmicData}
+      pageParams={compMeta.params}
+    >
+      <PlasmicComponent
+        component={compMeta.displayName}
+        componentProps={{
+          metadata: model,
+        }}
+      />
+    </PlasmicClientRootProvider>
+  );
+}

--- a/apps/frontend/app/models/page.tsx
+++ b/apps/frontend/app/models/page.tsx
@@ -1,0 +1,39 @@
+import { notFound } from "next/navigation";
+import { cache } from "react";
+import { PlasmicComponent } from "@plasmicapp/loader-nextjs";
+import { PLASMIC } from "../../plasmic-init";
+import { PlasmicClientRootProvider } from "../../plasmic-init-client";
+import { logger } from "../../lib/logger";
+
+const PLASMIC_COMPONENT = "ModelPage";
+export const dynamic = "force-static";
+export const revalidate = false; // 3600 = 1 hour
+
+const cachedFetchComponent = cache(async (componentName: string) => {
+  try {
+    const plasmicData = await PLASMIC.fetchComponentData(componentName);
+    return plasmicData;
+  } catch (e) {
+    logger.warn(e);
+    return null;
+  }
+});
+
+export default async function ModelPage() {
+  // Get Plasmic component
+  const plasmicData = await cachedFetchComponent(PLASMIC_COMPONENT);
+  if (!plasmicData) {
+    logger.warn(`Unable to get componentName=${PLASMIC_COMPONENT}`);
+    notFound();
+  }
+  const compMeta = plasmicData.entryCompMetas[0];
+
+  return (
+    <PlasmicClientRootProvider
+      prefetchedData={plasmicData}
+      pageParams={compMeta.params}
+    >
+      <PlasmicComponent component={compMeta.displayName} />
+    </PlasmicClientRootProvider>
+  );
+}

--- a/apps/frontend/lib/clickhouse/cached-queries.ts
+++ b/apps/frontend/lib/clickhouse/cached-queries.ts
@@ -11,6 +11,7 @@ import {
   GET_COLLECTIONS_BY_IDS,
   GET_COLLECTION_BY_NAME,
   GET_COLLECTION_IDS_BY_PROJECT_IDS,
+  GET_MODEL_BY_NAME,
   GET_METRICS_BY_IDS,
   GET_METRIC_BY_NAME,
   GET_KEY_METRICS_BY_ARTIFACT,
@@ -133,6 +134,13 @@ const cachedGetCollectionIdsByProjectIds = cache(
     }),
 );
 
+const cachedGetModelByName = cache(async (variables: { modelName: string }) =>
+  queryWrapper({
+    query: GET_MODEL_BY_NAME,
+    variables,
+  }),
+);
+
 const cachedGetMetricsByIds = cache(
   async (variables: { metricIds: string[] }) =>
     queryWrapper({
@@ -187,6 +195,7 @@ export {
   cachedGetCollectionByName,
   cachedGetCollectionsByIds,
   cachedGetCollectionIdsByProjectIds,
+  cachedGetModelByName,
   cachedGetMetricsByIds,
   cachedGetMetricByName,
   cachedGetKeyMetricsByArtifact,

--- a/apps/frontend/lib/clickhouse/queries.ts
+++ b/apps/frontend/lib/clickhouse/queries.ts
@@ -216,6 +216,30 @@ const GET_COLLECTION_IDS_BY_PROJECT_IDS = define(
 );
 
 /**********************
+ * MODELS
+ **********************/
+
+const modelResponse = {
+  model_id: "",
+  model_name: "",
+  rendered_sql: "",
+};
+
+const GET_MODEL_BY_NAME = define(
+  `
+  SELECT 
+    model_id, 
+    model_name, 
+    rendered_sql
+  FROM 
+    models_v0
+  WHERE 
+    model_name = {modelName: String}
+`,
+  modelResponse,
+);
+
+/**********************
  * METRICS
  **********************/
 
@@ -375,6 +399,7 @@ export {
   GET_COLLECTIONS_BY_IDS,
   GET_COLLECTION_BY_NAME,
   GET_COLLECTION_IDS_BY_PROJECT_IDS,
+  GET_MODEL_BY_NAME,
   GET_ALL_METRICS,
   GET_METRICS_BY_IDS,
   GET_METRIC_BY_NAME,


### PR DESCRIPTION
* Adds a /models/[...name] route that just shows the rendered SQL of a model
* Enables querying anything from `models_v0`
* Also added support for the Algolia index to serve any model