### PR TITLE
feat(consumer-trino): make consumer trino accept dynamic connectors and create admin role

### DIFF
--- a/ops/k8s-apps/production/consumer-trino/catalog-store-config.yaml
+++ b/ops/k8s-apps/production/consumer-trino/catalog-store-config.yaml
@@ -1,7 +1,0 @@
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: catalog-store-config
-data:
-  catalog-store.properties: |
-    catalog.config-dir: /etc/trino/dynamic-catalog

--- a/ops/k8s-apps/production/consumer-trino/catalog-store-config.yaml
+++ b/ops/k8s-apps/production/consumer-trino/catalog-store-config.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: catalog-store-config
+data:
+  catalog-store.properties: |
+    catalog.config-dir: /etc/trino/dynamic-catalog

--- a/ops/k8s-apps/production/consumer-trino/custom-helm-values.yaml
+++ b/ops/k8s-apps/production/consumer-trino/custom-helm-values.yaml
@@ -15,22 +15,9 @@ spec:
     serviceAccount:
       name: production-consumer-trino
     accessControl:
-      type: configmap
-      configFile: "rules.json"
-      rules:
-        rules.json: |-
-          {
-            "catalogs": [
-              {
-                "user": "admin",
-                "allow": "all"
-              },
-              {
-                "catalog": ".*",
-                "allow": "read-only"
-              }
-            ]
-          }
+      type: properties
+      properties: |
+        access-control.name=read-only
     additionalConfigProperties:
       - http-server.process-forwarded=true
       - internal-communication.shared-secret=gcp:secretmanager:production-consumer-trino-shared-secret/versions/latest
@@ -55,7 +42,7 @@ spec:
           command:
             - /bin/sh
             - -c
-            - 'echo "${TRINO_ADMIN}\n${TRINO_USER}" > /etc/auth/password.db'
+            - 'printf "${TRINO_ADMIN}\n${TRINO_USER}" > /etc/auth/password.db'
           env:
             - name: TRINO_USER
               value: gcp:secretmanager:production-consumer-trino-auth/versions/latest
@@ -82,10 +69,9 @@ spec:
         maxHeapSize: "7G"
       additionalJVMConfig:
         - "--add-opens=java.base/java.nio=ALL-UNNAMED"
-      configMounts:
-        - name: catalog-store-config
-          configMap: catalog-store-config
-          path: /etc/trino
+      additionalConfigFiles:
+        catalog-store.properties: |
+          catalog.config-dir=/etc/trino/dynamic-catalog
       additionalVolumeMounts:
         - name: trino-auth-volume
           mountPath: /etc/trino/auth/password
@@ -136,7 +122,7 @@ spec:
       config:
         authenticationType: PASSWORD
         query:
-          maxMemory: "100GB"  
+          maxMemory: "100GB"
       workers: 1
       autoscaling:
         enabled: true

--- a/ops/k8s-apps/production/consumer-trino/custom-helm-values.yaml
+++ b/ops/k8s-apps/production/consumer-trino/custom-helm-values.yaml
@@ -14,10 +14,33 @@ spec:
         value: gcp:secretmanager:production-mcs-gcs-secret/versions/latest
     serviceAccount:
       name: production-consumer-trino
+    securityContext:
+      fsGroup: 1000
     accessControl:
-      type: properties
-      properties: |
-        access-control.name=read-only
+      type: configmap
+      refreshPeriod: 60s
+      configFile: "rules.json"
+      rules:
+        rules.json: |
+          {
+            "catalogs": [
+              {
+                "user": "admin",
+                "allow": "owner"
+              },
+              {
+                "catalog": "system",
+                "allow": "none"
+              },
+              {
+                "user": "user",
+                "allow": "read-only"
+              },
+              {
+                "allow": "all"
+              }
+            ]
+          }
     additionalConfigProperties:
       - http-server.process-forwarded=true
       - internal-communication.shared-secret=gcp:secretmanager:production-consumer-trino-shared-secret/versions/latest

--- a/ops/k8s-apps/production/consumer-trino/custom-helm-values.yaml
+++ b/ops/k8s-apps/production/consumer-trino/custom-helm-values.yaml
@@ -15,14 +15,28 @@ spec:
     serviceAccount:
       name: production-consumer-trino
     accessControl:
-      type: properties
-      properties: |
-        access-control.name=read-only
+      type: configmap
+      configFile: "rules.json"
+      rules:
+        rules.json: |-
+          {
+            "catalogs": [
+              {
+                "user": "admin",
+                "allow": "all"
+              },
+              {
+                "catalog": ".*",
+                "allow": "read-only"
+              }
+            ]
+          }
     additionalConfigProperties:
       - http-server.process-forwarded=true
       - internal-communication.shared-secret=gcp:secretmanager:production-consumer-trino-shared-secret/versions/latest
       - http-server.authentication.allow-insecure-over-http=true
       - retry-policy=QUERY
+      - catalog.management=dynamic
     ingress:
       enabled: true
       className: ingress-internal-cloudflare
@@ -34,20 +48,25 @@ spec:
 
     initContainers:
       coordinator:
-        - name: init-coordinator-auth
+        # used to create the password.db file
+        - name: init-coordinator
           image: alpine
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh
             - -c
-            - 'echo "${TRINO_AUTH}" > /etc/auth/password.db'
+            - 'echo "${TRINO_ADMIN}\n${TRINO_USER}" > /etc/auth/password.db'
           env:
-            - name: TRINO_AUTH
+            - name: TRINO_USER
               value: gcp:secretmanager:production-consumer-trino-auth/versions/latest
+            - name: TRINO_ADMIN
+              value: gcp:secretmanager:production-consumer-trino-admin/versions/latest
           volumeMounts:
             - mountPath: /etc/auth
               name: trino-auth-volume
     coordinator:
+      annotations:
+        gke-gcsfuse/volumes: "true"
       resources:
         requests:
           cpu: 1200m
@@ -63,13 +82,23 @@ spec:
         maxHeapSize: "7G"
       additionalJVMConfig:
         - "--add-opens=java.base/java.nio=ALL-UNNAMED"
+      configMounts:
+        - name: catalog-store-config
+          configMap: catalog-store-config
+          path: /etc/trino
       additionalVolumeMounts:
         - name: trino-auth-volume
           mountPath: /etc/trino/auth/password
           readOnly: true
+        - name: trino-catalog-volume
+          mountPath: /etc/trino/dynamic-catalog
+          readOnly: false
       additionalVolumes:
         - name: trino-auth-volume
           emptyDir: {}
+        - name: trino-catalog-volume
+          persistentVolumeClaim:
+            claimName: trino-catalog-pvc
 
     worker:
       resources:
@@ -107,7 +136,7 @@ spec:
       config:
         authenticationType: PASSWORD
         query:
-          maxMemory: "100GB"
+          maxMemory: "100GB"  
       workers: 1
       autoscaling:
         enabled: true
@@ -130,15 +159,3 @@ spec:
                 value: 2
                 periodSeconds: 15
             selectPolicy: Max
-    catalogs:
-      iceberg: |
-        connector.name=iceberg
-        iceberg.catalog.type=rest
-        iceberg.rest-catalog.uri=http://production-nessie.production-nessie.svc.cluster.local:19120/iceberg
-        iceberg.rest-catalog.prefix=main
-        iceberg.rest-catalog.warehouse=gs://oso-iceberg-usc1/warehouse/
-        fs.native-gcs.enabled=true
-        gcs.project-id=opensource-observer
-      # bigquery: |
-      #   connector.name=bigquery
-      #   bigquery.project-id=opensource-observer

--- a/ops/k8s-apps/production/consumer-trino/kustomization.yaml
+++ b/ops/k8s-apps/production/consumer-trino/kustomization.yaml
@@ -2,6 +2,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../base/trino
+  - trino-catalog-volume.yaml
+  - catalog-store-config.yaml
 namespace: production-consumer-trino
 patches:
   - path: ./custom-helm-values.yaml

--- a/ops/k8s-apps/production/consumer-trino/kustomization.yaml
+++ b/ops/k8s-apps/production/consumer-trino/kustomization.yaml
@@ -3,7 +3,6 @@ kind: Kustomization
 resources:
   - ../../base/trino
   - trino-catalog-volume.yaml
-  - catalog-store-config.yaml
 namespace: production-consumer-trino
 patches:
   - path: ./custom-helm-values.yaml

--- a/ops/k8s-apps/production/consumer-trino/trino-catalog-volume.yaml
+++ b/ops/k8s-apps/production/consumer-trino/trino-catalog-volume.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: trino-catalog-pv
+  namespace: production-consumer-trino
+spec:
+  accessModes:
+    - ReadWriteMany
+  capacity:
+    storage: 100Mi
+  storageClassName: gcs-rwx
+  mountOptions:
+    - implicit-dirs
+  csi:
+    driver: gcsfuse.csi.storage.gke.io
+    volumeHandle: oso-dynamic-connectors
+  claimRef:
+    name: trino-catalog-pvc
+    namespace: production-consumer-trino
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: trino-catalog-pvc
+  namespace: production-consumer-trino
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: gcs-rwx
+  resources:
+    requests:
+      storage: 100Mi


### PR DESCRIPTION
Still need to test this setup on kubernetes, but it worked on docker.

Spent a lot of time trying to make `catalog.config-dir` work because it is badly documented. Had to do a small workaround for now since it's not supported by default on their helmchart, by manually creating a ConfigMap and mounting the `catalog-store.properties` file. Also did tweaked the initContainers to copy the static catalogs into the dynamic catalogs folder, so we can have "both"

Commented on a closed issue from their repo here https://github.com/trinodb/charts/issues/332 to document the usage of `catalog.config-dir`.

Draft until tested.

