### PR TITLE
chore: add more tags to models

### DIFF
--- a/warehouse/oso_sqlmesh/models/intermediate/blockchain_artifacts/int_contracts_deployment.sql
+++ b/warehouse/oso_sqlmesh/models/intermediate/blockchain_artifacts/int_contracts_deployment.sql
@@ -16,6 +16,9 @@ MODEL (
   ignored_rules (
     "incrementalmustdefinenogapsaudit",
   ),
+  tags (
+    "incremental"
+  )
 );
 
 /* The intent is to get the _first_ factory deployments as some contracts */ /* deployed via deterministic deployers allows for multiple calls to the */ /* create2 function. */

--- a/warehouse/oso_sqlmesh/models/intermediate/blockchain_artifacts/int_contracts_root_deployers.sql
+++ b/warehouse/oso_sqlmesh/models/intermediate/blockchain_artifacts/int_contracts_root_deployers.sql
@@ -17,6 +17,11 @@ MODEL (
   ignored_rules (
     "incrementalmustdefinenogapsaudit",
   ),
+  tags (
+    "blockchain",
+    "superchain",
+    "incremental",
+  ),
 );
 
 WITH existing_contracts AS (

--- a/warehouse/oso_sqlmesh/models/intermediate/blockchain_artifacts/int_contracts_transactions_weekly.sql
+++ b/warehouse/oso_sqlmesh/models/intermediate/blockchain_artifacts/int_contracts_transactions_weekly.sql
@@ -19,6 +19,11 @@ MODEL (
   ignored_rules (
     "incrementalmustdefinenogapsaudit",
   ),
+  tags (
+    "blockchain",
+    "superchain",
+    "incremental",
+  ),
 );
 
 /* Find all transactions involving the contracts from `derived_contracts` and */ /* aggregate their tx_count on a weekly basis */

--- a/warehouse/oso_sqlmesh/models/intermediate/blockchain_artifacts/int_deployers.sql
+++ b/warehouse/oso_sqlmesh/models/intermediate/blockchain_artifacts/int_deployers.sql
@@ -18,6 +18,9 @@ MODEL (
       ignore_before := @superchain_audit_start,
       missing_rate_min_threshold := 0.95,
     ),
+  ),
+  tags (
+    "incremental"
   )
 );
 

--- a/warehouse/oso_sqlmesh/models/intermediate/events/int_events__4337.sql
+++ b/warehouse/oso_sqlmesh/models/intermediate/events/int_events__4337.sql
@@ -18,7 +18,12 @@ MODEL (
   ),
   ignored_rules (
     "incrementalmustdefinenogapsaudit",
-  )
+  ),
+  tags (
+    "blockchain",
+    "superchain",
+    "incremental",
+  ),
 );
 
 WITH filtered_events AS (

--- a/warehouse/oso_sqlmesh/models/intermediate/events/int_events__blockchain.sql
+++ b/warehouse/oso_sqlmesh/models/intermediate/events/int_events__blockchain.sql
@@ -20,6 +20,9 @@ MODEL (
       ignore_before := @superchain_audit_start,
       missing_rate_min_threshold := 0.95,
     ),
+  ),
+  tags (
+    "incremental"
   )
 );
 

--- a/warehouse/oso_sqlmesh/models/intermediate/events/int_events__blockchain_token_transfers.sql
+++ b/warehouse/oso_sqlmesh/models/intermediate/events/int_events__blockchain_token_transfers.sql
@@ -21,7 +21,12 @@ MODEL (
       ignore_before := @superchain_audit_start,
       missing_rate_min_threshold := 0.95,
     ),
-  )
+  ),
+  tags (
+    "blockchain",
+    "superchain",
+    "incremental",
+  ),
 );
 
 SELECT

--- a/warehouse/oso_sqlmesh/models/intermediate/events/int_events__dependencies.sql
+++ b/warehouse/oso_sqlmesh/models/intermediate/events/int_events__dependencies.sql
@@ -20,6 +20,9 @@ MODEL (
       time_column := time,
       no_gap_date_part := 'day',
     ),
+  ),
+  tags (
+    "incremental"
   )
 );
 

--- a/warehouse/oso_sqlmesh/models/intermediate/events/int_events__funding.sql
+++ b/warehouse/oso_sqlmesh/models/intermediate/events/int_events__funding.sql
@@ -17,7 +17,11 @@ MODEL (
   ignored_rules (
     "incrementalmustdefinenogapsaudit",
     "incrementalmusthaveforwardonly",
-  )
+  ),
+  tags (
+    "funding",
+    "incremental",
+  ),
 );
 
 WITH open_collective_expenses AS (

--- a/warehouse/oso_sqlmesh/models/intermediate/events/int_events__funding_awarded.sql
+++ b/warehouse/oso_sqlmesh/models/intermediate/events/int_events__funding_awarded.sql
@@ -5,7 +5,10 @@ MODEL (
   kind full,
   audits (
     HAS_AT_LEAST_N_ROWS(threshold := 0)
-  )
+  ),
+  tags (
+    "funding",
+  ),
 );
 
 SELECT

--- a/warehouse/oso_sqlmesh/models/intermediate/events/int_events__github.sql
+++ b/warehouse/oso_sqlmesh/models/intermediate/events/int_events__github.sql
@@ -19,7 +19,11 @@ MODEL (
       time_column := time,
       no_gap_date_part := 'day',
     ),
-  )
+  ),
+  tags (
+    "github",
+    "incremental",
+  ),
 );
 
 WITH raw_events AS (

--- a/warehouse/oso_sqlmesh/models/intermediate/events/int_events_aux_issues.sql
+++ b/warehouse/oso_sqlmesh/models/intermediate/events/int_events_aux_issues.sql
@@ -18,6 +18,9 @@ MODEL (
       time_column := time,
       no_gap_date_part := 'day',
     ),
+  ),
+  tags (
+    "incremental"
   )
 );
 

--- a/warehouse/oso_sqlmesh/models/intermediate/events/int_events_daily__4337.sql
+++ b/warehouse/oso_sqlmesh/models/intermediate/events/int_events_daily__4337.sql
@@ -17,6 +17,9 @@ MODEL (
   ),
   ignored_rules (
     "incrementalmustdefinenogapsaudit",
+  ),
+  tags (
+    "incremental"
   )
 );
 

--- a/warehouse/oso_sqlmesh/models/intermediate/events/int_events_daily__blockchain.sql
+++ b/warehouse/oso_sqlmesh/models/intermediate/events/int_events_daily__blockchain.sql
@@ -18,6 +18,9 @@ MODEL (
       time_column := bucket_day,
       no_gap_date_part := 'day',
     ),
+  ),
+  tags (
+    "incremental"
   )
 );
 

--- a/warehouse/oso_sqlmesh/models/intermediate/events/int_events_daily__blockchain_token_transfers.sql
+++ b/warehouse/oso_sqlmesh/models/intermediate/events/int_events_daily__blockchain_token_transfers.sql
@@ -19,6 +19,9 @@ MODEL (
       time_column := bucket_day,
       no_gap_date_part := 'day',
     ),
+  ),
+  tags (
+    "incremental"
   )
 );
 

--- a/warehouse/oso_sqlmesh/models/intermediate/events/int_events_daily__dependencies.sql
+++ b/warehouse/oso_sqlmesh/models/intermediate/events/int_events_daily__dependencies.sql
@@ -18,6 +18,9 @@ MODEL (
       time_column := bucket_day,
       no_gap_date_part := 'day',
     ),
+  ),
+  tags (
+    "incremental"
   )
 );
 

--- a/warehouse/oso_sqlmesh/models/intermediate/events/int_events_daily__funding.sql
+++ b/warehouse/oso_sqlmesh/models/intermediate/events/int_events_daily__funding.sql
@@ -16,7 +16,11 @@ MODEL (
   ),
   ignored_rules (
     "incrementalmustdefinenogapsaudit",
-  )
+  ),
+  tags (
+    "github",
+    "incremental",
+  ),
 );
 
 SELECT

--- a/warehouse/oso_sqlmesh/models/intermediate/events/int_events_daily__github.sql
+++ b/warehouse/oso_sqlmesh/models/intermediate/events/int_events_daily__github.sql
@@ -17,6 +17,9 @@ MODEL (
       time_column := bucket_day,
       no_gap_date_part := 'day',
     ),
+  ),
+  tags (
+    "incremental"
   )
 );
 

--- a/warehouse/oso_sqlmesh/models/intermediate/events/int_events_daily__github_with_lag.sql
+++ b/warehouse/oso_sqlmesh/models/intermediate/events/int_events_daily__github_with_lag.sql
@@ -17,6 +17,9 @@ MODEL (
       time_column := bucket_day,
       no_gap_date_part := 'day',
     ),
+  ),
+  tags (
+    "incremental"
   )
 );
 

--- a/warehouse/oso_sqlmesh/models/intermediate/events/int_events_daily_to_artifact.sql
+++ b/warehouse/oso_sqlmesh/models/intermediate/events/int_events_daily_to_artifact.sql
@@ -18,6 +18,9 @@ MODEL (
       time_column := bucket_day,
       no_gap_date_part := 'day',
     ),
+  ),
+  tags (
+    "incremental"
   )
 );
 

--- a/warehouse/oso_sqlmesh/models/intermediate/events/int_events_daily_to_project__github.sql
+++ b/warehouse/oso_sqlmesh/models/intermediate/events/int_events_daily_to_project__github.sql
@@ -12,7 +12,9 @@ MODEL (
   partitioned_by (DAY("bucket_day"), "event_type"),
   grain (bucket_day, event_type, event_source, from_artifact_id, to_artifact_id),
   tags (
-    'entity_category=project'
+    "entity_category=project",
+    "github",
+    "incremental"
   ),
   audits (
     has_at_least_n_rows(threshold := 0),

--- a/warehouse/oso_sqlmesh/models/intermediate/events/int_events_filtered__github.sql
+++ b/warehouse/oso_sqlmesh/models/intermediate/events/int_events_filtered__github.sql
@@ -20,6 +20,9 @@ MODEL (
   ),
   ignored_rules (
     "incrementalmusthaveforwardonly",
+  ),
+  tags (
+    "incremental"
   )
 );
 

--- a/warehouse/oso_sqlmesh/models/intermediate/events/int_events_monthly_to_artifact.sql
+++ b/warehouse/oso_sqlmesh/models/intermediate/events/int_events_monthly_to_artifact.sql
@@ -17,6 +17,9 @@ MODEL (
   ),
   ignored_rules (
     "incrementalmustdefinenogapsaudit",
+  ),
+  tags (
+    "incremental"
   )
 );
 

--- a/warehouse/oso_sqlmesh/models/intermediate/events/int_events_monthly_to_project__github.sql
+++ b/warehouse/oso_sqlmesh/models/intermediate/events/int_events_monthly_to_project__github.sql
@@ -12,7 +12,9 @@ MODEL (
   partitioned_by (MONTH("bucket_month"), "event_type"),
   grain (bucket_month, event_type, event_source, from_artifact_id, to_artifact_id),
   tags (
-    'entity_category=project'
+    "entity_category=project",
+    "github",
+    "incremental",
   ),
   audits (
     has_at_least_n_rows(threshold := 0),
@@ -23,10 +25,6 @@ MODEL (
   ),
   ignored_rules (
     "incrementalmusthaveforwardonly",
-  ),
-  tags (
-    "github",
-    "incremental",
   ),
 );
 

--- a/warehouse/oso_sqlmesh/models/intermediate/events/int_events_monthly_to_project__github.sql
+++ b/warehouse/oso_sqlmesh/models/intermediate/events/int_events_monthly_to_project__github.sql
@@ -23,7 +23,11 @@ MODEL (
   ),
   ignored_rules (
     "incrementalmusthaveforwardonly",
-  )
+  ),
+  tags (
+    "github",
+    "incremental",
+  ),
 );
 
 SELECT

--- a/warehouse/oso_sqlmesh/models/intermediate/events/int_events_to_collection.sql
+++ b/warehouse/oso_sqlmesh/models/intermediate/events/int_events_to_collection.sql
@@ -13,7 +13,8 @@ MODEL (
   grain (time, event_type, event_source, from_artifact_id, to_artifact_id),
   enabled false,
   tags (
-    'entity_category=collection'
+    'entity_category=collection',
+    "incremental"
   ),
   audits (
     has_at_least_n_rows(threshold := 0),

--- a/warehouse/oso_sqlmesh/models/intermediate/events/int_events_to_project__github.sql
+++ b/warehouse/oso_sqlmesh/models/intermediate/events/int_events_to_project__github.sql
@@ -12,7 +12,9 @@ MODEL (
   partitioned_by (DAY("time"), "event_type"),
   grain (time, event_type, event_source, from_artifact_id, to_artifact_id),
   tags (
-    'entity_category=project'
+    'entity_category=project',
+    "github",
+    "incremental",
   ),
   audits (
     has_at_least_n_rows(threshold := 0),
@@ -23,10 +25,6 @@ MODEL (
   ),
   ignored_rules (
     "incrementalmusthaveforwardonly",
-  ),
-  tags (
-    "github",
-    "incremental",
   ),
 );
 

--- a/warehouse/oso_sqlmesh/models/intermediate/events/int_events_to_project__github.sql
+++ b/warehouse/oso_sqlmesh/models/intermediate/events/int_events_to_project__github.sql
@@ -23,7 +23,11 @@ MODEL (
   ),
   ignored_rules (
     "incrementalmusthaveforwardonly",
-  )
+  ),
+  tags (
+    "github",
+    "incremental",
+  ),
 );
 
 SELECT

--- a/warehouse/oso_sqlmesh/models/intermediate/events/int_events_weekly__github.sql
+++ b/warehouse/oso_sqlmesh/models/intermediate/events/int_events_weekly__github.sql
@@ -16,7 +16,11 @@ MODEL (
   ),
   ignored_rules (
     "incrementalmustdefinenogapsaudit",
-  )
+  ),
+  tags (
+    "github",
+    "incremental",
+  ),
 );
 
 SELECT

--- a/warehouse/oso_sqlmesh/models/intermediate/events/int_first_of_event_from_artifact__github.sql
+++ b/warehouse/oso_sqlmesh/models/intermediate/events/int_first_of_event_from_artifact__github.sql
@@ -5,7 +5,10 @@ MODEL (
   grain (time, event_type, event_source, from_artifact_id, to_artifact_id),
   audits (
     not_null(columns := (event_type, event_source))
-  )
+  ),
+  tags (
+    "github",
+  ),
 );
 
 SELECT

--- a/warehouse/oso_sqlmesh/models/intermediate/events/int_last_of_event_from_artifact__github.sql
+++ b/warehouse/oso_sqlmesh/models/intermediate/events/int_last_of_event_from_artifact__github.sql
@@ -5,7 +5,10 @@ MODEL (
   grain (time, event_type, event_source, from_artifact_id, to_artifact_id),
   audits (
     not_null(columns := (event_type, event_source))
-  )
+  ),
+  tags (
+    "github",
+  ),
 );
 
 SELECT

--- a/warehouse/oso_sqlmesh/models/staging/deps-dev/stg_deps_dev__packages.sql
+++ b/warehouse/oso_sqlmesh/models/staging/deps-dev/stg_deps_dev__packages.sql
@@ -15,6 +15,9 @@ MODEL (
   ),
   ignored_rules (
     "incrementalmustdefinenogapsaudit",
+  ),
+  tags (
+    "incremental"
   )
 );
 

--- a/warehouse/oso_sqlmesh/models/staging/github/stg_github__commits.sql
+++ b/warehouse/oso_sqlmesh/models/staging/github/stg_github__commits.sql
@@ -17,6 +17,9 @@ MODEL (
       time_column := created_at,
       no_gap_date_part := 'day',
     ),
+  ),
+  tags (
+    "incremental"
   )
 );
 

--- a/warehouse/oso_sqlmesh/models/staging/github/stg_github__issues.sql
+++ b/warehouse/oso_sqlmesh/models/staging/github/stg_github__issues.sql
@@ -16,6 +16,9 @@ MODEL (
       time_column := event_time,
       no_gap_date_part := 'day',
     ),
+  ),
+  tags (
+    "incremental"
   )
 );
 

--- a/warehouse/oso_sqlmesh/models/staging/github/stg_github__pull_requests.sql
+++ b/warehouse/oso_sqlmesh/models/staging/github/stg_github__pull_requests.sql
@@ -17,6 +17,9 @@ MODEL (
       time_column := event_time,
       no_gap_date_part := 'day',
     ),
+  ),
+  tags (
+    "incremental"
   )
 );
 

--- a/warehouse/oso_sqlmesh/models/staging/github/stg_github__push_events.sql
+++ b/warehouse/oso_sqlmesh/models/staging/github/stg_github__push_events.sql
@@ -17,6 +17,9 @@ MODEL (
       time_column := created_at,
       no_gap_date_part := 'day',
     ),
+  ),
+  tags (
+    "incremental"
   )
 );
 

--- a/warehouse/oso_sqlmesh/models/staging/github/stg_github__releases.sql
+++ b/warehouse/oso_sqlmesh/models/staging/github/stg_github__releases.sql
@@ -16,6 +16,9 @@ MODEL (
       time_column := created_at,
       no_gap_date_part := 'day',
     ),
+  ),
+  tags (
+    "incremental"
   )
 );
 

--- a/warehouse/oso_sqlmesh/models/staging/github/stg_github__stars_and_forks.sql
+++ b/warehouse/oso_sqlmesh/models/staging/github/stg_github__stars_and_forks.sql
@@ -16,6 +16,9 @@ MODEL (
       time_column := created_at,
       no_gap_date_part := 'day',
     ),
+  ),
+  tags (
+    "incremental"
   )
 );
 

--- a/warehouse/oso_sqlmesh/models/staging/open-collective/stg_open_collective__deposits.sql
+++ b/warehouse/oso_sqlmesh/models/staging/open-collective/stg_open_collective__deposits.sql
@@ -16,6 +16,9 @@ MODEL (
   ),
   ignored_rules (
     "incrementalmustdefinenogapsaudit",
+  ),
+  tags (
+    "incremental"
   )
 );
 

--- a/warehouse/oso_sqlmesh/models/staging/open-collective/stg_open_collective__expenses.sql
+++ b/warehouse/oso_sqlmesh/models/staging/open-collective/stg_open_collective__expenses.sql
@@ -16,6 +16,9 @@ MODEL (
   ),
   ignored_rules (
     "incrementalmustdefinenogapsaudit",
+  ),
+  tags (
+    "incremental"
   )
 );
 

--- a/warehouse/oso_sqlmesh/models/staging/superchain/stg_superchain__4337_traces.sql
+++ b/warehouse/oso_sqlmesh/models/staging/superchain/stg_superchain__4337_traces.sql
@@ -27,7 +27,11 @@ MODEL (
   ),
   ignored_rules (
     "incrementalmustdefinenogapsaudit",
-  )
+  ),
+  tags (
+    "superchain",
+    "incremental",
+  ),
 );
 
 SELECT

--- a/warehouse/oso_sqlmesh/models/staging/superchain/stg_superchain__4337_userop_logs.sql
+++ b/warehouse/oso_sqlmesh/models/staging/superchain/stg_superchain__4337_userop_logs.sql
@@ -25,7 +25,11 @@ MODEL (
   ),
   ignored_rules (
     "incrementalmustdefinenogapsaudit",
-  )
+  ),
+  tags (
+    "superchain",
+    "incremental",
+  ),
 );
 
 SELECT

--- a/warehouse/oso_sqlmesh/models/staging/superchain/stg_superchain__deployers.sql
+++ b/warehouse/oso_sqlmesh/models/staging/superchain/stg_superchain__deployers.sql
@@ -20,7 +20,11 @@ MODEL (
       ignore_before := @superchain_audit_start,
       missing_rate_min_threshold := 0.95,
     ),
-  )
+  ),
+  tags (
+    "superchain",
+    "incremental",
+  ),
 );
 
 @transactions_with_receipts_deployers(

--- a/warehouse/oso_sqlmesh/models/staging/superchain/stg_superchain__factories.sql
+++ b/warehouse/oso_sqlmesh/models/staging/superchain/stg_superchain__factories.sql
@@ -20,6 +20,9 @@ MODEL (
       ignore_before := @superchain_audit_start,
       missing_rate_min_threshold := 0.95,
     ),
+  ),
+  tags (
+    "incremental"
   )
 );
 

--- a/warehouse/oso_sqlmesh/models/staging/superchain/stg_superchain__first_time_addresses.sql
+++ b/warehouse/oso_sqlmesh/models/staging/superchain/stg_superchain__first_time_addresses.sql
@@ -25,6 +25,10 @@ model(
     ignored_rules (
       "incrementalmustdefinenogapsaudit",
     ),
+    tags (
+      "superchain",
+      "incremental",
+    ),
 )
 ;
 

--- a/warehouse/oso_sqlmesh/models/staging/superchain/stg_superchain__potential_bots.sql
+++ b/warehouse/oso_sqlmesh/models/staging/superchain/stg_superchain__potential_bots.sql
@@ -8,7 +8,10 @@ model(
     enabled false,
     audits (
       has_at_least_n_rows(threshold := 0),
-    )
+    ),
+    tags (
+      "incremental",
+    ),
 )
 ;
 

--- a/warehouse/oso_sqlmesh/models/staging/superchain/stg_superchain__proxies.sql
+++ b/warehouse/oso_sqlmesh/models/staging/superchain/stg_superchain__proxies.sql
@@ -26,7 +26,11 @@ MODEL (
   ),
   ignored_rules (
     "incrementalmustdefinenogapsaudit",
-  )
+  ),
+  tags (
+    "superchain",
+    "incremental",
+  ),
 );
 
 @known_proxies(

--- a/warehouse/oso_sqlmesh/models/staging/superchain/stg_superchain__traces.sql
+++ b/warehouse/oso_sqlmesh/models/staging/superchain/stg_superchain__traces.sql
@@ -20,7 +20,11 @@ MODEL (
       ignore_before := @superchain_audit_start,
       missing_rate_min_threshold := 0.95,
     ),
-  )
+  ),
+  tags (
+    "superchain",
+    "incremental",
+  ),
 );
 
 SELECT

--- a/warehouse/oso_sqlmesh/models/staging/superchain/stg_superchain__transactions.sql
+++ b/warehouse/oso_sqlmesh/models/staging/superchain/stg_superchain__transactions.sql
@@ -20,7 +20,11 @@ MODEL (
       ignore_before := @superchain_audit_start,
       missing_rate_min_threshold := 0.95,
     ),
-  )
+  ),
+  tags (
+    "superchain",
+    "incremental",
+  ),
 );
 
 SELECT

--- a/warehouse/oso_sqlmesh/models/staging/superchain/stg_worldchain__verified_users.sql
+++ b/warehouse/oso_sqlmesh/models/staging/superchain/stg_worldchain__verified_users.sql
@@ -24,6 +24,10 @@ MODEL (
     "incrementalmustdefinenogapsaudit",
     "incrementalmusthaveforwardonly",
   ),
+  tags (
+    "superchain",
+    "incremental",
+  ),
 );
 
 WITH raw AS (


### PR DESCRIPTION
Adds more tags so we can better target models when restating. This will be updated to have more but this is useful enough as is. 