### PR TITLE
Add Graphql Pagination with Giveth Data Contribution

### DIFF
--- a/warehouse/oso_dagster/assets/giveth.py
+++ b/warehouse/oso_dagster/assets/giveth.py
@@ -1,39 +1,100 @@
 import requests
 import polars as pl
 from dagster import multi_asset, AssetOut, Output
+from typing import Any
 
 @multi_asset(
     outs={
-        "giveth__qf_rounds": AssetOut(),
-        "giveth__projects_by_round": AssetOut(),
+        "giveth__qf_rounds_v2": AssetOut(),
+        "giveth__projects_by_round_v2": AssetOut(),
     },
 )
+
 def fetch_giveth_data():
     endpoint = "https://mainnet.serve.giveth.io/graphql"
 
-    def run_query(query, variables):
-        response = requests.post(endpoint, json={"query": query, "variables": variables})
-        response.raise_for_status()
-        return response.json()["data"]
+    def run_query(query, variables, retries=3, delay=5):
+        import time
+        for attempt in range(retries):
+            try:
+                response = requests.post(endpoint, json={"query": query, "variables": variables})
+                response.raise_for_status()
+                json_data = response.json()
+                if "data" not in json_data or json_data["data"] is None:
+                    raise ValueError(f"No 'data' field in response: {json_data}")
+                return json_data["data"]
+            except (requests.exceptions.RequestException, ValueError) as e:
+                if attempt < retries - 1:
+                    print(f"[Retry {attempt+1}] Giveth API failed: {e}. Retrying in {delay} seconds...")
+                    time.sleep(delay)
+                    delay *= 2
+                else:
+                    raise
 
-    # Fetch qfRounds
+    def flatten_dict(d: dict[str, Any], parent_key: str = '', sep: str = '_') -> dict[str, Any]:
+        items = []
+        for k, v in d.items():
+            new_key = f"{parent_key}{sep}{k}" if parent_key else k
+            if isinstance(v, dict):
+                items.extend(flatten_dict(v, new_key, sep=sep).items())
+            else:
+                items.append((new_key, v))
+        return dict(items)
+
+    def align_columns(data: list[dict]) -> pl.DataFrame:
+        # Get all unique keys across all rows
+        all_keys = sorted(set().union(*(row.keys() for row in data)))
+        # Ensure every row has all keys (fill with None)
+        aligned_data = [
+            {key: row.get(key, None) for key in all_keys}
+            for row in data
+        ]
+        return pl.DataFrame(aligned_data, schema=all_keys)
+
+    # QF Rounds Query
     qf_rounds_query = """
     query GetRounds($activeOnly: Boolean!) {
-        qfRounds(activeOnly: $activeOnly) {
-            id
-            title
-        }
+      qfRounds(activeOnly: $activeOnly) {
+          id
+          name
+          title
+          description
+          slug
+          isActive
+          allocatedFund
+          allocatedFundUSD
+          allocatedFundUSDPreferred
+          allocatedTokenSymbol
+          allocatedTokenChainId
+          maximumReward
+          minimumPassportScore
+          minMBDScore
+          minimumValidUsdValue
+          eligibleNetworks
+          beginDate
+          endDate
+          qfStrategy
+          bannerBgImage
+          sponsorsImgs
+          isDataAnalysisDone
+          clusterMatchingSyncAt 
+      }
     }
     """
     qf_rounds_result = run_query(qf_rounds_query, {"activeOnly": False})
+    if not qf_rounds_result or "qfRounds" not in qf_rounds_result:
+        raise ValueError("Invalid response: 'qfRounds' key is missing or response is None")
     qf_rounds = qf_rounds_result["qfRounds"]
+    qf_rounds_flat = [flatten_dict(r) for r in qf_rounds]
+    qf_rounds_df = align_columns(qf_rounds_flat)
+    print("QF Rounds DF schema:")
+    print(qf_rounds_df.schema)
+    print("QF Rounds DF preview:")
+    print(qf_rounds_df.head(3))
 
-    # Convert to Polars DataFrame
-    qf_rounds_df = pl.DataFrame(qf_rounds)
-    yield Output(qf_rounds_df, output_name="giveth__qf_rounds")
+    yield Output(qf_rounds_df, output_name="giveth__qf_rounds_v2")
 
-    # Fetch projects for each round
-    all_projects = []
+    # Projects Query
     projects_query = """
     query GetProjects($qfRoundId: Int!, $skip: Int!, $take: Int!) {
       allProjects(qfRoundId: $qfRoundId, skip: $skip, take: $take, orderBy: {
@@ -43,12 +104,112 @@ def fetch_giveth_data():
         projects {
           id
           title
+          slug
+          slugHistory
+          description
+          descriptionSummary
+          traceCampaignId
+          givingBlocksId
+          changeId
+          website
+          youtube
           creationDate
+          updatedAt
+          latestUpdateCreationDate
+          organization { id name website }
+          coOrdinates
+          image
+          impactLocation
+          categories {
+            id
+          }
+          qfRounds {
+            id
+            title
+          }
+          balance
+          stripeAccountId
+          walletAddress
+          verified
+          verificationStatus
+          isImported
+          giveBacks
+          donations {
+            id
+          }
+          qualityScore
+          contacts {
+            url
+          }
+          reactions{
+            id
+          }
+          addresses {
+            id
+          }
+          socialMedia {
+            id
+          }
+          anchorContracts {
+            id
+          }
+          status{
+            id
+            name
+          }
+          adminUserId
+          statusHistory {
+            id
+          }
+          projectVerificationForm {
+            id
+          }
+          featuredUpdate {
+            id
+          }
+          verificationFormStatus
+          socialProfiles { id name link socialNetwork isVerified }
+          projectEstimatedMatchingView { projectId qfRoundId }
+          totalDonations
+          totalTraceDonations
+          totalReactions
+          totalProjectUpdates
+          sumDonationValueUsdForActiveQfRound
+          countUniqueDonorsForActiveQfRound
+          countUniqueDonors
+          listed
+          isGivbackEligible
+          reviewStatus
+          projectUrl
+          prevStatusId
+          adminJsBaseUrl
+          campaigns {
+              id
+              slug
+              title
+              type
+              isActive
+              isNew
+              isFeatured
+              description
+              hashtags
+              relatedProjectsSlugs
+              landingLink
+              updatedAt
+              createdAt
+          }
+          estimatedMatching {
+            projectDonationsSqrtRootSum
+            allProjectsSum
+            matchingPool
+            matching
+          }
         }
       }
     }
     """
 
+    all_projects = []
     for round_ in qf_rounds:
         round_id = round_["id"]
         skip = 0
@@ -58,12 +219,17 @@ def fetch_giveth_data():
                 "skip": skip,
                 "take": 50
             })
-            page = projects_result["allProjects"]["projects"]
+            if not projects_result or "allProjects" not in projects_result:
+                break
+            page = projects_result["allProjects"].get("projects", [])
             if not page:
                 break
-            all_projects.extend(page)
+            all_projects.extend([flatten_dict(p) for p in page])
             skip += 50
 
-    # Convert all projects to Polars DataFrame
-    projects_df = pl.DataFrame(all_projects)
-    yield Output(projects_df, output_name="giveth__projects_by_round")
+    projects_df = align_columns(all_projects)
+    print("Projects DF schema:")
+    print(projects_df.schema)
+    print("Projects DF preview:")
+    print(projects_df.head(3))
+    yield Output(projects_df, output_name="giveth__projects_by_round_v2")

--- a/warehouse/oso_dagster/assets/giveth.py
+++ b/warehouse/oso_dagster/assets/giveth.py
@@ -1,35 +1,69 @@
-from ..factories.graphql import GraphQLResourceConfig, graphql_factory
+import requests
+import polars as pl
+from dagster import multi_asset, AssetOut, Output
 
-configs = [
-    GraphQLResourceConfig(
-        name="all_projects",
-        endpoint="https://mainnet.serve.giveth.io/graphql",
-        max_depth=1,
-        parameters={
-            "qfRoundId": {"type": "Int", "value": 12},  # Dynamically templated later
-            "skip": {"type": "Int", "value": 0},
-            "take": {"type": "Int", "value": 50},
-            "orderBy": {
-                "type": "OrderBy",
-                "value": {
-                    "field": "CreationDate",
-                    "direction": "DESC"
-                }
-            }
-        },
-        target_query="allProjects",
-        target_type="AllProjects",      
-        transform_fn=lambda result: result["allProjects"]["projects"]
-    ),
-    GraphQLResourceConfig(
-        name="qf_rounds",
-        endpoint="https://mainnet.serve.giveth.io/graphql",
-        max_depth=2,
-        parameters={"activeOnly": {"type": "Boolean", "value": False}},
-        target_query="qfRounds",
-        target_type="QfRound",
-        transform_fn=lambda result: result["qfRounds"]
-    ),
-]
+@multi_asset(
+    outs={
+        "giveth__qf_rounds": AssetOut(),
+        "giveth__projects_by_round": AssetOut(),
+    },
+)
+def fetch_giveth_data():
+    endpoint = "https://mainnet.serve.giveth.io/graphql"
 
-giveth_assets = [graphql_factory(config, key_prefix="giveth") for config in configs]
+    def run_query(query, variables):
+        response = requests.post(endpoint, json={"query": query, "variables": variables})
+        response.raise_for_status()
+        return response.json()["data"]
+
+    # Fetch qfRounds
+    qf_rounds_query = """
+    query GetRounds($activeOnly: Boolean!) {
+        qfRounds(activeOnly: $activeOnly) {
+            id
+            title
+        }
+    }
+    """
+    qf_rounds_result = run_query(qf_rounds_query, {"activeOnly": False})
+    qf_rounds = qf_rounds_result["qfRounds"]
+
+    # Convert to Polars DataFrame
+    qf_rounds_df = pl.DataFrame(qf_rounds)
+    yield Output(qf_rounds_df, output_name="giveth__qf_rounds")
+
+    # Fetch projects for each round
+    all_projects = []
+    projects_query = """
+    query GetProjects($qfRoundId: Int!, $skip: Int!, $take: Int!) {
+      allProjects(qfRoundId: $qfRoundId, skip: $skip, take: $take, orderBy: {
+        field: CreationDate,
+        direction: DESC
+      }) {
+        projects {
+          id
+          title
+          creationDate
+        }
+      }
+    }
+    """
+
+    for round_ in qf_rounds:
+        round_id = round_["id"]
+        skip = 0
+        while True:
+            projects_result = run_query(projects_query, {
+                "qfRoundId": int(round_id),
+                "skip": skip,
+                "take": 50
+            })
+            page = projects_result["allProjects"]["projects"]
+            if not page:
+                break
+            all_projects.extend(page)
+            skip += 50
+
+    # Convert all projects to Polars DataFrame
+    projects_df = pl.DataFrame(all_projects)
+    yield Output(projects_df, output_name="giveth__projects_by_round")

--- a/warehouse/oso_dagster/assets/giveth.py
+++ b/warehouse/oso_dagster/assets/giveth.py
@@ -1,0 +1,35 @@
+from ..factories.graphql import GraphQLResourceConfig, graphql_factory
+
+configs = [
+    GraphQLResourceConfig(
+        name="all_projects",
+        endpoint="https://mainnet.serve.giveth.io/graphql",
+        max_depth=1,
+        parameters={
+            "qfRoundId": {"type": "Int", "value": 12},  # Dynamically templated later
+            "skip": {"type": "Int", "value": 0},
+            "take": {"type": "Int", "value": 50},
+            "orderBy": {
+                "type": "OrderBy",
+                "value": {
+                    "field": "CreationDate",
+                    "direction": "DESC"
+                }
+            }
+        },
+        target_query="allProjects",
+        target_type="AllProjects",      
+        transform_fn=lambda result: result["allProjects"]["projects"]
+    ),
+    GraphQLResourceConfig(
+        name="qf_rounds",
+        endpoint="https://mainnet.serve.giveth.io/graphql",
+        max_depth=2,
+        parameters={"activeOnly": {"type": "Boolean", "value": False}},
+        target_query="qfRounds",
+        target_type="QfRound",
+        transform_fn=lambda result: result["qfRounds"]
+    ),
+]
+
+giveth_assets = [graphql_factory(config, key_prefix="giveth") for config in configs]


### PR DESCRIPTION
### Summary

This PR introduces full support for **pagination in GraphQL data sources** using both **offset-based** and **cursor-based** methods. It extends the `GraphQLResourceConfig` and dynamically handles paginated GraphQL queries across any compatible API. The implementation is generic and reusable, with minimal changes required to onboard new data sources.

### Features Added

#### 1. **Extended GraphQLResourceConfig**

* Added a new `pagination` field to support dynamic pagination configuration.
* Compatible with both `offset` and `cursor` styles.

#### 2. **Offset-Based Pagination Support**

* Implements `skip` + `take` logic.
* Configurable parameter names (`offset_param`, `limit_param`, `start_offset`).
* Automatically paginates through all data using defined chunk sizes.

#### 3. **Cursor-Based Pagination Support**

* Supports `after` or `before` cursors and limits via `first`/`last`.
* Walks the GraphQL response using user-defined paths (`path_to_data`, `path_to_cursor`, `path_to_next`).
* Designed to work with GraphQL Relay-style APIs and dynamic datasets.

#### 4. **Retry and Debounce Handling**

* Includes retry mechanism with exponential backoff across pagination calls.
* Prevents accidental infinite loops by checking `hasNextPage` and cursor equality.

### **Changes Made**

* Rewrote the `_execute_query` logic inside `graphql_factory`.
* Added a helper `walk_path()` function for nested cursor paths.
* Ensured backward compatibility for non-paginated resources.


### Integration Test: Giveth Data Contribution

Documentation: https://hackmd.io/@torchablazed/S1Iloae-ge
![image](https://github.com/user-attachments/assets/39acfab6-bf4d-496d-bf9f-47d23e25b246)
