### PR TITLE
Update github actions versions due to deprecation

### DIFF
--- a/.github/workflows/refresh-test-credentials.yml
+++ b/.github/workflows/refresh-test-credentials.yml
@@ -90,7 +90,7 @@ jobs:
       PUBLIC_VARS_TEST: "THISISATEST"
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
 


### PR DESCRIPTION
Artifact Actions v3 will be deprecated by January 30, 2025. GitHub has started temporarily failing workflows that haven't been updated ahead of this deadline. This PR updates the action versions accordingly, following the [official migration guide](https://github.com/actions/checkout/releases).