### PR TITLE
feat: track API calls by user and models

### DIFF
--- a/apps/frontend/app/api/v1/graphql/route.ts
+++ b/apps/frontend/app/api/v1/graphql/route.ts
@@ -12,6 +12,7 @@ import { NextRequest } from "next/server";
 import { spawn } from "@opensource-observer/utils";
 import { withPostHog } from "../../../../lib/clients/posthog";
 import { EVENTS } from "../../../../lib/types/posthog";
+import { AuthUser } from "../../../../lib/auth/auth";
 //import { ApolloGateway, IntrospectAndCompose } from "@apollo/gateway";
 //import { HASURA_URL } from "../../../../lib/config";
 
@@ -54,15 +55,16 @@ class AuthenticatedDataSource extends RemoteGraphQLDataSource {
     const modelNames = getModelNames(op);
     //console.log(modelNames);
     spawn(
-      withPostHog(async (posthog, userId: string) => {
+      withPostHog(async (posthog, user: AuthUser) => {
         posthog.capture({
-          distinctId: userId,
+          distinctId: user.userId,
           event: EVENTS.API_CALL,
           properties: {
             type: "graphql",
             operation: op.operation,
             models: modelNames,
             query: opts.request.query,
+            apiKeyName: user.keyName,
           },
         });
       }, opts.context.req),

--- a/apps/frontend/app/api/v1/sql/route.ts
+++ b/apps/frontend/app/api/v1/sql/route.ts
@@ -3,6 +3,7 @@ import { getTrinoClient, TrinoError } from "../../../../lib/clients/trino";
 import type { QueryResult, Iterator } from "trino-client";
 import { withPostHog } from "../../../../lib/clients/posthog";
 import { getTableNamesFromSql } from "../../../../lib/parsing";
+import { AuthUser } from "../../../../lib/auth/auth";
 //import { logger } from "../../../lib/logger";
 
 // Next.js route control
@@ -51,14 +52,15 @@ export async function POST(request: NextRequest) {
     return makeErrorResponse("Please provide a 'query' parameter", 400);
   }
   try {
-    await withPostHog(async (posthog, userId: string) => {
+    await withPostHog(async (posthog, user: AuthUser) => {
       posthog.capture({
-        distinctId: userId,
+        distinctId: user.userId,
         event: "api_call",
         properties: {
           type: "sql",
           models: getTableNamesFromSql(query),
           query: query,
+          apiKeyName: user.keyName,
         },
       });
     }, request);

--- a/apps/frontend/components/widgets/supabase-write.tsx
+++ b/apps/frontend/components/widgets/supabase-write.tsx
@@ -5,6 +5,7 @@ import Alert from "@mui/material/Alert";
 import { ADT } from "ts-adt";
 import { HttpError, assertNever, spawn } from "@opensource-observer/utils";
 import { usePostHog } from "posthog-js/react";
+import { EVENTS } from "../../lib/types/posthog";
 import { RegistrationProps } from "../../lib/types/plasmic";
 import { supabaseClient } from "../../lib/clients/supabase";
 
@@ -135,7 +136,7 @@ function SupabaseWrite(props: SupabaseWriteProps) {
 
     // Execute query
     const { error, status } = await query;
-    posthog.capture("supabase_write", {
+    posthog.capture(EVENTS.DB_WRITE, {
       tableName,
       actionType,
       status,

--- a/apps/frontend/jest.config.js
+++ b/apps/frontend/jest.config.js
@@ -1,0 +1,7 @@
+/** @type {import('ts-jest').JestConfigWithTsJest} **/
+module.exports = {
+  testEnvironment: "node",
+  transform: {
+    "^.+.tsx?$": ["ts-jest", {}],
+  },
+};

--- a/apps/frontend/lib/clients/posthog.ts
+++ b/apps/frontend/lib/clients/posthog.ts
@@ -1,7 +1,7 @@
 import { type NextRequest } from "next/server";
 import { PostHog } from "posthog-node";
 import { POSTHOG_HOST, POSTHOG_KEY } from "../config";
-import { getUser } from "../auth/auth";
+import { AuthUser, getUser } from "../auth/auth";
 
 /**
  * Use this if you want direct access to the PostHog client
@@ -25,13 +25,13 @@ function PostHogClient() {
  * @param request
  */
 async function withPostHog(
-  fn: (posthog: PostHog, userId: string) => Promise<void>,
+  fn: (posthog: PostHog, user: AuthUser) => Promise<void>,
   request: NextRequest,
 ) {
   const posthog = PostHogClient();
   const user = await getUser(request);
   if (user.role !== "anonymous") {
-    await fn(posthog, user.userId);
+    await fn(posthog, user);
   } else {
     console.warn("PostHog: No user found");
   }

--- a/apps/frontend/lib/parsing.test.ts
+++ b/apps/frontend/lib/parsing.test.ts
@@ -1,0 +1,96 @@
+import { getTableNamesFromSql } from "./parsing";
+
+describe("parses SQL", () => {
+  it("handles simple retrieval", () => {
+    const names = getTableNamesFromSql(`SELECT * FROM event`);
+    expect(names.length).toBe(1);
+    expect(names).toContain("event");
+  });
+
+  it("handles ctes", () => {
+    const names = getTableNamesFromSql(`
+WITH Devs AS (
+    SELECT 
+        p."id" AS "projectId",
+        e."fromId" AS "fromId",
+        TO_CHAR(DATE_TRUNC('MONTH', e."time"), 'YYYY-MM-01') AS "bucketMonthly",
+        CASE 
+            WHEN COUNT(DISTINCT CASE WHEN e."typeId" = 4 THEN e."time" END) >= 10 THEN 'FULL_TIME_DEV'
+            WHEN COUNT(DISTINCT CASE WHEN e."typeId" = 4 THEN e."time" END) >= 1 THEN 'PART_TIME_DEV'
+            ELSE 'OTHER_CONTRIBUTOR'
+        END AS "devType",
+        1 AS amount
+    FROM 
+        event e
+    JOIN 
+        project_artifacts_artifact paa ON e."toId" = paa."artifactId"
+    JOIN 
+        project p ON paa."projectId" = p.id
+        
+    WHERE
+        e."typeId" IN (
+            2,
+            3,
+            4,
+            6,
+            18
+        )
+    GROUP BY
+        p."id",
+        e."fromId",
+        TO_CHAR(DATE_TRUNC('MONTH', e."time"), 'YYYY-MM-01')
+)
+SELECT
+    Devs."projectId",
+    Devs."devType",
+    Devs."bucketMonthly",
+    SUM(Devs."amount") AS "amount"
+FROM 
+    Devs
+GROUP BY
+    Devs."projectId",
+    Devs."devType",
+    Devs."bucketMonthly";
+    `);
+    expect(names.length).toBe(3);
+    expect(names).toContain("event");
+    expect(names).toContain("project_artifacts_artifact");
+    expect(names).toContain("project");
+  });
+
+  it("handles joins", () => {
+    const names = getTableNamesFromSql(`
+SELECT
+    p."slug" AS project_slug,
+    p."name" AS project_name,
+    a1."name" AS artifact_name,
+    a2."name" AS contributor_name,
+    e."time" AS event_time,
+    e."type" AS event_type
+FROM
+    project p
+JOIN
+    project_artifacts_artifact paa ON p."id" = paa."projectId"
+JOIN
+    artifact a1 ON paa."artifactId" = a1."id"
+JOIN
+    event e ON a1."id" = e."toId"
+JOIN
+    artifact a2 ON e."fromId" = a2."id"
+JOIN
+    collection_projects_project cpp ON p."id" = cpp."projectId"
+JOIN
+    collection c ON cpp."collectionId" = c."id"    
+WHERE 
+    c."slug" = 'a'
+    AND a1."namespace" = 'a'
+    `);
+    expect(names.length).toBe(6);
+    expect(names).toContain("project");
+    expect(names).toContain("project_artifacts_artifact");
+    expect(names).toContain("artifact");
+    expect(names).toContain("event");
+    expect(names).toContain("collection_projects_project");
+    expect(names).toContain("collection");
+  });
+});

--- a/apps/frontend/lib/parsing.ts
+++ b/apps/frontend/lib/parsing.ts
@@ -1,5 +1,6 @@
 import dayjs from "dayjs";
 import _ from "lodash";
+import { Parser, AST } from "node-sql-parser";
 
 /**
  * Parse a comma-separated list into a string array
@@ -29,4 +30,59 @@ const eventTimeToLabel = (t: any) => dayjs(t).format("YYYY-MM-DD");
  */
 const eventTypeToLabel = (t: string) => _.capitalize(t.replace(/_/g, " "));
 
-export { csvToArray, stringToIntArray, eventTimeToLabel, eventTypeToLabel };
+/**
+ * Get the names of all tables referenced in a SQL AST
+ * @param ast
+ * @returns
+ */
+function getTableNamesFromAst(ast: AST): string[] {
+  if (ast.type == "select") {
+    const cteNames = ast.with ? _.flatMap(ast.with, (x) => x.name.value) : [];
+    const cteTables = ast.with
+      ? _.flatMap(ast.with, (x) => x.stmt.tableList)
+      : [];
+    // Sometimes the table name is prefixed with the operation
+    // e.g. "select::null::event",
+    // This just gets the last part
+    const cteTrimmedNames = cteTables.map((x: string) => {
+      const parts = x.split("::");
+      return parts[parts.length - 1];
+    });
+    const tableNames = Array.isArray(ast.from)
+      ? ast.from.map((x: any) => x.table)
+      : [];
+    const truthyNames = tableNames.filter((name: string) => !!name);
+    const combinedNames = [...truthyNames, ...cteTrimmedNames];
+    const removeCtes = combinedNames.filter(
+      (name: string) => !cteNames.includes(name),
+    );
+    return removeCtes;
+  } else {
+    console.warn("SQL is not a SELECT statement");
+    return [];
+  }
+}
+
+/**
+ * Get the names of all tables referenced in a SQL query
+ * @param query
+ * @returns
+ */
+function getTableNamesFromSql(query: string): string[] {
+  const parser = new Parser();
+  const ast = parser.astify(query);
+  const tableNames = Array.isArray(ast)
+    ? _.flatMap(ast, (x) => getTableNamesFromAst(x))
+    : getTableNamesFromAst(ast);
+
+  // De-duplicate
+  return _.uniq(tableNames);
+}
+
+export {
+  csvToArray,
+  stringToIntArray,
+  eventTimeToLabel,
+  eventTypeToLabel,
+  getTableNamesFromSql,
+};

--- a/apps/frontend/lib/types/posthog.ts
+++ b/apps/frontend/lib/types/posthog.ts
@@ -1,0 +1,7 @@
+// An enum defining the events that can be tracked in PostHog.
+const EVENTS = {
+  API_CALL: "api_call",
+  DB_WRITE: "supabase_write",
+};
+
+export { EVENTS };

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -105,6 +105,7 @@
     "jest-environment-jsdom": "^29.7.0",
     "postcss": "^8.5.3",
     "tailwindcss": "^3.4.4",
+    "ts-jest": "^29.2.5",
     "ts-node": "^10.9.2",
     "typescript": "^5.8.2"
   }

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -55,6 +55,7 @@
     "graphql-tag": "^2.12.6",
     "instantsearch.css": "^8.5.1",
     "next": "^14.2.25",
+    "node-sql-parser": "^5.3.8",
     "posthog-js": "^1.236.5",
     "posthog-node": "^4.13.0",
     "qs": "^6.14.0",

--- a/apps/frontend/tsconfig.json
+++ b/apps/frontend/tsconfig.json
@@ -26,6 +26,7 @@
     "**/*.ts",
     "**/*.tsx",
     "next.config.js",
+    "jest.config.js",
     "tailwind.config.js",
     ".next/types/**/*.ts"
   ],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -199,6 +199,9 @@ importers:
       next:
         specifier: ^14.2.25
         version: 14.2.25(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      node-sql-parser:
+        specifier: ^5.3.8
+        version: 5.3.8
       posthog-js:
         specifier: ^1.236.5
         version: 1.236.5
@@ -5255,6 +5258,9 @@ packages:
   '@types/pbkdf2@3.1.2':
     resolution: {integrity: sha512-uRwJqmiXmh9++aSu1VNEn3iIxWOhd8AHXNSdlaLfdAAdSTY9jYVeGWnzejM3dvrkbqE3/hyQkQQ29IFATEGlew==}
 
+  '@types/pegjs@0.10.6':
+    resolution: {integrity: sha512-eLYXDbZWXh2uxf+w8sXS8d6KSoXTswfps6fvCUuVAGN8eRpfe7h9eSRydxiSJvo9Bf+GzifsDOr9TMQlmJdmkw==}
+
   '@types/phoenix@1.6.5':
     resolution: {integrity: sha512-xegpDuR+z0UqG9fwHqNoy3rI7JDlvaPh2TY47Fl80oq6g+hXT+c/LEuE43X48clZ6lOfANl5WrPur9fYO1RJ/w==}
 
@@ -6008,6 +6014,10 @@ packages:
 
   before-after-hook@2.2.3:
     resolution: {integrity: sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==}
+
+  big-integer@1.6.52:
+    resolution: {integrity: sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==}
+    engines: {node: '>=0.6'}
 
   big.js@5.2.2:
     resolution: {integrity: sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==}
@@ -10231,6 +10241,10 @@ packages:
 
   node-releases@2.0.19:
     resolution: {integrity: sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==}
+
+  node-sql-parser@5.3.8:
+    resolution: {integrity: sha512-aqGTzK8kPJAwQ6tqdS0l+vX358LXMmZDw902ePfiPn3PSDsg2HeR2tHFioXNHJW00YHoic6VVYY80waFb/zdxw==}
+    engines: {node: '>=8'}
 
   nopt@1.0.10:
     resolution: {integrity: sha512-NWmpvLSqUrgrAC9HCuxEvb+PSloHpqVu+FqcO4eeF2h5qYRhA7ev6KvelyQAKtegUbC6RypJnlEOhd8vloNKYg==}
@@ -21175,6 +21189,8 @@ snapshots:
     dependencies:
       '@types/node': 20.14.12
 
+  '@types/pegjs@0.10.6': {}
+
   '@types/phoenix@1.6.5': {}
 
   '@types/prismjs@1.26.4': {}
@@ -21973,7 +21989,7 @@ snapshots:
 
   axios@1.7.7:
     dependencies:
-      follow-redirects: 1.15.9
+      follow-redirects: 1.15.9(debug@4.4.0)
       form-data: 4.0.0
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
@@ -21981,7 +21997,7 @@ snapshots:
 
   axios@1.8.4:
     dependencies:
-      follow-redirects: 1.15.9
+      follow-redirects: 1.15.9(debug@4.4.0)
       form-data: 4.0.0
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
@@ -22166,6 +22182,8 @@ snapshots:
   bech32@1.1.4: {}
 
   before-after-hook@2.2.3: {}
+
+  big-integer@1.6.52: {}
 
   big.js@5.2.2: {}
 
@@ -24641,8 +24659,6 @@ snapshots:
     optional: true
 
   fn.name@1.1.0: {}
-
-  follow-redirects@1.15.9: {}
 
   follow-redirects@1.15.9(debug@4.4.0):
     optionalDependencies:
@@ -27838,6 +27854,11 @@ snapshots:
   node-int64@0.4.0: {}
 
   node-releases@2.0.19: {}
+
+  node-sql-parser@5.3.8:
+    dependencies:
+      '@types/pegjs': 0.10.6
+      big-integer: 1.6.52
 
   nopt@1.0.10:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -344,6 +344,9 @@ importers:
       tailwindcss:
         specifier: ^3.4.4
         version: 3.4.4(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.8.2))
+      ts-jest:
+        specifier: ^29.2.5
+        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@22.13.10)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.8.2)))(typescript@5.8.2)
       ts-node:
         specifier: ^10.9.2
         version: 10.9.2(@types/node@22.13.10)(typescript@5.8.2)
@@ -30839,6 +30842,25 @@ snapshots:
       make-error: 1.3.6
       semver: 7.6.3
       typescript: 5.5.3
+      yargs-parser: 21.1.1
+    optionalDependencies:
+      '@babel/core': 7.26.0
+      '@jest/transform': 29.7.0
+      '@jest/types': 29.6.3
+      babel-jest: 29.7.0(@babel/core@7.26.0)
+
+  ts-jest@29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@22.13.10)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.8.2)))(typescript@5.8.2):
+    dependencies:
+      bs-logger: 0.2.6
+      ejs: 3.1.10
+      fast-json-stable-stringify: 2.1.0
+      jest: 29.7.0(@types/node@22.13.10)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.8.2))
+      jest-util: 29.7.0
+      json5: 2.2.3
+      lodash.memoize: 4.1.2
+      make-error: 1.3.6
+      semver: 7.6.3
+      typescript: 5.8.2
       yargs-parser: 21.1.1
     optionalDependencies:
       '@babel/core': 7.26.0


### PR DESCRIPTION
* Identifies `api_call` events by user
* Also tags the api key name in case we need that label
* Introduces SQL and GraphQL parsing to get the table/model names from the query
* Adds those names as metadata to the event