### PR TITLE
feat: implement `consolidated` analytics `middleware`

### DIFF
--- a/apps/frontend/lib/clients/posthog.ts
+++ b/apps/frontend/lib/clients/posthog.ts
@@ -14,7 +14,7 @@ function PostHogClient() {
     host: POSTHOG_HOST_DIRECT,
     flushAt: 1,
     flushInterval: 0,
-    fetch,
+    fetch: (...args) => fetch(...args),
   });
   return posthogClient;
 }

--- a/apps/frontend/lib/clients/posthog.ts
+++ b/apps/frontend/lib/clients/posthog.ts
@@ -14,22 +14,26 @@ function PostHogClient() {
     host: POSTHOG_HOST_DIRECT,
     flushAt: 1,
     flushInterval: 0,
+    fetch,
   });
   return posthogClient;
 }
 
 /**
- * Use this to simplify PostHog usage,
- * which will automatically identify and teardown
- * @param fn
- * @param request
+ * Creates a disposable PostHog instance
+ * - Automatically calls posthog.shutdown() when done
+ * @returns
  */
-async function withPostHog(fn: (posthog: PostHog) => Promise<void>) {
-  //console.log(user);
+function createPostHog() {
   const posthog = PostHogClient();
-  await fn(posthog);
-  // TODO: this seems to be taking many seconds
-  await posthog.shutdown();
+
+  return {
+    client: posthog,
+    [Symbol.asyncDispose]: async () => {
+      // TODO: this seems to be taking many seconds
+      await posthog.shutdown();
+    },
+  };
 }
 
-export { PostHogClient, withPostHog };
+export { PostHogClient, createPostHog };

--- a/apps/frontend/middleware.ts
+++ b/apps/frontend/middleware.ts
@@ -1,0 +1,295 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { getUser } from "./lib/auth/auth";
+import { withPostHog } from "./lib/clients/posthog";
+import { EVENTS } from "./lib/types/posthog";
+import { logger } from "./lib/logger";
+import { getTableNamesFromSql } from "./lib/parsing";
+import type { User } from "./lib/types/user";
+import type { PostHog } from "posthog-node";
+import { OperationDefinitionNode, parse, visit } from "graphql";
+
+const API_TYPES = ["sql", "graphql", "chat"] as const;
+type ApiType = (typeof API_TYPES)[number];
+
+interface SqlRequestBody {
+  query: string;
+  format?: string;
+}
+
+interface GraphQLRequestBody {
+  query: string;
+  variables?: Record<string, unknown>;
+  operationName?: string;
+}
+
+interface ChatMessage {
+  role: string;
+  content: string;
+}
+
+interface ChatRequestBody {
+  messages: ChatMessage[];
+}
+
+type ApiRequestBody = SqlRequestBody | GraphQLRequestBody | ChatRequestBody;
+
+function isSqlBody(body: unknown): body is SqlRequestBody {
+  return typeof body === "object" && body !== null && "query" in body;
+}
+
+function isGraphQLBody(body: unknown): body is GraphQLRequestBody {
+  return typeof body === "object" && body !== null && "query" in body;
+}
+
+function isChatBody(body: unknown): body is ChatRequestBody {
+  return (
+    typeof body === "object" &&
+    body !== null &&
+    "messages" in body &&
+    Array.isArray((body as ChatRequestBody).messages)
+  );
+}
+
+interface BaseTrackingData {
+  type: ApiType;
+  endpoint: string;
+  method: string;
+  userId: string;
+  apiKeyName: string;
+  host: string | null;
+}
+
+interface SqlTrackingData extends BaseTrackingData {
+  type: "sql";
+  query: string;
+  models: string[];
+}
+
+interface GraphQLTrackingData extends BaseTrackingData {
+  type: "graphql";
+  query: string;
+  operation?: string;
+  models?: string[];
+  operationName?: string;
+}
+
+interface ChatTrackingData extends BaseTrackingData {
+  type: "chat";
+  message: string;
+}
+
+type TrackingData = SqlTrackingData | GraphQLTrackingData | ChatTrackingData;
+
+function getModelNames(operation: OperationDefinitionNode): string[] {
+  const modelNames: string[] = [];
+  const selectionSet = operation.selectionSet.selections;
+
+  for (const selection of selectionSet) {
+    if (selection.kind === "Field") {
+      const fieldName = selection.name.value;
+      modelNames.push(fieldName);
+    }
+  }
+
+  return modelNames;
+}
+
+function parseGraphQLQuery(query: string): {
+  operation?: string;
+  models?: string[];
+} {
+  try {
+    const document = parse(query);
+    let operation: string | undefined;
+    let models: string[] | undefined;
+
+    visit(document, {
+      OperationDefinition(node) {
+        operation = node.operation;
+        models = getModelNames(node);
+      },
+    });
+
+    return { operation, models };
+  } catch (error) {
+    logger.warn("Failed to parse GraphQL query", error);
+    return {};
+  }
+}
+
+type TrackCallback<T extends ApiRequestBody, R> = (body: T) => R;
+
+const TRACK_CALLBACKS: {
+  sql: TrackCallback<SqlRequestBody, Pick<SqlTrackingData, "query" | "models">>;
+  graphql: TrackCallback<
+    GraphQLRequestBody,
+    Pick<
+      GraphQLTrackingData,
+      "query" | "operation" | "models" | "operationName"
+    >
+  >;
+  chat: TrackCallback<ChatRequestBody, Pick<ChatTrackingData, "message">>;
+} = {
+  sql: (body) => ({
+    query: body.query,
+    models: getTableNamesFromSql(body.query),
+  }),
+  graphql: (body) => {
+    const { operation, models } = parseGraphQLQuery(body.query);
+    return {
+      query: body.query,
+      operation,
+      models,
+      operationName: body.operationName,
+    };
+  },
+  chat: (body) => ({
+    message: getLatestMessage(body.messages),
+  }),
+};
+
+export const config = {
+  matcher: ["/api/v1/sql", "/api/v1/graphql", "/api/v1/chat"],
+};
+
+function isValidApiType(type: string): type is ApiType {
+  return API_TYPES.includes(type as ApiType);
+}
+
+export async function middleware(request: NextRequest): Promise<NextResponse> {
+  const path = request.nextUrl.pathname;
+
+  try {
+    const user = await getUser(request);
+
+    if (request.method === "OPTIONS") {
+      return NextResponse.next();
+    }
+
+    const [, , , apiType] = path.split("/");
+
+    if (!isValidApiType(apiType)) {
+      logger.warn(`Invalid API type in path: ${apiType}`);
+      return NextResponse.next();
+    }
+
+    if (user.role !== "anonymous") {
+      await trackApiCall(request, user, apiType);
+    }
+
+    const requestHeaders = new Headers(request.headers);
+    requestHeaders.set(
+      "x-user-id",
+      user.role === "anonymous" ? "" : user.userId,
+    );
+    requestHeaders.set("x-user-role", user.role);
+    requestHeaders.set(
+      "x-user-key-name",
+      user.role === "anonymous" ? "" : user.keyName,
+    );
+
+    return NextResponse.next({
+      request: {
+        headers: requestHeaders,
+      },
+    });
+  } catch (error) {
+    logger.error("Middleware error:", error);
+    return NextResponse.next();
+  }
+}
+
+async function trackApiCall(
+  request: NextRequest,
+  user: Exclude<User, { role: "anonymous" }>,
+  apiType: ApiType,
+): Promise<void> {
+  const path = request.nextUrl.pathname;
+  const body = await getRequestBody(request);
+
+  const baseData: BaseTrackingData = {
+    type: apiType,
+    endpoint: path,
+    method: request.method,
+    userId: user.userId,
+    apiKeyName: user.keyName,
+    host: user.host,
+  };
+
+  let trackingData: TrackingData;
+
+  switch (apiType) {
+    case "sql":
+      if (body && isSqlBody(body)) {
+        const sqlData = TRACK_CALLBACKS.sql(body);
+        trackingData = { ...baseData, type: "sql", ...sqlData };
+      } else {
+        trackingData = { ...baseData, type: "sql", query: "", models: [] };
+      }
+      break;
+
+    case "graphql":
+      if (body && isGraphQLBody(body)) {
+        const gqlData = TRACK_CALLBACKS.graphql(body);
+        trackingData = { ...baseData, type: "graphql", ...gqlData };
+      } else {
+        trackingData = { ...baseData, type: "graphql", query: "" };
+      }
+      break;
+
+    case "chat":
+      if (body && isChatBody(body)) {
+        const chatData = TRACK_CALLBACKS.chat(body);
+        trackingData = { ...baseData, type: "chat", ...chatData };
+      } else {
+        trackingData = { ...baseData, type: "chat", message: "No messages" };
+      }
+      break;
+
+    default: {
+      const exhaustiveCheck: never = apiType;
+      throw new Error(`Unhandled API type: ${exhaustiveCheck}`);
+    }
+  }
+
+  await withPostHog(async (posthog: PostHog) => {
+    posthog.capture({
+      distinctId: user.userId,
+      event: EVENTS.API_CALL,
+      properties: trackingData,
+    });
+  });
+}
+
+async function getRequestBody(request: NextRequest): Promise<unknown | null> {
+  try {
+    if (request.method === "GET") return null;
+
+    const clonedRequest = request.clone();
+    return await clonedRequest.json();
+  } catch {
+    return null;
+  }
+}
+
+function getLatestMessage(messages: ChatMessage[]): string {
+  if (messages.length === 0) {
+    return "Message not found";
+  }
+  const latestMessage = messages[messages.length - 1];
+  return latestMessage.content || "Message not found";
+}
+
+export interface UserInfoFromHeaders {
+  userId: string | null;
+  role: string | null;
+  keyName: string | null;
+}
+
+export function getUserFromHeaders(request: NextRequest): UserInfoFromHeaders {
+  return {
+    userId: request.headers.get("x-user-id"),
+    role: request.headers.get("x-user-role"),
+    keyName: request.headers.get("x-user-key-name"),
+  };
+}

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -61,7 +61,7 @@
     "next": "^14.2.25",
     "node-sql-parser": "^5.3.8",
     "posthog-js": "^1.236.5",
-    "posthog-node": "^4.13.0",
+    "posthog-node": "^4.17.0",
     "qs": "^6.14.0",
     "random-words": "^2.0.1",
     "react": "^18.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,13 +32,13 @@ importers:
     dependencies:
       '@docusaurus/core':
         specifier: 3.7.0
-        version: 3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.11)(react@18.3.1))(eslint@9.12.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.2)
+        version: 3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.11)(react@18.3.1))(eslint@9.12.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.2)
       '@docusaurus/preset-classic':
         specifier: 3.7.0
-        version: 3.7.0(@algolia/client-search@5.21.0)(@mdx-js/react@3.1.0(@types/react@18.3.11)(react@18.3.1))(@types/react@18.3.11)(eslint@9.12.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.3)(typescript@5.8.2)
+        version: 3.7.0(@algolia/client-search@5.21.0)(@mdx-js/react@3.1.0(@types/react@18.3.11)(react@18.3.1))(@types/react@18.3.11)(eslint@9.12.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.3)(typescript@5.8.2)
       '@docusaurus/theme-common':
         specifier: 3.7.0
-        version: 3.7.0(@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.11)(react@18.3.1))(eslint@9.12.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 3.7.0(@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.11)(react@18.3.1))(eslint@9.12.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@mdx-js/react':
         specifier: ^3.1.0
         version: 3.1.0(@types/react@18.3.11)(react@18.3.1)
@@ -78,7 +78,7 @@ importers:
         version: 3.7.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@eslint/compat':
         specifier: ^1.2.7
-        version: 1.2.7(eslint@9.12.0)
+        version: 1.2.7(eslint@9.12.0(jiti@2.4.2))
       '@eslint/eslintrc':
         specifier: ^3.3.1
         version: 3.3.1
@@ -195,7 +195,7 @@ importers:
         version: 5.0.0-alpha.1(@mui/material@5.16.0(@emotion/react@11.14.0(@types/react@18.3.11)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.11)(react@18.3.1))(@types/react@18.3.11)(react@18.3.1))(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(formik@2.4.6(react@18.3.1))(react@18.3.1)(tiny-warning@1.0.3)
       formik-mui-x-date-pickers:
         specifier: ^1.0.0
-        version: 1.0.0(cbbyjq4p6erp3flzp2wa6pm6eu)
+        version: 1.0.0(d50c1871fb7030c4cc9f48f318f7ba95)
       generate-api-key:
         specifier: ^1.0.2
         version: 1.0.2
@@ -218,8 +218,8 @@ importers:
         specifier: ^1.236.5
         version: 1.236.5
       posthog-node:
-        specifier: ^4.13.0
-        version: 4.13.0
+        specifier: ^4.17.0
+        version: 4.17.1
       qs:
         specifier: ^6.14.0
         version: 6.14.0
@@ -9895,8 +9895,8 @@ packages:
       rrweb-snapshot:
         optional: true
 
-  posthog-node@4.13.0:
-    resolution: {integrity: sha512-4rGi+9hf4WmMcKjWuzBtQYzFRltfVmSPCB5N364AhchFAT2Eoclx1M7KUWJZ0C2fMObdNGRNw1NQYEO4iGnviQ==}
+  posthog-node@4.17.1:
+    resolution: {integrity: sha512-cVlQPOwOPjakUnrueKRCQe1m2Ku+XzKaOos7Tn/zDZkkZFeBT/byP7tbNf7LiwhaBRWFBRowZZb/MsTtSRaorg==}
     engines: {node: '>=15.0.0'}
 
   preact@10.22.1:
@@ -14147,7 +14147,7 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/bundler@3.7.0(eslint@9.12.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.2)':
+  '@docusaurus/bundler@3.7.0(eslint@9.12.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.2)':
     dependencies:
       '@babel/core': 7.26.0
       '@docusaurus/babel': 3.7.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -14168,7 +14168,7 @@ snapshots:
       postcss: 8.5.3
       postcss-loader: 7.3.4(postcss@8.5.3)(typescript@5.8.2)(webpack@5.95.0)
       postcss-preset-env: 10.1.5(postcss@8.5.3)
-      react-dev-utils: 12.0.1(eslint@9.12.0)(typescript@5.8.2)(webpack@5.95.0)
+      react-dev-utils: 12.0.1(eslint@9.12.0(jiti@2.4.2))(typescript@5.8.2)(webpack@5.95.0)
       terser-webpack-plugin: 5.3.10(webpack@5.95.0)
       tslib: 2.8.0
       url-loader: 4.1.1(file-loader@6.2.0(webpack@5.95.0))(webpack@5.95.0)
@@ -14191,10 +14191,10 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/core@3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.11)(react@18.3.1))(eslint@9.12.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.2)':
+  '@docusaurus/core@3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.11)(react@18.3.1))(eslint@9.12.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.2)':
     dependencies:
       '@docusaurus/babel': 3.7.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/bundler': 3.7.0(eslint@9.12.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.2)
+      '@docusaurus/bundler': 3.7.0(eslint@9.12.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.2)
       '@docusaurus/logger': 3.7.0
       '@docusaurus/mdx-loader': 3.7.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/utils': 3.7.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -14221,7 +14221,7 @@ snapshots:
       p-map: 4.0.0
       prompts: 2.4.2
       react: 18.3.1
-      react-dev-utils: 12.0.1(eslint@9.12.0)(typescript@5.8.2)(webpack@5.95.0)
+      react-dev-utils: 12.0.1(eslint@9.12.0(jiti@2.4.2))(typescript@5.8.2)(webpack@5.95.0)
       react-dom: 18.3.1(react@18.3.1)
       react-helmet-async: '@slorber/react-helmet-async@1.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)'
       react-loadable: '@docusaurus/react-loadable@6.0.0(react@18.3.1)'
@@ -14322,13 +14322,13 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/plugin-content-blog@3.7.0(@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.11)(react@18.3.1))(eslint@9.12.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.2))(@mdx-js/react@3.1.0(@types/react@18.3.11)(react@18.3.1))(eslint@9.12.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.2)':
+  '@docusaurus/plugin-content-blog@3.7.0(@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.11)(react@18.3.1))(eslint@9.12.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.2))(@mdx-js/react@3.1.0(@types/react@18.3.11)(react@18.3.1))(eslint@9.12.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.2)':
     dependencies:
-      '@docusaurus/core': 3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.11)(react@18.3.1))(eslint@9.12.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.2)
+      '@docusaurus/core': 3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.11)(react@18.3.1))(eslint@9.12.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.2)
       '@docusaurus/logger': 3.7.0
       '@docusaurus/mdx-loader': 3.7.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/plugin-content-docs': 3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.11)(react@18.3.1))(eslint@9.12.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.2)
-      '@docusaurus/theme-common': 3.7.0(@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.11)(react@18.3.1))(eslint@9.12.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/plugin-content-docs': 3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.11)(react@18.3.1))(eslint@9.12.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.2)
+      '@docusaurus/theme-common': 3.7.0(@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.11)(react@18.3.1))(eslint@9.12.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/types': 3.7.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/utils': 3.7.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/utils-common': 3.7.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -14365,13 +14365,13 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.11)(react@18.3.1))(eslint@9.12.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.2)':
+  '@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.11)(react@18.3.1))(eslint@9.12.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.2)':
     dependencies:
-      '@docusaurus/core': 3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.11)(react@18.3.1))(eslint@9.12.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.2)
+      '@docusaurus/core': 3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.11)(react@18.3.1))(eslint@9.12.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.2)
       '@docusaurus/logger': 3.7.0
       '@docusaurus/mdx-loader': 3.7.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/module-type-aliases': 3.7.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/theme-common': 3.7.0(@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.11)(react@18.3.1))(eslint@9.12.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/theme-common': 3.7.0(@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.11)(react@18.3.1))(eslint@9.12.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/types': 3.7.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/utils': 3.7.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/utils-common': 3.7.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -14406,9 +14406,9 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-content-pages@3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.11)(react@18.3.1))(eslint@9.12.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.2)':
+  '@docusaurus/plugin-content-pages@3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.11)(react@18.3.1))(eslint@9.12.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.2)':
     dependencies:
-      '@docusaurus/core': 3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.11)(react@18.3.1))(eslint@9.12.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.2)
+      '@docusaurus/core': 3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.11)(react@18.3.1))(eslint@9.12.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.2)
       '@docusaurus/mdx-loader': 3.7.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/types': 3.7.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/utils': 3.7.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -14438,9 +14438,9 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-debug@3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.11)(react@18.3.1))(eslint@9.12.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.2)':
+  '@docusaurus/plugin-debug@3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.11)(react@18.3.1))(eslint@9.12.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.2)':
     dependencies:
-      '@docusaurus/core': 3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.11)(react@18.3.1))(eslint@9.12.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.2)
+      '@docusaurus/core': 3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.11)(react@18.3.1))(eslint@9.12.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.2)
       '@docusaurus/types': 3.7.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/utils': 3.7.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       fs-extra: 11.2.0
@@ -14468,9 +14468,9 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-google-analytics@3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.11)(react@18.3.1))(eslint@9.12.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.2)':
+  '@docusaurus/plugin-google-analytics@3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.11)(react@18.3.1))(eslint@9.12.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.2)':
     dependencies:
-      '@docusaurus/core': 3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.11)(react@18.3.1))(eslint@9.12.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.2)
+      '@docusaurus/core': 3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.11)(react@18.3.1))(eslint@9.12.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.2)
       '@docusaurus/types': 3.7.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/utils-validation': 3.7.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
@@ -14496,9 +14496,9 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-google-gtag@3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.11)(react@18.3.1))(eslint@9.12.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.2)':
+  '@docusaurus/plugin-google-gtag@3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.11)(react@18.3.1))(eslint@9.12.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.2)':
     dependencies:
-      '@docusaurus/core': 3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.11)(react@18.3.1))(eslint@9.12.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.2)
+      '@docusaurus/core': 3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.11)(react@18.3.1))(eslint@9.12.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.2)
       '@docusaurus/types': 3.7.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/utils-validation': 3.7.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@types/gtag.js': 0.0.12
@@ -14525,9 +14525,9 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-google-tag-manager@3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.11)(react@18.3.1))(eslint@9.12.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.2)':
+  '@docusaurus/plugin-google-tag-manager@3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.11)(react@18.3.1))(eslint@9.12.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.2)':
     dependencies:
-      '@docusaurus/core': 3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.11)(react@18.3.1))(eslint@9.12.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.2)
+      '@docusaurus/core': 3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.11)(react@18.3.1))(eslint@9.12.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.2)
       '@docusaurus/types': 3.7.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/utils-validation': 3.7.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
@@ -14553,9 +14553,9 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-sitemap@3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.11)(react@18.3.1))(eslint@9.12.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.2)':
+  '@docusaurus/plugin-sitemap@3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.11)(react@18.3.1))(eslint@9.12.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.2)':
     dependencies:
-      '@docusaurus/core': 3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.11)(react@18.3.1))(eslint@9.12.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.2)
+      '@docusaurus/core': 3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.11)(react@18.3.1))(eslint@9.12.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.2)
       '@docusaurus/logger': 3.7.0
       '@docusaurus/types': 3.7.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/utils': 3.7.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -14586,9 +14586,9 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-svgr@3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.11)(react@18.3.1))(eslint@9.12.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.2)':
+  '@docusaurus/plugin-svgr@3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.11)(react@18.3.1))(eslint@9.12.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.2)':
     dependencies:
-      '@docusaurus/core': 3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.11)(react@18.3.1))(eslint@9.12.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.2)
+      '@docusaurus/core': 3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.11)(react@18.3.1))(eslint@9.12.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.2)
       '@docusaurus/types': 3.7.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/utils': 3.7.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/utils-validation': 3.7.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -14618,21 +14618,21 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/preset-classic@3.7.0(@algolia/client-search@5.21.0)(@mdx-js/react@3.1.0(@types/react@18.3.11)(react@18.3.1))(@types/react@18.3.11)(eslint@9.12.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.3)(typescript@5.8.2)':
+  '@docusaurus/preset-classic@3.7.0(@algolia/client-search@5.21.0)(@mdx-js/react@3.1.0(@types/react@18.3.11)(react@18.3.1))(@types/react@18.3.11)(eslint@9.12.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.3)(typescript@5.8.2)':
     dependencies:
-      '@docusaurus/core': 3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.11)(react@18.3.1))(eslint@9.12.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.2)
-      '@docusaurus/plugin-content-blog': 3.7.0(@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.11)(react@18.3.1))(eslint@9.12.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.2))(@mdx-js/react@3.1.0(@types/react@18.3.11)(react@18.3.1))(eslint@9.12.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.2)
-      '@docusaurus/plugin-content-docs': 3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.11)(react@18.3.1))(eslint@9.12.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.2)
-      '@docusaurus/plugin-content-pages': 3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.11)(react@18.3.1))(eslint@9.12.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.2)
-      '@docusaurus/plugin-debug': 3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.11)(react@18.3.1))(eslint@9.12.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.2)
-      '@docusaurus/plugin-google-analytics': 3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.11)(react@18.3.1))(eslint@9.12.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.2)
-      '@docusaurus/plugin-google-gtag': 3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.11)(react@18.3.1))(eslint@9.12.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.2)
-      '@docusaurus/plugin-google-tag-manager': 3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.11)(react@18.3.1))(eslint@9.12.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.2)
-      '@docusaurus/plugin-sitemap': 3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.11)(react@18.3.1))(eslint@9.12.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.2)
-      '@docusaurus/plugin-svgr': 3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.11)(react@18.3.1))(eslint@9.12.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.2)
-      '@docusaurus/theme-classic': 3.7.0(@types/react@18.3.11)(eslint@9.12.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.2)
-      '@docusaurus/theme-common': 3.7.0(@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.11)(react@18.3.1))(eslint@9.12.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/theme-search-algolia': 3.7.0(@algolia/client-search@5.21.0)(@mdx-js/react@3.1.0(@types/react@18.3.11)(react@18.3.1))(@types/react@18.3.11)(eslint@9.12.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.3)(typescript@5.8.2)
+      '@docusaurus/core': 3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.11)(react@18.3.1))(eslint@9.12.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.2)
+      '@docusaurus/plugin-content-blog': 3.7.0(@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.11)(react@18.3.1))(eslint@9.12.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.2))(@mdx-js/react@3.1.0(@types/react@18.3.11)(react@18.3.1))(eslint@9.12.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.2)
+      '@docusaurus/plugin-content-docs': 3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.11)(react@18.3.1))(eslint@9.12.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.2)
+      '@docusaurus/plugin-content-pages': 3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.11)(react@18.3.1))(eslint@9.12.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.2)
+      '@docusaurus/plugin-debug': 3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.11)(react@18.3.1))(eslint@9.12.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.2)
+      '@docusaurus/plugin-google-analytics': 3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.11)(react@18.3.1))(eslint@9.12.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.2)
+      '@docusaurus/plugin-google-gtag': 3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.11)(react@18.3.1))(eslint@9.12.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.2)
+      '@docusaurus/plugin-google-tag-manager': 3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.11)(react@18.3.1))(eslint@9.12.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.2)
+      '@docusaurus/plugin-sitemap': 3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.11)(react@18.3.1))(eslint@9.12.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.2)
+      '@docusaurus/plugin-svgr': 3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.11)(react@18.3.1))(eslint@9.12.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.2)
+      '@docusaurus/theme-classic': 3.7.0(@types/react@18.3.11)(eslint@9.12.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.2)
+      '@docusaurus/theme-common': 3.7.0(@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.11)(react@18.3.1))(eslint@9.12.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/theme-search-algolia': 3.7.0(@algolia/client-search@5.21.0)(@mdx-js/react@3.1.0(@types/react@18.3.11)(react@18.3.1))(@types/react@18.3.11)(eslint@9.12.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.3)(typescript@5.8.2)
       '@docusaurus/types': 3.7.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -14664,16 +14664,16 @@ snapshots:
       '@types/react': 18.3.11
       react: 18.3.1
 
-  '@docusaurus/theme-classic@3.7.0(@types/react@18.3.11)(eslint@9.12.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.2)':
+  '@docusaurus/theme-classic@3.7.0(@types/react@18.3.11)(eslint@9.12.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.2)':
     dependencies:
-      '@docusaurus/core': 3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.11)(react@18.3.1))(eslint@9.12.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.2)
+      '@docusaurus/core': 3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.11)(react@18.3.1))(eslint@9.12.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.2)
       '@docusaurus/logger': 3.7.0
       '@docusaurus/mdx-loader': 3.7.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/module-type-aliases': 3.7.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/plugin-content-blog': 3.7.0(@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.11)(react@18.3.1))(eslint@9.12.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.2))(@mdx-js/react@3.1.0(@types/react@18.3.11)(react@18.3.1))(eslint@9.12.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.2)
-      '@docusaurus/plugin-content-docs': 3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.11)(react@18.3.1))(eslint@9.12.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.2)
-      '@docusaurus/plugin-content-pages': 3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.11)(react@18.3.1))(eslint@9.12.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.2)
-      '@docusaurus/theme-common': 3.7.0(@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.11)(react@18.3.1))(eslint@9.12.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/plugin-content-blog': 3.7.0(@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.11)(react@18.3.1))(eslint@9.12.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.2))(@mdx-js/react@3.1.0(@types/react@18.3.11)(react@18.3.1))(eslint@9.12.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.2)
+      '@docusaurus/plugin-content-docs': 3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.11)(react@18.3.1))(eslint@9.12.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.2)
+      '@docusaurus/plugin-content-pages': 3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.11)(react@18.3.1))(eslint@9.12.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.2)
+      '@docusaurus/theme-common': 3.7.0(@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.11)(react@18.3.1))(eslint@9.12.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/theme-translations': 3.7.0
       '@docusaurus/types': 3.7.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/utils': 3.7.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -14714,11 +14714,11 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/theme-common@3.7.0(@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.11)(react@18.3.1))(eslint@9.12.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@docusaurus/theme-common@3.7.0(@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.11)(react@18.3.1))(eslint@9.12.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@docusaurus/mdx-loader': 3.7.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/module-type-aliases': 3.7.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/plugin-content-docs': 3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.11)(react@18.3.1))(eslint@9.12.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.2)
+      '@docusaurus/plugin-content-docs': 3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.11)(react@18.3.1))(eslint@9.12.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.2)
       '@docusaurus/utils': 3.7.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/utils-common': 3.7.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@types/history': 4.7.11
@@ -14738,13 +14738,13 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/theme-search-algolia@3.7.0(@algolia/client-search@5.21.0)(@mdx-js/react@3.1.0(@types/react@18.3.11)(react@18.3.1))(@types/react@18.3.11)(eslint@9.12.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.3)(typescript@5.8.2)':
+  '@docusaurus/theme-search-algolia@3.7.0(@algolia/client-search@5.21.0)(@mdx-js/react@3.1.0(@types/react@18.3.11)(react@18.3.1))(@types/react@18.3.11)(eslint@9.12.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.3)(typescript@5.8.2)':
     dependencies:
       '@docsearch/react': 3.9.0(@algolia/client-search@5.21.0)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.3)
-      '@docusaurus/core': 3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.11)(react@18.3.1))(eslint@9.12.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.2)
+      '@docusaurus/core': 3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.11)(react@18.3.1))(eslint@9.12.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.2)
       '@docusaurus/logger': 3.7.0
-      '@docusaurus/plugin-content-docs': 3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.11)(react@18.3.1))(eslint@9.12.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.2)
-      '@docusaurus/theme-common': 3.7.0(@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.11)(react@18.3.1))(eslint@9.12.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/plugin-content-docs': 3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.11)(react@18.3.1))(eslint@9.12.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.2)
+      '@docusaurus/theme-common': 3.7.0(@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.11)(react@18.3.1))(eslint@9.12.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/theme-translations': 3.7.0
       '@docusaurus/utils': 3.7.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/utils-validation': 3.7.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -14989,9 +14989,9 @@ snapshots:
       eslint: 8.57.1
       eslint-visitor-keys: 3.4.3
 
-  '@eslint-community/eslint-utils@4.6.1(eslint@9.12.0)':
+  '@eslint-community/eslint-utils@4.6.1(eslint@9.12.0(jiti@2.4.2))':
     dependencies:
-      eslint: 9.12.0
+      eslint: 9.12.0(jiti@2.4.2)
       eslint-visitor-keys: 3.4.3
     optional: true
 
@@ -14999,9 +14999,9 @@ snapshots:
 
   '@eslint-community/regexpp@4.12.1': {}
 
-  '@eslint/compat@1.2.7(eslint@9.12.0)':
+  '@eslint/compat@1.2.7(eslint@9.12.0(jiti@2.4.2))':
     optionalDependencies:
-      eslint: 9.12.0
+      eslint: 9.12.0(jiti@2.4.2)
 
   '@eslint/config-array@0.18.0':
     dependencies:
@@ -16328,7 +16328,7 @@ snapshots:
 
   '@mui/base@5.0.0-beta.40(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@babel/runtime': 7.24.7
+      '@babel/runtime': 7.27.0
       '@floating-ui/react-dom': 2.1.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@mui/types': 7.2.14(@types/react@18.3.11)
       '@mui/utils': 5.16.0(@types/react@18.3.11)(react@18.3.1)
@@ -16393,7 +16393,7 @@ snapshots:
 
   '@mui/system@5.16.0(@emotion/react@11.14.0(@types/react@18.3.11)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.11)(react@18.3.1))(@types/react@18.3.11)(react@18.3.1))(@types/react@18.3.11)(react@18.3.1)':
     dependencies:
-      '@babel/runtime': 7.24.7
+      '@babel/runtime': 7.27.0
       '@mui/private-theming': 5.16.0(@types/react@18.3.11)(react@18.3.1)
       '@mui/styled-engine': 5.15.14(@emotion/react@11.14.0(@types/react@18.3.11)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.11)(react@18.3.1))(@types/react@18.3.11)(react@18.3.1))(react@18.3.1)
       '@mui/types': 7.2.14(@types/react@18.3.11)
@@ -16413,7 +16413,7 @@ snapshots:
 
   '@mui/utils@5.16.0(@types/react@18.3.11)(react@18.3.1)':
     dependencies:
-      '@babel/runtime': 7.24.7
+      '@babel/runtime': 7.27.0
       '@types/prop-types': 15.7.12
       prop-types: 15.8.1
       react: 18.3.1
@@ -20666,7 +20666,7 @@ snapshots:
       debug: 4.4.0
       enhanced-resolve: 5.17.0
       eslint: 8.57.1
-      eslint-module-utils: 2.8.1(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.57.1))(eslint@8.57.1)
+      eslint-module-utils: 2.8.1(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.1)
       eslint-plugin-import: 2.29.1(@typescript-eslint/parser@8.26.1(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1)
       fast-glob: 3.3.2
       get-tsconfig: 4.7.5
@@ -20678,7 +20678,7 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-module-utils@2.8.1(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.57.1))(eslint@8.57.1):
+  eslint-module-utils@2.8.1(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -20878,9 +20878,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint@9.12.0:
+  eslint@9.12.0(jiti@2.4.2):
     dependencies:
-      '@eslint-community/eslint-utils': 4.6.1(eslint@9.12.0)
+      '@eslint-community/eslint-utils': 4.6.1(eslint@9.12.0(jiti@2.4.2))
       '@eslint-community/regexpp': 4.12.1
       '@eslint/config-array': 0.18.0
       '@eslint/core': 0.6.0
@@ -20915,6 +20915,8 @@ snapshots:
       natural-compare: 1.4.0
       optionator: 0.9.4
       text-table: 0.2.0
+    optionalDependencies:
+      jiti: 2.4.2
     transitivePeerDependencies:
       - supports-color
     optional: true
@@ -21361,7 +21363,7 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
-  fork-ts-checker-webpack-plugin@6.5.3(eslint@9.12.0)(typescript@5.8.2)(webpack@5.95.0):
+  fork-ts-checker-webpack-plugin@6.5.3(eslint@9.12.0(jiti@2.4.2))(typescript@5.8.2)(webpack@5.95.0):
     dependencies:
       '@babel/code-frame': 7.26.2
       '@types/json-schema': 7.0.15
@@ -21379,7 +21381,7 @@ snapshots:
       typescript: 5.8.2
       webpack: 5.95.0
     optionalDependencies:
-      eslint: 9.12.0
+      eslint: 9.12.0(jiti@2.4.2)
 
   form-data-encoder@2.1.4: {}
 
@@ -21397,7 +21399,7 @@ snapshots:
 
   format@0.2.2: {}
 
-  formik-mui-x-date-pickers@1.0.0(cbbyjq4p6erp3flzp2wa6pm6eu):
+  formik-mui-x-date-pickers@1.0.0(d50c1871fb7030c4cc9f48f318f7ba95):
     dependencies:
       '@emotion/react': 11.14.0(@types/react@18.3.11)(react@18.3.1)
       '@emotion/styled': 11.14.0(@emotion/react@11.14.0(@types/react@18.3.11)(react@18.3.1))(@types/react@18.3.11)(react@18.3.1)
@@ -22265,7 +22267,7 @@ snapshots:
 
   instantsearch-ui-components@0.11.1:
     dependencies:
-      '@babel/runtime': 7.26.10
+      '@babel/runtime': 7.27.0
 
   instantsearch.css@8.5.1: {}
 
@@ -25265,7 +25267,7 @@ snapshots:
       preact: 10.22.1
       web-vitals: 4.2.4
 
-  posthog-node@4.13.0:
+  posthog-node@4.17.1:
     dependencies:
       axios: 1.8.4
     transitivePeerDependencies:
@@ -25737,7 +25739,7 @@ snapshots:
       date-fns: 3.6.0
       react: 18.3.1
 
-  react-dev-utils@12.0.1(eslint@9.12.0)(typescript@5.8.2)(webpack@5.95.0):
+  react-dev-utils@12.0.1(eslint@9.12.0(jiti@2.4.2))(typescript@5.8.2)(webpack@5.95.0):
     dependencies:
       '@babel/code-frame': 7.26.2
       address: 1.2.2
@@ -25748,7 +25750,7 @@ snapshots:
       escape-string-regexp: 4.0.0
       filesize: 8.0.7
       find-up: 5.0.0
-      fork-ts-checker-webpack-plugin: 6.5.3(eslint@9.12.0)(typescript@5.8.2)(webpack@5.95.0)
+      fork-ts-checker-webpack-plugin: 6.5.3(eslint@9.12.0(jiti@2.4.2))(typescript@5.8.2)(webpack@5.95.0)
       global-modules: 2.0.0
       globby: 11.1.0
       gzip-size: 6.0.0
@@ -25785,7 +25787,7 @@ snapshots:
 
   react-instantsearch-core@7.15.4(algoliasearch@5.21.0)(react@18.3.1):
     dependencies:
-      '@babel/runtime': 7.26.10
+      '@babel/runtime': 7.27.0
       algoliasearch: 5.21.0
       algoliasearch-helper: 3.24.2(algoliasearch@5.21.0)
       instantsearch.js: 4.78.0(algoliasearch@5.21.0)
@@ -25881,7 +25883,7 @@ snapshots:
 
   react-transition-group@4.4.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
-      '@babel/runtime': 7.24.7
+      '@babel/runtime': 7.27.0
       dom-helpers: 5.2.1
       loose-envify: 1.4.0
       prop-types: 15.8.1


### PR DESCRIPTION
WIP. This PR closes #3773 by centralizing `PostHog` analytics in a middleware route. It also adds some permissions checks. This is where we want to track credits, permissions, rate limits, etc.

Next steps:
- implement role-based auth
- implement usage measurement

Blocked by #3774. We need to migrate individual users to organizations first.