### PR TITLE
chore: reduce run launcher request sizes

### DIFF
--- a/ops/k8s-apps/base/redis/redis.yaml
+++ b/ops/k8s-apps/base/redis/redis.yaml
@@ -31,7 +31,6 @@ spec:
             cpu: "100m"
           limits:
             memory: "2048Mi"
-            cpu: "200m"
         env:
         - name: REDIS_MAXMEMORY
           value: "1024mb"

--- a/ops/k8s-apps/production/dagster/custom-helm-values.yaml
+++ b/ops/k8s-apps/production/dagster/custom-helm-values.yaml
@@ -38,7 +38,7 @@ spec:
           limits:
             memory: 768Mi
           requests:
-            cpu: 500m
+            cpu: 100m
             memory: 512Mi
 
       dagsterWebserver:
@@ -49,7 +49,7 @@ spec:
           limits:
             memory: 768Mi
           requests:
-            cpu: 500m
+            cpu: 100m
             memory: 512Mi
 
       runLauncher:

--- a/ops/k8s-apps/production/dagster/custom-helm-values.yaml
+++ b/ops/k8s-apps/production/dagster/custom-helm-values.yaml
@@ -69,8 +69,8 @@ spec:
                   limits:
                     memory: 2048Mi
                   requests:
-                    cpu: 700m
-                    memory: 1024Mi
+                    cpu: 100m
+                    memory: 512Mi
         
     sqlmesh:
       gateway: "trino"

--- a/ops/k8s-infrastructure/gke/gcp-secrets-store-plugin/gcp-secrets-store-plugin.yaml
+++ b/ops/k8s-infrastructure/gke/gcp-secrets-store-plugin/gcp-secrets-store-plugin.yaml
@@ -97,10 +97,9 @@ spec:
           imagePullPolicy: IfNotPresent
           resources:
             requests:
-              cpu: 50m
+              cpu: 25m
               memory: 100Mi
             limits:
-              cpu: 50m
               memory: 100Mi
           env:
             - name: TARGET_DIR

--- a/warehouse/oso_dagster/utils/dlt.py
+++ b/warehouse/oso_dagster/utils/dlt.py
@@ -362,7 +362,7 @@ CHUNKED_STATE_JOB_CONFIG = {
         "container_config": {
             "resources": {
                 "requests": {
-                    "cpu": "500m",
+                    "cpu": "250m",
                     "memory": "1024Mi",
                 },
                 "limits": {


### PR DESCRIPTION
Trying to do some cost reduction. The run launcher spins up a bunch of pods just to monitor steps. I'm wondering if we can do better here. 