### PR TITLE
revert some staging models to "duckdb"

### DIFF
--- a/warehouse/oso_sqlmesh/models/intermediate/events/int_events__dependencies.sql
+++ b/warehouse/oso_sqlmesh/models/intermediate/events/int_events__dependencies.sql
@@ -10,6 +10,7 @@ MODEL (
   cron '@daily',
   partitioned_by (DAY("time"), "event_type"),
   grain (time, event_type, event_source, from_artifact_id, to_artifact_id)
+  enabled false,
 );
 
 @DEF(event_source_name, 'DEPS_DEV');

--- a/warehouse/oso_sqlmesh/models/intermediate/events/int_events__dependencies.sql
+++ b/warehouse/oso_sqlmesh/models/intermediate/events/int_events__dependencies.sql
@@ -9,7 +9,7 @@ MODEL (
   start @github_incremental_start,
   cron '@daily',
   partitioned_by (DAY("time"), "event_type"),
-  grain (time, event_type, event_source, from_artifact_id, to_artifact_id)
+  grain (time, event_type, event_source, from_artifact_id, to_artifact_id),
   enabled false,
 );
 

--- a/warehouse/oso_sqlmesh/models/intermediate/events/int_events_daily__dependencies.sql
+++ b/warehouse/oso_sqlmesh/models/intermediate/events/int_events_daily__dependencies.sql
@@ -8,7 +8,8 @@ MODEL (
   start @github_incremental_start,
   cron '@daily',
   partitioned_by (DAY("bucket_day"), "event_type"),
-  grain (bucket_day, event_type, event_source, from_artifact_id, to_artifact_id)
+  grain (bucket_day, event_type, event_source, from_artifact_id, to_artifact_id),
+  enabled false
 );
 
 SELECT

--- a/warehouse/oso_sqlmesh/models/marts/events/event_types_v1.sql
+++ b/warehouse/oso_sqlmesh/models/marts/events/event_types_v1.sql
@@ -18,10 +18,6 @@ WITH all_event_types AS (
   SELECT
     event_type
   FROM oso.int_events_daily__funding
-  UNION ALL
-  SELECT
-    event_type
-  FROM oso.int_events_daily__dependencies
 )
 
 SELECT DISTINCT

--- a/warehouse/oso_sqlmesh/models/metrics_factories.py
+++ b/warehouse/oso_sqlmesh/models/metrics_factories.py
@@ -22,7 +22,6 @@ timeseries_metrics(
         "int_events_daily__github",
         "int_events_daily__github_with_lag",
         "int_events_daily__funding",
-        "int_events_daily__dependencies",
     ],
     metric_queries={
         # This will automatically generate star counts for the given roll up periods.
@@ -517,25 +516,25 @@ timeseries_metrics(
             ),
             additional_tags=["data_category:funding"],
         ),
-        "dependencies": MetricQueryDef(
-            ref="deps/dependencies.sql",
-            time_aggregations=[
-                "daily",
-                "weekly",
-                "monthly",
-                "quarterly",
-                "biannually",
-                "yearly",
-            ],
-            entity_types=["artifact", "project", "collection"],
-            over_all_time=True,
-            metadata=MetricMetadata(
-                display_name="Dependencies",
-                description="Metrics related to dependencies",
-            ),
-            additional_tags=[
-                "data_category:dependencies",
-            ],
-        ),
+        # "dependencies": MetricQueryDef(
+        #     ref="deps/dependencies.sql",
+        #     time_aggregations=[
+        #         "daily",
+        #         "weekly",
+        #         "monthly",
+        #         "quarterly",
+        #         "biannually",
+        #         "yearly",
+        #     ],
+        #     entity_types=["artifact", "project", "collection"],
+        #     over_all_time=True,
+        #     metadata=MetricMetadata(
+        #         display_name="Dependencies",
+        #         description="Metrics related to dependencies",
+        #     ),
+        #     additional_tags=[
+        #         "data_category:dependencies",
+        #     ],
+        # ),
     },
 )

--- a/warehouse/oso_sqlmesh/models/staging/github/stg_github__distinct_commits_resolved_mergebot.sql
+++ b/warehouse/oso_sqlmesh/models/staging/github/stg_github__distinct_commits_resolved_mergebot.sql
@@ -8,6 +8,7 @@ MODEL (
     lookback 7
   ),
   start @github_incremental_start,
+  dialect duckdb,
   partitioned_by DAY(created_at)
 );
 

--- a/warehouse/oso_sqlmesh/models/staging/github/stg_github__releases.sql
+++ b/warehouse/oso_sqlmesh/models/staging/github/stg_github__releases.sql
@@ -8,6 +8,7 @@ MODEL (
   ),
   start @github_incremental_start,
   partitioned_by DAY(created_at),
+  dialect duckdb,
 );
 
 WITH release_events AS (

--- a/warehouse/oso_sqlmesh/models/staging/github/stg_github__stars_and_forks.sql
+++ b/warehouse/oso_sqlmesh/models/staging/github/stg_github__stars_and_forks.sql
@@ -8,6 +8,7 @@ MODEL (
   ),
   start @github_incremental_start,
   partitioned_by DAY(created_at),
+  dialect duckdb,
 );
 
 WITH watch_events AS (

--- a/warehouse/oso_sqlmesh/models/staging/superchain/stg_superchain__4337_userop_logs.sql
+++ b/warehouse/oso_sqlmesh/models/staging/superchain/stg_superchain__4337_userop_logs.sql
@@ -17,7 +17,8 @@ MODEL (
     sender_address,
     paymaster_address,
     contract_address
-  )
+  ),
+  dialect duckdb,
 );
 
 SELECT

--- a/warehouse/oso_sqlmesh/models/staging/superchain/stg_superchain__deployers.sql
+++ b/warehouse/oso_sqlmesh/models/staging/superchain/stg_superchain__deployers.sql
@@ -9,7 +9,8 @@ MODEL (
   start @blockchain_incremental_start,
   cron '@daily',
   partitioned_by (DAY("block_timestamp"), "chain"),
-  grain (block_timestamp, chain_id, transaction_hash, deployer_address, contract_address)
+  grain (block_timestamp, chain_id, transaction_hash, deployer_address, contract_address),
+  dialect duckdb,
 );
 
 @transactions_with_receipts_deployers(

--- a/warehouse/oso_sqlmesh/models/staging/superchain/stg_superchain__factories.sql
+++ b/warehouse/oso_sqlmesh/models/staging/superchain/stg_superchain__factories.sql
@@ -9,7 +9,8 @@ MODEL (
   start @blockchain_incremental_start,
   cron '@daily',
   partitioned_by (DAY("block_timestamp"), "chain", "create_type"),
-  grain (block_timestamp, chain_id, transaction_hash, deployer_address, contract_address)
+  grain (block_timestamp, chain_id, transaction_hash, deployer_address, contract_address),
+  dialect duckdb,
 );
 
 @factory_deployments(

--- a/warehouse/oso_sqlmesh/models/staging/superchain/stg_superchain__proxies.sql
+++ b/warehouse/oso_sqlmesh/models/staging/superchain/stg_superchain__proxies.sql
@@ -18,7 +18,8 @@ MODEL (
     to_address,
     proxy_type,
     proxy_address
-  )
+  ),
+  dialect duckdb,
 );
 
 @known_proxies(

--- a/warehouse/oso_sqlmesh/models/staging/superchain/stg_superchain__traces.sql
+++ b/warehouse/oso_sqlmesh/models/staging/superchain/stg_superchain__traces.sql
@@ -9,7 +9,8 @@ MODEL (
   start @blockchain_incremental_start,
   cron '@daily',
   partitioned_by (DAY("block_timestamp"), "chain"),
-  grain (block_timestamp, chain, transaction_hash, from_address, to_address)
+  grain (block_timestamp, chain, transaction_hash, from_address, to_address),
+  dialect duckdb,
 );
 
 SELECT

--- a/warehouse/oso_sqlmesh/models/staging/superchain/stg_superchain__transactions.sql
+++ b/warehouse/oso_sqlmesh/models/staging/superchain/stg_superchain__transactions.sql
@@ -9,7 +9,8 @@ MODEL (
   start '2021-10-01',
   cron '@daily',
   partitioned_by (DAY("block_timestamp"), "chain"),
-  grain (block_timestamp, chain, transaction_hash, from_address, to_address)
+  grain (block_timestamp, chain, transaction_hash, from_address, to_address),
+  dialect duckdb,
 );
 
 SELECT


### PR DESCRIPTION
This ensures that we don't unnecessarily restate things in the next production run. Also this disables dependencies for now. 