### PR TITLE
feat: separate OsoAppProvider into OsoDataProvider and OsoGlobalContext

### DIFF
--- a/apps/frontend/components/dataprovider/oso-data-provider.tsx
+++ b/apps/frontend/components/dataprovider/oso-data-provider.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import _ from "lodash";
 import useSWR from "swr";
-//import { RegistrationProps, RegistrationRefActions } from "../../lib/types/plasmic";
+import { RegistrationProps } from "../../lib/types/plasmic";
 import {
   CommonDataProviderProps,
   CommonDataProviderRegistration,
@@ -11,7 +11,7 @@ import { OsoAppClient } from "../../lib/clients/oso-app";
 
 // The name used to pass data into the Plasmic DataProvider
 const KEY_PREFIX = "oso";
-const genKey = (props: OsoAppProviderProps) =>
+const genKey = (props: OsoDataProviderProps) =>
   `${KEY_PREFIX}:${JSON.stringify(props)}`;
 
 type DataFetch = {
@@ -22,7 +22,7 @@ type DataFetch = {
 /**
  * OSO app client
  */
-type OsoAppProviderProps = CommonDataProviderProps & {
+type OsoDataProviderProps = CommonDataProviderProps & {
   /**
    * An object containing the client calls to be made, keyed by a unique name.
    * See OsoAppClient for the available methods and their arguments
@@ -37,7 +37,7 @@ type OsoAppProviderProps = CommonDataProviderProps & {
   dataFetches?: { [name: string]: Partial<DataFetch> };
 };
 
-const OsoAppProviderRegistration: any = {
+const OsoDataProviderRegistration: RegistrationProps<OsoDataProviderProps> = {
   ...CommonDataProviderRegistration,
   dataFetches: {
     type: "object",
@@ -46,45 +46,10 @@ const OsoAppProviderRegistration: any = {
   },
 };
 
-const OsoAppProviderRefActions: any = {
-  updateMyUserProfile: {
-    description: "Update the current user's profile",
-    argTypes: [{ name: "args", type: "object" }],
-  },
-  createApiKey: {
-    description: "Create an API key for the current user",
-    argTypes: [{ name: "args", type: "object" }],
-  },
-  createOrganization: {
-    description: "Create an organization",
-    argTypes: [{ name: "args", type: "object" }],
-  },
-  addUserToOrganizationByEmail: {
-    description: "Add an existing user to an organization by email",
-    argTypes: [{ name: "args", type: "object" }],
-  },
-  changeUserRole: {
-    description: "Change a user's role in an organization",
-    argTypes: [{ name: "args", type: "object" }],
-  },
-  removeUserFromOrganization: {
-    description: "Remove a user from an organization",
-    argTypes: [{ name: "args", type: "object" }],
-  },
-  deleteOrganization: {
-    description: "Deletes an organization",
-    argTypes: [{ name: "args", type: "object" }],
-  },
-};
-
-const OsoAppProvider = React.forwardRef<OsoAppClient>(function _OsoAppProvider(
-  props: OsoAppProviderProps,
-  ref: React.ForwardedRef<OsoAppClient>,
-) {
+function OsoDataProvider(props: OsoDataProviderProps) {
   const { dataFetches, variableName, testData, useTestData } = props;
   const key = variableName ?? genKey(props);
   const osoClient = new OsoAppClient();
-  React.useImperativeHandle(ref, () => osoClient, []);
   const { data, error, isLoading } = useSWR(key, async () => {
     if (useTestData) {
       return testData;
@@ -104,6 +69,7 @@ const OsoAppProvider = React.forwardRef<OsoAppClient>(function _OsoAppProvider(
     return result;
   });
   //console.log(data);
+  //console.log(JSON.stringify(data, null, 2));
   //console.log(error);
 
   // Error messages are currently rendered in the component
@@ -119,7 +85,7 @@ const OsoAppProvider = React.forwardRef<OsoAppClient>(function _OsoAppProvider(
       error={error}
     />
   );
-});
+}
 
-export { OsoAppProviderRegistration, OsoAppProviderRefActions, OsoAppProvider };
-export type { OsoAppProviderProps };
+export { OsoDataProviderRegistration, OsoDataProvider };
+export type { OsoDataProviderProps };

--- a/apps/frontend/components/dataprovider/oso-global-context.tsx
+++ b/apps/frontend/components/dataprovider/oso-global-context.tsx
@@ -1,0 +1,70 @@
+import React, { ReactNode } from "react";
+import { DataProvider, GlobalActionsProvider } from "@plasmicapp/loader-nextjs"; // or "@plasmicapp/loader-*""
+import * as config from "../../lib/config";
+import { OsoAppClient } from "../../lib/clients/oso-app";
+
+const PLASMIC_KEY = "globals";
+const PLASMIC_CONTEXT_NAME = "OsoGlobalContext";
+
+const OsoGlobalActions: any = {
+  updateMyUserProfile: { parameters: [{ name: "args", type: "object" }] },
+  createApiKey: { parameters: [{ name: "args", type: "object" }] },
+  createOrganization: { parameters: [{ name: "args", type: "object" }] },
+  addUserToOrganizationByEmail: {
+    parameters: [{ name: "args", type: "object" }],
+  },
+  changeUserRole: { parameters: [{ name: "args", type: "object" }] },
+  removeUserFromOrganization: {
+    parameters: [{ name: "args", type: "object" }],
+  },
+  deleteOrganization: { parameters: [{ name: "args", type: "object" }] },
+};
+
+// Users will be able to set these props in Studio.
+interface OsoGlobalContextProps {
+  children?: ReactNode;
+}
+
+function OsoGlobalContext(props: OsoGlobalContextProps) {
+  const { children } = props;
+  const [actionResult, setResult] = React.useState<any>(null);
+  const osoClient = new OsoAppClient();
+  const data = {
+    config,
+    actionResult,
+  };
+
+  const actions = React.useMemo(
+    () => ({
+      updateMyUserProfile: (args: any) =>
+        osoClient.updateMyUserProfile(args).then((res) => setResult(res)),
+      createApiKey: (args: any) =>
+        osoClient.createApiKey(args).then((res) => setResult(res)),
+      createOrganization: (args: any) =>
+        osoClient.createOrganization(args).then((res) => setResult(res)),
+      addUserToOrganizationByEmail: (args: any) =>
+        osoClient
+          .addUserToOrganizationByEmail(args)
+          .then((res) => setResult(res)),
+      changeUserRole: (args: any) =>
+        osoClient.changeUserRole(args).then((res) => setResult(res)),
+      removeUserFromOrganization: (args: any) =>
+        osoClient
+          .removeUserFromOrganization(args)
+          .then((res) => setResult(res)),
+      deleteOrganization: (args: any) =>
+        osoClient.deleteOrganization(args).then((res) => setResult(res)),
+    }),
+    [osoClient],
+  );
+
+  return (
+    <GlobalActionsProvider contextName={PLASMIC_CONTEXT_NAME} actions={actions}>
+      <DataProvider name={PLASMIC_KEY} data={data}>
+        {children}
+      </DataProvider>
+    </GlobalActionsProvider>
+  );
+}
+
+export { OsoGlobalContext, OsoGlobalActions };

--- a/apps/frontend/lib/types/plasmic.ts
+++ b/apps/frontend/lib/types/plasmic.ts
@@ -1,7 +1,5 @@
-import { PropType, CodeComponentMeta } from "@plasmicapp/loader-nextjs";
+import { PropType } from "@plasmicapp/loader-nextjs";
 
 export type RegistrationProps<P> = {
   [prop: string]: PropType<P>;
 };
-
-export type RegistrationRefActions<P> = CodeComponentMeta<P>["refActions"];

--- a/apps/frontend/plasmic-init-client.tsx
+++ b/apps/frontend/plasmic-init-client.tsx
@@ -36,10 +36,25 @@ import { MonacoEditor } from "./components/widgets/monaco-editor";
 import { OSOChat } from "./components/widgets/oso-chat";
 import { register as registerMetricsUtils } from "./lib/metrics-utils";
 import {
-  OsoAppProvider,
-  OsoAppProviderRegistration,
-  OsoAppProviderRefActions,
-} from "./components/dataprovider/oso-app-provider";
+  OsoDataProvider,
+  OsoDataProviderRegistration,
+} from "./components/dataprovider/oso-data-provider";
+import {
+  OsoGlobalContext,
+  OsoGlobalActions,
+} from "./components/dataprovider/oso-global-context";
+
+/**
+ * Plasmic global context
+ */
+
+PLASMIC.registerGlobalContext(OsoGlobalContext, {
+  name: "OsoGlobalContext",
+  props: {},
+  providesData: true,
+  globalActions: { ...OsoGlobalActions },
+  importPath: "./components/dataprovider/oso-global-context",
+});
 
 /**
  * Plasmic component registration
@@ -253,13 +268,12 @@ PLASMIC.registerComponent(SupabaseQuery, {
   importPath: "./components/dataprovider/supabase-query",
 });
 
-PLASMIC.registerComponent(OsoAppProvider, {
-  name: "OsoAppProvider",
-  description: "OSO App client provider",
-  props: { ...OsoAppProviderRegistration },
-  refActions: { ...OsoAppProviderRefActions },
+PLASMIC.registerComponent(OsoDataProvider, {
+  name: "OsoDataProvider",
+  description: "OSO data provider",
+  props: { ...OsoDataProviderRegistration },
   providesData: true,
-  importPath: "./components/dataprovider/oso-app-provider",
+  importPath: "./components/dataprovider/oso-data-provider",
 });
 
 PLASMIC.registerComponent(SupabaseWrite, {


### PR DESCRIPTION
* Previous approach wasn't working
* This makes it cleaner, where write actions are exposed globally, but read data context is local
* Also exposes config as a global context