### PR TITLE
feat: adds generic app chart

### DIFF
--- a/ops/helm-charts/generic/Chart.yaml
+++ b/ops/helm-charts/generic/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: generic
+description: Deploys a generic application
+
+type: application
+version: 0.1.0

--- a/ops/helm-charts/generic/lint-only-values.yaml
+++ b/ops/helm-charts/generic/lint-only-values.yaml
@@ -1,0 +1,10 @@
+# To use this make sure you have the following in your helm config for vscode:
+# "helm-intellisense.customValueFileNames": [
+#     "prod-values.yaml",
+#     "dev-values.yaml",
+#     "values.yaml"
+# ]
+
+app:
+  name: "oso" 
+  command: ["python"]

--- a/ops/helm-charts/generic/templates/_helpers.tpl
+++ b/ops/helm-charts/generic/templates/_helpers.tpl
@@ -1,0 +1,83 @@
+{{/*
+Expand the name of the chart.
+*/}}
+
+# Disable the pgisready check due to our use of cloudsql proxy injected into the
+pod.
+{{- define "app.logging.config" }}
+# Default log configuration for a python service. This can be
+# used by uvicorn Thanks to:
+# https://gist.github.com/liviaerxin/d320e33cbcddcc5df76dd92948e5be3b for a
+# starting point.
+version: 1
+disable_existing_loggers: False
+formatters:
+  default:
+    # "()": uvicorn.logging.DefaultFormatter
+    format: '{{ .Values.app.logging.format }}'
+  access:
+    # "()": uvicorn.logging.AccessFormatter
+    format: '{{ .Values.app.logging.format }}'
+handlers:
+  default:
+    formatter: default
+    class: logging.StreamHandler
+    stream: ext://sys.stderr
+  access:
+    formatter: access
+    class: logging.StreamHandler
+    stream: ext://sys.stdout
+loggers:
+  uvicorn.error:
+    level: {{ .Values.app.logging.uvicorn.level }}
+    handlers:
+      - default
+    propagate: no
+  uvicorn.access:
+    level: {{ .Values.app.logging.uvicorn.level }}
+    handlers:
+      - access
+    propagate: no
+  {{ .Values.app.logging.appRoot.loggerName }}:
+    level: {{ .Values.app.logging.appRoot.level }}
+    handlers:
+      - default
+    propagate: no
+root:
+  level: {{ .Values.app.logging.root.level }}
+  handlers:
+    - default
+  propagate: no
+{{- end }}
+
+{{/* 
+This is copied due to some kind of error with helm and flux when overriding
+portions of this
+*/}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "app.fullname" -}}
+{{- if .Values.global.fullnameOverride -}}
+{{- .Values.global.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := "app" -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "app.labels" -}}
+app.kubernetes.io/name: {{ include "app.fullname" . }}
+{{- end -}}
+
+{{- define "app.selectorLabels" -}}
+{{ include "app.labels" . }}
+component: {{ required "app component name is required" .Values.app.name }}
+{{- end -}}

--- a/ops/helm-charts/generic/templates/app.yaml
+++ b/ops/helm-charts/generic/templates/app.yaml
@@ -1,0 +1,65 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "app.fullname" . }}
+  labels:
+    {{- include "app.labels" . | nindent 4 }}
+spec:
+  # for now this application is a single process + thread
+  replicas: 1
+  selector:
+    matchLabels:
+      component: app
+  template:
+    metadata:
+      labels:
+        {{- include "app.selectorLabels" . | nindent 8 }}
+    spec:
+      serviceAccountName: {{ include "app.fullname" . }}
+      {{- with .Values.app.affinity }}
+      affinity:
+        {{ toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.app.nodeSelector }}
+      nodeSelector:
+        {{ toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.app.tolerations }}
+      tolerations:
+        {{ toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+      - name: {{ .Values.app.name }}
+        image: {{ .Values.app.image.repo }}:{{ .Values.app.image.tag }}
+        command: {{ required "command is required" .Values.app.command }}
+        {{- if .Values.app.args }}
+        args: {{ Values.app.args }}
+        {{- end }}
+        imagePullPolicy: Always
+        ports:
+          - containerPort: 8000
+        {{- with .Values.app.resources }}
+        resources:
+          {{ toYaml . | nindent 10 }}
+        {{- end }}
+        {{ - with .Values.app.volumeMounts }}
+        volumeMounts:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        env:
+          - name: {{ .Values.app.hostEnvVar }}
+            value: "{{ .Values.app.host }}"
+          - name: {{ .Values.app.portEnvVar }}
+            value: "{{ .Values.app.port }}"
+          {{- range $key, $value := .Values.app.envVars }}
+          - name: {{ $key }}
+            value: {{ $value | quote }}
+          {{- end }}
+          {{- range .Values.app.rawEnvVars }}
+            {{- toYaml . | nindent 12 }}
+          {{ end }}
+      {{- with .Values.app.volumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/ops/helm-charts/generic/templates/service-account.yaml
+++ b/ops/helm-charts/generic/templates/service-account.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "app.fullname" . }}

--- a/ops/helm-charts/generic/templates/service.yaml
+++ b/ops/helm-charts/generic/templates/service.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "app.fullname" . }}
+  annotations:
+    {{- toYaml .Values.app.service.annotations | nindent 4 }}
+spec:
+  selector:
+    {{ include "app.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: http
+      protocol: TCP
+      port: {{ .Values.app.port }}
+      targetPort: {{ .Values.app.port }}

--- a/ops/helm-charts/generic/values.yaml
+++ b/ops/helm-charts/generic/values.yaml
@@ -1,0 +1,31 @@
+global:
+  fullnameOverride: ""
+app:
+  # name: "oso" # This must be set
+  # command: []
+  # args: []
+  host: 0.0.0.0
+  hostEnvVar: APP_HOST
+  port: 8000
+  portEnvVar: APP_PORT
+  image:
+    repo: ghcr.io/opensource-observer/oso
+    tag: latest
+  logging:
+    format: "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+    root:
+      level: "ERROR"
+    oso_mcp:
+      level: "DEBUG"
+    uvicorn:
+      level: "INFO"
+  affinity: {}
+  nodeSelector: {}
+  tolerations: []
+  resources: {}
+  envVars: {}
+  # if you want to set env vars in a raw format but this makes it harder to
+  # extend with flux
+  rawEnvVars: [] 
+  volumes: []
+  volumeMounts: []


### PR DESCRIPTION
Adds a generic app chart to deploy things. I really didn't want to make this as a helm chart but we don't have a good alternative yet that would work with flux. 