### PR TITLE
chore: allow at least a batch concurrency of 2

### DIFF
--- a/warehouse/oso_sqlmesh/models/intermediate/blockchain_artifacts/int_contracts_deployment.sql
+++ b/warehouse/oso_sqlmesh/models/intermediate/blockchain_artifacts/int_contracts_deployment.sql
@@ -3,7 +3,7 @@ MODEL (
   kind INCREMENTAL_BY_TIME_RANGE (
     time_column deployment_timestamp,
     batch_size 90,
-    batch_concurrency 1,
+    batch_concurrency 2,
     lookback 31,
     forward_only true,
     on_destructive_change warn,

--- a/warehouse/oso_sqlmesh/models/intermediate/blockchain_artifacts/int_contracts_root_deployers.sql
+++ b/warehouse/oso_sqlmesh/models/intermediate/blockchain_artifacts/int_contracts_root_deployers.sql
@@ -4,7 +4,7 @@ MODEL (
   kind INCREMENTAL_BY_TIME_RANGE (
     time_column deployment_timestamp,
     batch_size 90,
-    batch_concurrency 1,
+    batch_concurrency 2,
     lookback 31,
     forward_only true,
     on_destructive_change warn,

--- a/warehouse/oso_sqlmesh/models/intermediate/blockchain_artifacts/int_deployers.sql
+++ b/warehouse/oso_sqlmesh/models/intermediate/blockchain_artifacts/int_deployers.sql
@@ -3,7 +3,7 @@ MODEL (
   kind INCREMENTAL_BY_TIME_RANGE (
     time_column block_timestamp,
     batch_size 365,
-    batch_concurrency 1,
+    batch_concurrency 2,
     lookback 31,
     forward_only true,
     on_destructive_change warn,

--- a/warehouse/oso_sqlmesh/models/intermediate/events/code/int_issue_event_time_deltas.sql
+++ b/warehouse/oso_sqlmesh/models/intermediate/events/code/int_issue_event_time_deltas.sql
@@ -4,7 +4,7 @@ MODEL (
   kind INCREMENTAL_BY_TIME_RANGE (
     time_column time,
     batch_size 365,
-    batch_concurrency 1,
+    batch_concurrency 2,
     lookback 31,
     forward_only true,
   ),

--- a/warehouse/oso_sqlmesh/models/intermediate/events/int_events__4337.sql
+++ b/warehouse/oso_sqlmesh/models/intermediate/events/int_events__4337.sql
@@ -4,7 +4,7 @@ MODEL (
   kind INCREMENTAL_BY_TIME_RANGE (
     time_column time,
     batch_size 180,
-    batch_concurrency 1,
+    batch_concurrency 2,
     lookback 31,
     forward_only true,
     on_destructive_change warn,

--- a/warehouse/oso_sqlmesh/models/intermediate/events/int_events__blockchain.sql
+++ b/warehouse/oso_sqlmesh/models/intermediate/events/int_events__blockchain.sql
@@ -4,7 +4,7 @@ MODEL (
   kind INCREMENTAL_BY_TIME_RANGE (
     time_column time,
     batch_size 180,
-    batch_concurrency 1,
+    batch_concurrency 2,
     lookback 31,
     forward_only true,
   ),

--- a/warehouse/oso_sqlmesh/models/intermediate/events/int_events__blockchain_token_transfers.sql
+++ b/warehouse/oso_sqlmesh/models/intermediate/events/int_events__blockchain_token_transfers.sql
@@ -4,7 +4,7 @@ MODEL (
   kind INCREMENTAL_BY_TIME_RANGE (
     time_column time,
     batch_size 180,
-    batch_concurrency 1,
+    batch_concurrency 2,
     lookback 31,
     forward_only true,
     on_destructive_change warn,

--- a/warehouse/oso_sqlmesh/models/intermediate/events/int_events__dependencies.sql
+++ b/warehouse/oso_sqlmesh/models/intermediate/events/int_events__dependencies.sql
@@ -4,7 +4,7 @@ MODEL (
   kind INCREMENTAL_BY_TIME_RANGE (
     time_column time,
     batch_size 365,
-    batch_concurrency 1,
+    batch_concurrency 2,
     lookback 31,
     forward_only true,
     on_destructive_change warn,

--- a/warehouse/oso_sqlmesh/models/intermediate/events/int_events__funding.sql
+++ b/warehouse/oso_sqlmesh/models/intermediate/events/int_events__funding.sql
@@ -4,7 +4,7 @@ MODEL (
   kind INCREMENTAL_BY_TIME_RANGE (
     time_column time,
     batch_size 90,
-    batch_concurrency 1,
+    batch_concurrency 2,
     lookback 31
   ),
   start @funding_incremental_start,

--- a/warehouse/oso_sqlmesh/models/intermediate/events/int_events__github.sql
+++ b/warehouse/oso_sqlmesh/models/intermediate/events/int_events__github.sql
@@ -3,7 +3,7 @@ MODEL (
   kind INCREMENTAL_BY_TIME_RANGE (
     time_column time,
     batch_size 365,
-    batch_concurrency 1,
+    batch_concurrency 2,
     lookback 31,
     forward_only true,
     on_destructive_change warn,

--- a/warehouse/oso_sqlmesh/models/intermediate/events/int_events_aux_issues.sql
+++ b/warehouse/oso_sqlmesh/models/intermediate/events/int_events_aux_issues.sql
@@ -3,7 +3,7 @@ MODEL (
   kind INCREMENTAL_BY_TIME_RANGE (
     time_column time,
     batch_size 365,
-    batch_concurrency 1,
+    batch_concurrency 2,
     lookback 31,
     forward_only true
   ),

--- a/warehouse/oso_sqlmesh/models/intermediate/events/int_events_daily__4337.sql
+++ b/warehouse/oso_sqlmesh/models/intermediate/events/int_events_daily__4337.sql
@@ -4,7 +4,7 @@ MODEL (
   kind INCREMENTAL_BY_TIME_RANGE (
     time_column bucket_day,
     batch_size 180,
-    batch_concurrency 1,
+    batch_concurrency 2,
     lookback 31,
     forward_only true,
   ),

--- a/warehouse/oso_sqlmesh/models/intermediate/events/int_events_daily__blockchain.sql
+++ b/warehouse/oso_sqlmesh/models/intermediate/events/int_events_daily__blockchain.sql
@@ -4,7 +4,7 @@ MODEL (
   kind INCREMENTAL_BY_TIME_RANGE (
     time_column bucket_day,
     batch_size 180,
-    batch_concurrency 1,
+    batch_concurrency 2,
     lookback 31,
     forward_only true,
   ),

--- a/warehouse/oso_sqlmesh/models/intermediate/events/int_events_daily__blockchain_token_transfers.sql
+++ b/warehouse/oso_sqlmesh/models/intermediate/events/int_events_daily__blockchain_token_transfers.sql
@@ -4,7 +4,7 @@ MODEL (
   kind INCREMENTAL_BY_TIME_RANGE (
     time_column bucket_day,
     batch_size 180,
-    batch_concurrency 1,
+    batch_concurrency 2,
     lookback 31,
     forward_only true,
   ),

--- a/warehouse/oso_sqlmesh/models/intermediate/events/int_events_daily__dependencies.sql
+++ b/warehouse/oso_sqlmesh/models/intermediate/events/int_events_daily__dependencies.sql
@@ -3,7 +3,7 @@ MODEL (
   kind INCREMENTAL_BY_TIME_RANGE (
     time_column bucket_day,
     batch_size 365,
-    batch_concurrency 1,
+    batch_concurrency 2,
     lookback 31,
     forward_only true,
   ),

--- a/warehouse/oso_sqlmesh/models/intermediate/events/int_events_daily__funding.sql
+++ b/warehouse/oso_sqlmesh/models/intermediate/events/int_events_daily__funding.sql
@@ -3,7 +3,7 @@ MODEL (
   kind INCREMENTAL_BY_TIME_RANGE (
     time_column bucket_day,
     batch_size 365,
-    batch_concurrency 1,
+    batch_concurrency 2,
     lookback 31,
     forward_only true,
   ),

--- a/warehouse/oso_sqlmesh/models/intermediate/events/int_events_daily__github.sql
+++ b/warehouse/oso_sqlmesh/models/intermediate/events/int_events_daily__github.sql
@@ -3,7 +3,7 @@ MODEL (
   kind INCREMENTAL_BY_TIME_RANGE (
     time_column bucket_day,
     batch_size 365,
-    batch_concurrency 1,
+    batch_concurrency 2,
     lookback 31,
     forward_only true,
   ),

--- a/warehouse/oso_sqlmesh/models/intermediate/events/int_events_daily__github_with_lag.sql
+++ b/warehouse/oso_sqlmesh/models/intermediate/events/int_events_daily__github_with_lag.sql
@@ -3,7 +3,7 @@ MODEL (
   kind INCREMENTAL_BY_TIME_RANGE (
     time_column bucket_day,
     batch_size 365,
-    batch_concurrency 1,
+    batch_concurrency 2,
     lookback 31,
     forward_only true,
   ),

--- a/warehouse/oso_sqlmesh/models/intermediate/events/int_events_daily_to_artifact.sql
+++ b/warehouse/oso_sqlmesh/models/intermediate/events/int_events_daily_to_artifact.sql
@@ -3,7 +3,7 @@ MODEL (
   kind INCREMENTAL_BY_TIME_RANGE (
     time_column bucket_day,
     batch_size 365,
-    batch_concurrency 1,
+    batch_concurrency 2,
     lookback 31,
     forward_only true,
   ),

--- a/warehouse/oso_sqlmesh/models/intermediate/events/int_events_daily_to_project__github.sql
+++ b/warehouse/oso_sqlmesh/models/intermediate/events/int_events_daily_to_project__github.sql
@@ -4,7 +4,7 @@ MODEL (
   kind INCREMENTAL_BY_TIME_RANGE (
     time_column bucket_day,
     batch_size 365,
-    batch_concurrency 1,
+    batch_concurrency 2,
     lookback 31
   ),
   start '2015-01-01',

--- a/warehouse/oso_sqlmesh/models/intermediate/events/int_events_filtered__github.sql
+++ b/warehouse/oso_sqlmesh/models/intermediate/events/int_events_filtered__github.sql
@@ -3,7 +3,7 @@ MODEL (
   kind INCREMENTAL_BY_TIME_RANGE (
     time_column time,
     batch_size 365,
-    batch_concurrency 1,
+    batch_concurrency 2,
     lookback 31
   ),
   start @github_incremental_start,

--- a/warehouse/oso_sqlmesh/models/intermediate/events/int_events_monthly_to_artifact.sql
+++ b/warehouse/oso_sqlmesh/models/intermediate/events/int_events_monthly_to_artifact.sql
@@ -3,7 +3,7 @@ MODEL (
   kind INCREMENTAL_BY_TIME_RANGE (
     time_column bucket_week,
     batch_size 365,
-    batch_concurrency 1,
+    batch_concurrency 2,
     lookback 1,
     forward_only true,
   ),

--- a/warehouse/oso_sqlmesh/models/intermediate/events/int_events_monthly_to_project__github.sql
+++ b/warehouse/oso_sqlmesh/models/intermediate/events/int_events_monthly_to_project__github.sql
@@ -4,7 +4,7 @@ MODEL (
   kind INCREMENTAL_BY_TIME_RANGE (
     time_column bucket_month,
     batch_size 12,
-    batch_concurrency 1,
+    batch_concurrency 2,
     lookback 1
   ),
   start '2015-01-01',

--- a/warehouse/oso_sqlmesh/models/intermediate/events/int_events_to_collection.sql
+++ b/warehouse/oso_sqlmesh/models/intermediate/events/int_events_to_collection.sql
@@ -4,7 +4,7 @@ MODEL (
   kind INCREMENTAL_BY_TIME_RANGE (
     time_column time,
     batch_size 365,
-    batch_concurrency 1,
+    batch_concurrency 2,
     lookback 31
   ),
   start '2015-01-01',

--- a/warehouse/oso_sqlmesh/models/intermediate/events/int_events_to_project__github.sql
+++ b/warehouse/oso_sqlmesh/models/intermediate/events/int_events_to_project__github.sql
@@ -4,7 +4,7 @@ MODEL (
   kind INCREMENTAL_BY_TIME_RANGE (
     time_column time,
     batch_size 365,
-    batch_concurrency 1,
+    batch_concurrency 2,
     lookback 31
   ),
   start '2015-01-01',

--- a/warehouse/oso_sqlmesh/models/intermediate/events/int_events_weekly__github.sql
+++ b/warehouse/oso_sqlmesh/models/intermediate/events/int_events_weekly__github.sql
@@ -3,7 +3,7 @@ MODEL (
   kind INCREMENTAL_BY_TIME_RANGE (
     time_column bucket_week,
     batch_size 365,
-    batch_concurrency 1,
+    batch_concurrency 2,
     lookback 31,
     forward_only true,
   ),

--- a/warehouse/oso_sqlmesh/models/intermediate/superchain/int_superchain_events_by_project.sql
+++ b/warehouse/oso_sqlmesh/models/intermediate/superchain/int_superchain_events_by_project.sql
@@ -3,7 +3,7 @@ MODEL (
   kind incremental_by_time_range(
    time_column time,
    batch_size 60,
-   batch_concurrency 1,
+   batch_concurrency 2,
    lookback 31
   ),
   start '2024-09-01',

--- a/warehouse/oso_sqlmesh/models/intermediate/superchain/s7/int_superchain_s7_onchain_builder_events.sql
+++ b/warehouse/oso_sqlmesh/models/intermediate/superchain/s7/int_superchain_s7_onchain_builder_events.sql
@@ -4,7 +4,7 @@ MODEL(
   kind incremental_by_time_range(
    time_column time,
    batch_size 60,
-   batch_concurrency 1,
+   batch_concurrency 2,
    lookback 31
   ),
   start '2024-09-01',

--- a/warehouse/oso_sqlmesh/models/staging/superchain/stg_superchain__proxies.sql
+++ b/warehouse/oso_sqlmesh/models/staging/superchain/stg_superchain__proxies.sql
@@ -3,7 +3,7 @@ MODEL (
   kind INCREMENTAL_BY_TIME_RANGE (
     time_column block_timestamp,
     batch_size 90,
-    batch_concurrency 1,
+    batch_concurrency 2,
     lookback 31,
     forward_only true,
   ),

--- a/warehouse/oso_sqlmesh/models/staging/superchain/stg_superchain__traces.sql
+++ b/warehouse/oso_sqlmesh/models/staging/superchain/stg_superchain__traces.sql
@@ -3,7 +3,7 @@ MODEL (
   kind INCREMENTAL_BY_TIME_RANGE (
     time_column block_timestamp,
     batch_size 90,
-    batch_concurrency 1,
+    batch_concurrency 2,
     lookback 31,
     forward_only true,
   ),

--- a/warehouse/oso_sqlmesh/models/staging/superchain/stg_superchain__transactions.sql
+++ b/warehouse/oso_sqlmesh/models/staging/superchain/stg_superchain__transactions.sql
@@ -3,7 +3,7 @@ MODEL (
   kind INCREMENTAL_BY_TIME_RANGE (
     time_column block_timestamp,
     batch_size 90,
-    batch_concurrency 1,
+    batch_concurrency 2,
     lookback 31,
     forward_only true,
   ),

--- a/warehouse/oso_sqlmesh/models/staging/superchain/stg_worldchain__verified_users.sql
+++ b/warehouse/oso_sqlmesh/models/staging/superchain/stg_worldchain__verified_users.sql
@@ -3,7 +3,7 @@ MODEL (
   kind INCREMENTAL_BY_TIME_RANGE (
     time_column block_timestamp,
     batch_size 90,
-    batch_concurrency 1,
+    batch_concurrency 2,
     lookback 31
   ),
   dialect trino,


### PR DESCRIPTION
This hopefully speeds up runs. It was originally set like this because I didn't understand why some things failed on iceberg + trino but I think this can run without a massive limit on concurrency. Likely can set this even larger, especially if we scale up the instance sizes.