### PR TITLE
feat: implement `oso-mcp` server

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,7 +103,7 @@ dev = [
 pyoso = { workspace = true }
 
 [tool.uv.workspace]
-members = ["warehouse/pyoso"]
+members = ["warehouse/pyoso", "warehouse/oso_mcp"]
 
 [build-system]
 requires = ["hatchling"]

--- a/uv.lock
+++ b/uv.lock
@@ -10,6 +10,7 @@ resolution-markers = [
 [manifest]
 members = [
     "oso",
+    "oso-mcp",
     "pyoso",
 ]
 
@@ -2041,6 +2042,15 @@ wheels = [
 ]
 
 [[package]]
+name = "httpx-sse"
+version = "0.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4c/60/8f4281fa9bbf3c8034fd54c0e7412e66edbab6bc74c4996bd616f8d0406e/httpx-sse-0.4.0.tar.gz", hash = "sha256:1e81a3a3070ce322add1d3529ed42eb5f70817f45ed6ec915ab753f961139721", size = 12624 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/9b/a181f281f65d776426002f330c31849b86b31fc9d848db62e16f03ff739f/httpx_sse-0.4.0-py3-none-any.whl", hash = "sha256:f329af6eae57eaa2bdfd962b42524764af68075ea87370a2de920af5341e318f", size = 7819 },
+]
+
+[[package]]
 name = "httpx-ws"
 version = "0.7.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2557,6 +2567,31 @@ wheels = [
 ]
 
 [[package]]
+name = "mcp"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpx" },
+    { name = "httpx-sse" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+    { name = "sse-starlette" },
+    { name = "starlette" },
+    { name = "uvicorn" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/95/d2/f587cb965a56e992634bebc8611c5b579af912b74e04eb9164bd49527d21/mcp-1.6.0.tar.gz", hash = "sha256:d9324876de2c5637369f43161cd71eebfd803df5a95e46225cab8d280e366723", size = 200031 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/30/20a7f33b0b884a9d14dd3aa94ff1ac9da1479fe2ad66dd9e2736075d2506/mcp-1.6.0-py3-none-any.whl", hash = "sha256:7bd24c6ea042dbec44c754f100984d186620d8b841ec30f1b19eda9b93a634d0", size = 76077 },
+]
+
+[package.optional-dependencies]
+cli = [
+    { name = "python-dotenv" },
+    { name = "typer" },
+]
+
+[[package]]
 name = "mdit-py-plugins"
 version = "0.4.2"
 source = { registry = "https://pypi.org/simple" }
@@ -2955,6 +2990,27 @@ dev = [
     { name = "shandy-sqlfmt", extras = ["jinjafmt"], specifier = ">=0.21.1,<1.0.0" },
     { name = "sqlfluff", specifier = "~=3.2.5" },
     { name = "sqlfluff-templater-dbt", specifier = "~=3.2.5" },
+]
+
+[[package]]
+name = "oso-mcp"
+version = "0.1.0"
+source = { virtual = "warehouse/oso_mcp" }
+dependencies = [
+    { name = "mcp", extra = ["cli"] },
+    { name = "pydantic" },
+    { name = "pyoso" },
+    { name = "python-dotenv" },
+    { name = "requests" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "mcp", extras = ["cli"], specifier = ">=1.6.0" },
+    { name = "pydantic", specifier = ">=2.10.6" },
+    { name = "pyoso", editable = "warehouse/pyoso" },
+    { name = "python-dotenv", specifier = ">=1.0.1" },
+    { name = "requests", specifier = ">=2.32.3" },
 ]
 
 [[package]]
@@ -4383,6 +4439,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e5/40/edede8dd6977b0d3da179a342c198ed100dd2aba4be081861ee5911e4da4/sqlparse-0.5.3.tar.gz", hash = "sha256:09f67787f56a0b16ecdbde1bfc7f5d9c3371ca683cfeaa8e6ff60b4807ec9272", size = 84999 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a9/5c/bfd6bd0bf979426d405cc6e71eceb8701b148b16c21d2dc3c261efc61c7b/sqlparse-0.5.3-py3-none-any.whl", hash = "sha256:cf2196ed3418f3ba5de6af7e82c694a9fbdbfecccdfc72e281548517081f16ca", size = 44415 },
+]
+
+[[package]]
+name = "sse-starlette"
+version = "2.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "starlette" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/71/a4/80d2a11af59fe75b48230846989e93979c892d3a20016b42bb44edb9e398/sse_starlette-2.2.1.tar.gz", hash = "sha256:54470d5f19274aeed6b2d473430b08b4b379ea851d953b11d7f1c4a2c118b419", size = 17376 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d9/e0/5b8bd393f27f4a62461c5cf2479c75a2cc2ffa330976f9f00f5f6e4f50eb/sse_starlette-2.2.1-py3-none-any.whl", hash = "sha256:6410a3d3ba0c89e7675d4c273a301d64649c03a5ef1ca101f10b47f895fd0e99", size = 10120 },
 ]
 
 [[package]]

--- a/warehouse/oso_mcp/README.md
+++ b/warehouse/oso_mcp/README.md
@@ -1,0 +1,133 @@
+# OSO-MCP Server
+
+A Model Context Protocol (MCP) server for interacting with the Open Source
+Observer (OSO) data lake.
+
+> [!WARNING]
+> This is a work in progress and is not yet ready for production use. Yet.
+
+## Overview
+
+This MCP server provides tools for exploring and analyzing the Open Source
+Observer (OSO) data lake, allowing you to:
+
+- Run SQL queries against the OSO data lake
+- Explore available tables and their schemas
+- Access sample queries to help you get started
+
+OSO tracks metrics about open source projects, including GitHub stats, funding
+data, and on-chain activity.
+
+## Installation
+
+1. Install dependencies:
+
+```bash
+uv venv && uv sync
+```
+
+2. Get an OSO API key from
+   [Open Source Observer](https://www.opensource.observer). Follow the
+   instructions in the [Getting OSO API Key](#getting-oso-api-key) section to
+   obtain your key.
+
+## Setting Up with Claude Desktop
+
+1. Open Claude Desktop settings by clicking on the Claude menu and selecting
+   "Settings"
+2. Select "Developer" in the sidebar and click "Edit Config"
+3. Add the following configuration to the `claude_desktop_config.json`:
+
+```jsonc
+{
+  "mcpServers": {
+    // other MCP servers...
+    "oso-data-lake": {
+      "command": "uv",
+      "args": ["run", "/path/to/your/oso/warehouse/oso_mcp/main.py"],
+      "env": {
+        "OSO_API_KEY": "your_api_key_here",
+        "VIRTUAL_ENV": "/path/to/your/oso/warehouse/oso_mcp/.venv",
+      },
+    },
+  },
+}
+```
+
+4. Replace `/path/to/your/oso_mcp/` with the actual path to your repository
+5. Replace `your_api_key_here` with your OSO API key
+6. Restart Claude Desktop
+
+## Available Tools
+
+### query_oso
+
+Run SQL queries against the OSO data lake.
+
+**Parameters:**
+
+- `sql` (string): SQL query to execute (SELECT statements only)
+- `limit` (integer, optional): Limit to apply to the query results
+
+**Example:**
+
+```
+Can you run this SQL query against the OSO data lake: SELECT * FROM collections_v1 LIMIT 5
+```
+
+### list_tables
+
+List all available tables in the OSO data lake.
+
+**Example:**
+
+```
+What tables are available in the OSO data lake?
+```
+
+### get_table_schema
+
+Get the schema for a specific table in the OSO data lake.
+
+**Parameters:**
+
+- `table_name` (string): Name of the table to get schema for
+
+**Example:**
+
+```
+Show me the schema for the projects_v1 table
+```
+
+### get_sample_queries
+
+Get a set of sample queries to help users get started with the OSO data lake.
+
+**Example:**
+
+```
+Show me some sample queries for the OSO data lake
+```
+
+## Resources
+
+- **help://getting-started**: Basic guide to using the OSO data lake explorer
+
+## Example Usage
+
+Here are some examples of how you might use this MCP server with Claude:
+
+1. "Show me the available tables in the OSO data lake"
+2. "What's the schema for the projects_v1 table?"
+3. "Can you run a query to find the top 10 most funded open source projects?"
+4. "Analyze the funding history of the Uniswap project"
+5. "Show me all the projects in the ethereum-github collection"
+6. "Do a deep dive on the contribution patterns for the ethereum project"
+
+## Getting OSO API Key
+
+1. Go to [www.opensource.observer](https://www.opensource.observer) and create
+   an account
+2. Go to [Account settings](https://www.opensource.observer/settings/profile)
+3. In the "API" section, click "+ New"
+4. Give your key a label and save the key when it's generated

--- a/warehouse/oso_mcp/main.py
+++ b/warehouse/oso_mcp/main.py
@@ -1,0 +1,306 @@
+import os
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+from dotenv import load_dotenv
+from mcp.server.fastmcp import Context, FastMCP
+from pyoso import Client
+
+load_dotenv()
+
+
+@dataclass
+class AppContext:
+    oso_client: Optional[Client] = None
+
+
+@asynccontextmanager
+async def app_lifespan(_server: FastMCP) -> AsyncIterator[AppContext]:
+    """Manage application lifecycle with OSO client in context"""
+    api_key = os.environ.get("OSO_API_KEY")
+    if not api_key:
+        raise ValueError("OSO_API_KEY environment variable is required")
+
+    client = Client(api_key)
+    context = AppContext(oso_client=client)
+
+    try:
+        yield context
+    finally:
+        pass
+
+
+mcp = FastMCP(
+    "OSO Data Lake Explorer",
+    dependencies=["pyoso", "python-dotenv", "requests"],
+    lifespan=app_lifespan,
+)
+
+
+@mcp.tool()
+async def query_oso(
+    sql: str,
+    ctx: Context,
+    limit: Optional[int] = None,
+) -> Dict[str, Any]:
+    """
+    Run a SQL query against the OSO data lake.
+
+    Args:
+        sql: SQL query to execute (SELECT statements only)
+        limit: Optional limit to apply to the query results
+
+    Returns:
+        Dict containing query results and metadata
+    """
+    if ctx:
+        await ctx.info(f"Executing query: {sql}")
+
+    if limit is not None:
+        sql_upper = sql.upper().strip()
+
+        if "LIMIT" not in sql_upper.split() and limit is not None:
+            sql = f"{sql.rstrip(';')} LIMIT {limit}"
+        elif limit is not None and ctx:
+            await ctx.warning(
+                "LIMIT clause already exists in query; ignoring limit parameter"
+            )
+
+    try:
+        oso_client: Optional[Client] = ctx.request_context.lifespan_context.oso_client
+        if not oso_client:
+            raise ValueError("OSO client is not available in the context")
+
+        df = oso_client.to_pandas(sql)
+
+        results = df.to_dict(orient="records")
+
+        response = {
+            "success": True,
+            "query": sql,
+            "row_count": len(results),
+            "columns": list(df.columns),
+            "results": results,
+        }
+
+        return response
+    except Exception as e:
+        error_msg = str(e)
+        if ctx:
+            await ctx.error(f"Query failed: {error_msg}")
+
+        return {"success": False, "query": sql, "error": error_msg}
+
+
+@mcp.tool()
+async def list_tables(ctx: Context) -> Dict[str, Any]:
+    """
+    List all available tables in the OSO data lake.
+
+    Returns:
+        Dict containing list of available tables
+    """
+    try:
+        oso_client: Optional[Client] = ctx.request_context.lifespan_context.oso_client
+        if not oso_client:
+            raise ValueError("OSO client is not available in the context")
+
+        df = oso_client.to_pandas("SHOW TABLES")
+
+        tables = df.to_dict(orient="records")
+
+        return {"success": True, "tables": tables}
+    except Exception as e:
+        error_msg = str(e)
+        if ctx:
+            await ctx.error(f"Failed to list tables: {error_msg}")
+
+        return {"success": False, "error": error_msg}
+
+
+@mcp.tool()
+async def get_table_schema(
+    table_name: str,
+    ctx: Context,
+) -> Dict[str, Any]:
+    """
+    Get the schema for a specific table in the OSO data lake.
+
+    Args:
+        table_name: Name of the table to get schema for
+
+    Returns:
+        Dict containing table schema information
+    """
+    try:
+        oso_client: Optional[Client] = ctx.request_context.lifespan_context.oso_client
+        if not oso_client:
+            raise ValueError("OSO client is not available in the context")
+
+        schema_query = f"DESCRIBE {table_name}"
+        df = oso_client.to_pandas(schema_query)
+
+        schema = df.to_dict(orient="records")
+
+        return {"success": True, "table": table_name, "schema": schema}
+    except Exception as e:
+        error_msg = str(e)
+        if ctx:
+            await ctx.error(f"Failed to get schema for {table_name}: {error_msg}")
+
+        return {"success": False, "table": table_name, "error": error_msg}
+
+
+@mcp.tool()
+async def get_sample_queries(ctx: Context) -> Dict[str, Any]:
+    """
+    Get a set of sample queries to help users get started with the OSO data lake.
+
+    Returns:
+        Dict containing sample queries with descriptions
+    """
+    return {
+        "success": True,
+        "samples": [
+            {
+                "name": "All Collections",
+                "description": "Get the names of all collections on OSO",
+                "query": """
+                SELECT
+                  collection_name,
+                  display_name
+                FROM collections_v1
+                ORDER BY collection_name
+                """,
+            },
+            {
+                "name": "Projects in Collection",
+                "description": "Get the names of all projects in the Ethereum GitHub collection",
+                "query": """
+                SELECT
+                  project_id,
+                  project_name
+                FROM projects_by_collection_v1
+                WHERE collection_name = 'ethereum-github'
+                """,
+            },
+            {
+                "name": "Collection Code Metrics",
+                "description": "Get GitHub commit metrics for the Ethereum GitHub collection",
+                "query": """
+                SELECT
+                  tm.sample_date,
+                  tm.amount
+                FROM timeseries_metrics_by_collection_v0 AS tm
+                JOIN collections_v1 AS c ON tm.collection_id = c.collection_id
+                JOIN metrics_v0 AS m ON tm.metric_id = m.metric_id
+                WHERE
+                    c.collection_name = 'ethereum-github'
+                    AND m.metric_name = 'GITHUB_commits_daily'
+                ORDER BY 1
+                """,
+            },
+            {
+                "name": "Collection Onchain Metrics",
+                "description": "Get onchain metrics for projects in a collection",
+                "query": """
+                SELECT
+                  tm.sample_date,
+                  tm.amount
+                FROM timeseries_metrics_by_collection_v0 AS tm
+                JOIN collections_v1 AS c ON tm.collection_id = c.collection_id
+                JOIN metrics_v0 AS m ON tm.metric_id = m.metric_id
+                WHERE
+                    c.collection_name = 'op-retrofunding-4'
+                    AND m.metric_name = 'BASE_gas_fees_weekly'
+                ORDER BY 1
+                """,
+            },
+            {
+                "name": "Project Funding History",
+                "description": "Get the complete funding history for Uniswap",
+                "query": """
+                SELECT
+                  time,
+                  event_source,
+                  from_project_name as funder,
+                  amount,
+                  grant_pool_name
+                FROM oss_funding_v0
+                WHERE to_project_name = 'uniswap'
+                ORDER BY time DESC
+                """,
+            },
+            {
+                "name": "Top Funded Projects",
+                "description": "Find the projects that have received the most funding",
+                "query": """
+                SELECT
+                  to_project_name,
+                  COUNT(DISTINCT event_source) as funding_sources,
+                  COUNT(*) as number_of_grants,
+                  SUM(amount) as total_funding
+                FROM oss_funding_v0
+                GROUP BY to_project_name
+                HAVING total_funding > 0
+                ORDER BY total_funding DESC
+                LIMIT 20
+                """,
+            },
+            {
+                "name": "Repository Dependencies",
+                "description": "Get package dependencies for Ethereum Go implementation",
+                "query": """
+                SELECT *
+                FROM sboms_v0
+                WHERE from_artifact_id = '0mjl8VhWsui_6TEZZnbQzyf8h1A9bOioIlK17p0D5hI='
+                """,
+            },
+            {
+                "name": "Package Maintainers",
+                "description": "Find the repository that maintains a specific package",
+                "query": """
+                SELECT
+                  package_artifact_source,
+                  package_artifact_name,
+                  package_owner_project_id,
+                  package_owner_artifact_namespace,
+                  package_owner_artifact_name
+                FROM package_owners_v0
+                WHERE package_artifact_name = '@libp2p/echo'
+                """,
+            },
+        ],
+    }
+
+
+@mcp.resource("help://getting-started")
+def get_help_guide() -> str:
+    """
+    Resource providing help information about using the OSO data lake server.
+
+    Returns:
+        str: Help information as a string
+    """
+    return """
+    # OSO Data Lake Explorer - Getting Started
+    
+    This MCP server provides tools for querying and exploring the OSO (Open Source Observer) data lake.
+    
+    ## Available Tools
+    
+    1. `query_oso` - Run custom SQL queries against the data lake
+    2. `list_tables` - Get a list of all available tables
+    3. `get_table_schema` - Retrieve the schema for a specific table
+    4. `get_sample_queries` - Get sample queries to help you get started
+    
+    ## Authentication
+    
+    This server requires an OSO API key to be set as the `OSO_API_KEY` environment variable.
+    """
+
+
+if __name__ == "__main__":
+    mcp.run(transport="stdio")

--- a/warehouse/oso_mcp/pyproject.toml
+++ b/warehouse/oso_mcp/pyproject.toml
@@ -1,0 +1,17 @@
+[project]
+name = "oso-mcp"
+version = "0.1.0"
+description = "The OpenSource Observer MCP server"
+readme = "README.md"
+requires-python = ">=3.10"
+authors = [{ name = "Javier Ríos", email = "javi@karibalabs.co" }]
+dependencies = [
+    "mcp[cli]>=1.6.0",
+    "pydantic>=2.10.6",
+    "pyoso",
+    "python-dotenv>=1.0.1",
+    "requests>=2.32.3",
+]
+
+[tool.uv.sources]
+pyoso = { workspace = true }


### PR DESCRIPTION
This PR implements an MCP server to interact with `OSO` using `pyoso`. This means LLMs like `Claude` can interact with our data lake seamlessly. In order to achieve this, only an api key is needed. This is still an early version, so some extra config is required. Next steps would be to add more `tools` and publish it to `pypi` under `oso-mcp` or similar.