### PR TITLE
feat: add row count audit

### DIFF
--- a/warehouse/oso_sqlmesh/audits/has_at_least_n_rows.sql
+++ b/warehouse/oso_sqlmesh/audits/has_at_least_n_rows.sql
@@ -1,0 +1,12 @@
+AUDIT (
+  name has_at_least_n_rows,
+  dialect duckdb
+
+);
+
+with num_rows as (
+  select count(*) as amount from @this_model
+)
+-- Yield no rows if audit passes
+-- Yield 1 row (count) if audit fails
+select amount from num_rows where amount < @threshold

--- a/warehouse/oso_sqlmesh/models/marts/directory/artifacts_by_collection_v1.sql
+++ b/warehouse/oso_sqlmesh/models/marts/directory/artifacts_by_collection_v1.sql
@@ -3,6 +3,9 @@ MODEL (
   kind FULL,
   tags (
     'export'
+  ),
+  audits (
+    has_at_least_n_rows(threshold := 1)
   )
 );
 


### PR DESCRIPTION
* Follows the sqlmesh generic audit pattern for counting rows and reporting if it falls below a threshold