### PR TITLE
Fix: rename where export goes

### DIFF
--- a/warehouse/oso_dagster/config.py
+++ b/warehouse/oso_dagster/config.py
@@ -69,7 +69,7 @@ class DagsterConfig(BaseSettings):
     sqlmesh_gateway: str = "local"
     sqlmesh_catalog: str = "iceberg"
     sqlmesh_schema: str = "oso"
-    sqlmesh_bq_export_dataset_id: str = "metrics"
+    sqlmesh_bq_export_dataset_id: str = "oso"
 
     enable_k8s_executor: bool = False
 

--- a/warehouse/oso_dagster/definitions.py
+++ b/warehouse/oso_dagster/definitions.py
@@ -111,14 +111,14 @@ def load_definitions():
 
     sqlmesh_exporter = [
         Trino2ClickhouseSQLMeshExporter(
-            ["clickhouse_metrics"],
+            ["clickhouse_export"],
             destination_catalog="clickhouse",
             destination_schema="default",
             source_catalog=sqlmesh_catalog,
             source_schema=sqlmesh_schema,
         ),
         Trino2BigQuerySQLMeshExporter(
-            ["bigquery_metrics"],
+            ["bigquery_export"],
             project_id=project_id,
             dataset_id=sqlmesh_bq_export_dataset_id,
             source_catalog=sqlmesh_catalog,


### PR DESCRIPTION
* Trino exporters - renaming prefix from `metrics` to `export`
* The Trino2Bigquery exporter should go to the `oso` dataset