### PR TITLE
chore: sets up a post production sync action

### DIFF
--- a/.github/workflows/post-production-sync.yml
+++ b/.github/workflows/post-production-sync.yml
@@ -1,0 +1,58 @@
+# This workflow is triggered after a sync to production occurs. That means that 
+# a new docker image has been published and the production branch has the 
+# updated references.
+name: post-production-sync
+env:
+  X_GITHUB_GRAPHQL_API: ${{ vars.X_GITHUB_GRAPHQL_API }}
+  X_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+# This workflow only runs when we push to the production branch.
+on:
+  # Allows you to run this workflow manually from the Actions tab
+  push:
+    branches:
+      - production
+
+jobs:
+  post-production-sync:
+    name: post-production-sync
+    environment: indexer
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Setup Python and UV
+        uses: astral-sh/setup-uv@v5
+        with:
+          python-version: 3.12
+  
+      - name: Install dependencies
+        run: uv sync --all-packages --all-extras
+
+      - uses: 'google-github-actions/auth@v2'
+        with:
+          credentials_json: '${{ secrets.GOOGLE_CREDENTIALS_JSON }}'
+          create_credentials_file: true
+      
+      - name: 'Set up Cloud SDK'
+        uses: 'google-github-actions/setup-gcloud@v2'
+        with:
+          version: '>= 363.0.0'
+
+      - uses: google-github-actions/get-gke-credentials@db150f2cc60d1716e61922b832eae71d2a45938f
+        with:
+          cluster_name: ${{ secrets.GKE_CLUSTER_NAME }}
+          location: ${{ secrets.GKE_CLUSTER_REGION }}
+          project_id: ${{ vars.GOOGLE_PROJECT_ID }}
+
+      # If there's a push to production we need to run the migration for sqlmesh
+      - name: Run sqlmesh migrate
+        run: uv run oso production sqlmesh-migrate

--- a/.github/workflows/warehouse-publish-docker-containers.yml
+++ b/.github/workflows/warehouse-publish-docker-containers.yml
@@ -73,12 +73,3 @@ jobs:
       # image in the kubernetes cluster.
       - name: Trigger flux image update
         run: uv run oso production trigger-image-update --endpoint ${{ secrets.FLUX_IMAGE_UPDATE_WEBHOOK_ENDPOINT }}
-
-      # We may need a better place for this in the future but for now we need to
-      # ensure that sqlmesh state is up to date _before_ we deploy the new
-      # containers
-      - name: Run sqlmesh migrate
-        run: uv run oso production sqlmesh-migrate
-
-      - name: Delete pod for dagster
-        run: kubectl delete pods --namespace production-dagster -l app.kubernetes.io/instance=production-dagster,component=user-deployments


### PR DESCRIPTION
This is a bit better than our previous delete and pray setup with our docker publishing actions. As a push to production means that there's a new docker container, this is a better place to but deployment hooks.