### PR TITLE
fix: Supabase global variables tech debt

### DIFF
--- a/apps/frontend/app/layout.tsx
+++ b/apps/frontend/app/layout.tsx
@@ -1,5 +1,6 @@
 import { ApolloWrapper } from "../components/dataprovider/apollo-wrapper";
 import { PostHogProvider } from "../components/dataprovider/posthog-provider";
+import { SupabaseProvider } from "../components/hooks/supabase";
 import { GoogleAnalytics } from "../components/widgets/google-analytics";
 import "./globals.css";
 
@@ -14,9 +15,11 @@ export default function RootLayout({
         <link rel="icon" href="/img/oso-emblem-black.svg" />
       </head>
       <body>
-        <PostHogProvider>
-          <ApolloWrapper>{children}</ApolloWrapper>
-        </PostHogProvider>
+        <SupabaseProvider>
+          <PostHogProvider>
+            <ApolloWrapper>{children}</ApolloWrapper>
+          </PostHogProvider>
+        </SupabaseProvider>
       </body>
       <GoogleAnalytics />
     </html>

--- a/apps/frontend/components/dataprovider/apollo-wrapper.tsx
+++ b/apps/frontend/components/dataprovider/apollo-wrapper.tsx
@@ -1,62 +1,47 @@
 "use client";
 
-import { ApolloLink, HttpLink, useApolloClient } from "@apollo/client";
+import { ApolloLink, HttpLink } from "@apollo/client";
 import {
   ApolloNextAppProvider,
   InMemoryCache,
   ApolloClient,
   SSRMultipartLink,
 } from "@apollo/experimental-nextjs-app-support";
-import { userSession } from "../../lib/clients/supabase";
+import { useSupabaseState } from "../hooks/supabase";
 import { DB_GRAPHQL_URL } from "../../lib/config";
 
-/**
- * You must call this hook in any component that uses Apollo in code client-side
- * This will ensure that the Apollo client eventually gets the correct
- * Supabase credentials, which gets populated later on.
- * This is a workaround for the fact that the Apollo client is initialized
- * before the Supabase client is initialized.
- */
-let initialized = false;
-const useEnsureAuth = () => {
-  const client = useApolloClient();
-  if (!initialized && userSession?.access_token) {
-    client.setLink(makeLink());
-    initialized = true;
-  }
-};
-
-function makeLink() {
-  //console.log(userToken);
-  const httpLink = new HttpLink({
-    uri: DB_GRAPHQL_URL,
-    headers: userSession?.access_token
-      ? {
-          Authorization: `Bearer ${userSession.access_token}`,
-        }
-      : {},
-  });
-  return httpLink;
-}
-
-function makeClient() {
-  const httpLink = makeLink();
-  const client = new ApolloClient({
-    cache: new InMemoryCache(),
-    link:
-      typeof window === "undefined"
-        ? ApolloLink.from([
-            new SSRMultipartLink({
-              stripDefer: true,
-            }),
-            httpLink,
-          ])
-        : httpLink,
-  });
-  return client;
-}
-
 function ApolloWrapper({ children }: React.PropsWithChildren) {
+  const supabaseState = useSupabaseState();
+  const makeLink = () => {
+    //console.log(userToken);
+    const httpLink = new HttpLink({
+      uri: DB_GRAPHQL_URL,
+      headers: supabaseState?.session?.access_token
+        ? {
+            Authorization: `Bearer ${supabaseState.session.access_token}`,
+          }
+        : {},
+    });
+    return httpLink;
+  };
+
+  const makeClient = () => {
+    const httpLink = makeLink();
+    const client = new ApolloClient({
+      cache: new InMemoryCache(),
+      link:
+        typeof window === "undefined"
+          ? ApolloLink.from([
+              new SSRMultipartLink({
+                stripDefer: true,
+              }),
+              httpLink,
+            ])
+          : httpLink,
+    });
+    return client;
+  };
+
   return (
     <ApolloNextAppProvider makeClient={makeClient}>
       {children}
@@ -64,4 +49,4 @@ function ApolloWrapper({ children }: React.PropsWithChildren) {
   );
 }
 
-export { ApolloWrapper, useEnsureAuth };
+export { ApolloWrapper };

--- a/apps/frontend/components/dataprovider/auth-router.tsx
+++ b/apps/frontend/components/dataprovider/auth-router.tsx
@@ -1,5 +1,4 @@
 import { ReactNode } from "react";
-import { useAsync } from "react-use";
 import { usePostHog } from "posthog-js/react";
 import {
   CommonDataProviderProps,
@@ -7,8 +6,7 @@ import {
   DataProviderView,
 } from "./provider-view";
 import { RegistrationProps } from "../../lib/types/plasmic";
-import { logger } from "../../lib/logger";
-import { supabaseClient, userSession } from "../../lib/clients/supabase";
+import { useSupabaseState } from "../hooks/supabase";
 
 const DEFAULT_PLASMIC_VARIABLE = "auth";
 
@@ -51,49 +49,27 @@ function AuthRouter(props: AuthRouterProps) {
     testNoAuth,
   } = props;
   const key = variableName ?? DEFAULT_PLASMIC_VARIABLE;
+  const supabaseState = useSupabaseState();
   const posthog = usePostHog();
 
-  const {
-    value: data,
-    error,
-    loading,
-  } = useAsync(async () => {
-    if (useTestData) {
-      return testData;
-    }
-    /**
-    const {
-      data: { user },
-    } = await supabaseClient.auth.getUser();
-    const {
-      data: { session },
-    } = await supabaseClient.auth.getSession();
-    */
-    // Identify the user via PostHog
-    const user = userSession?.user;
-    if (user) {
-      posthog?.identify(user.id, {
-        name: user.user_metadata?.name,
-        email: user.email,
-      });
-    }
+  const data = useTestData
+    ? testData
+    : {
+        user: supabaseState?.session?.user,
+        session: supabaseState?.session,
+        supabase: supabaseState?.supabaseClient,
+      };
 
-    console.log("User: ", user);
-    console.log("Session: ", userSession);
-    return {
-      user,
-      session: userSession,
-      supabase: supabaseClient,
-    };
-  }, []);
-
-  // Error messages are currently silently logged
-  if (!loading && error) {
-    logger.error(error);
+  if (!useTestData && data.user) {
+    posthog?.identify(data.user.id, {
+      name: data.user.user_metadata?.name,
+      email: data.user.email,
+    });
   }
+  //console.log("AuthRouter: ", data);
 
   // Show unauthenticated view
-  if (testNoAuth || (!loading && !ignoreNoAuth && !data?.user)) {
+  if (testNoAuth || (!ignoreNoAuth && !data?.user)) {
     return <div className={className}>{noAuthChildren}</div>;
   }
 
@@ -102,8 +78,8 @@ function AuthRouter(props: AuthRouterProps) {
       {...props}
       variableName={key}
       formattedData={data}
-      loading={loading}
-      error={error}
+      loading={false}
+      error={null}
     />
   );
 }

--- a/apps/frontend/components/dataprovider/metrics-data-provider.tsx
+++ b/apps/frontend/components/dataprovider/metrics-data-provider.tsx
@@ -8,7 +8,6 @@ import {
   ensure,
   uncheckedCast,
 } from "@opensource-observer/utils";
-import { useEnsureAuth } from "./apollo-wrapper";
 import {
   GET_TIMESERIES_METRICS_BY_ARTIFACT,
   GET_TIMESERIES_METRICS_BY_PROJECT,
@@ -323,7 +322,6 @@ const formatData = (
  * @returns
  */
 function MetricsDataProvider(props: MetricsDataProviderProps) {
-  useEnsureAuth();
   return props.entityType === "artifact" ? (
     <ArtifactMetricsDataProvider {...props} />
   ) : props.entityType === "project" ? (

--- a/apps/frontend/components/dataprovider/oso-global-context.tsx
+++ b/apps/frontend/components/dataprovider/oso-global-context.tsx
@@ -4,7 +4,7 @@ import Snackbar from "@mui/material/Snackbar";
 import Alert from "@mui/material/Alert";
 import { ADT } from "ts-adt";
 import * as config from "../../lib/config";
-import { OsoAppClient } from "../../lib/clients/oso-app";
+import { useOsoAppClient } from "../hooks/oso-app";
 
 const PLASMIC_KEY = "globals";
 const PLASMIC_CONTEXT_NAME = "OsoGlobalContext";
@@ -51,12 +51,12 @@ const OsoGlobalContextPropsRegistration: any = {
 
 function OsoGlobalContext(props: OsoGlobalContextProps) {
   const { children, errorCodeMap } = props;
+  const { client } = useOsoAppClient();
   const [actionResult, setResult] = React.useState<any>(null);
   const [actionError, setError] = React.useState<any>(null);
   const [snackbarState, setSnackbarState] = React.useState<SnackbarState>({
     _type: "closed",
   });
-  const osoClient = new OsoAppClient();
   const data = {
     config,
     actionResult,
@@ -64,10 +64,12 @@ function OsoGlobalContext(props: OsoGlobalContextProps) {
   };
 
   const handleSuccess = (result: any) => {
+    console.log("Success: ", result);
     setResult(result);
     setSnackbarState({ _type: "success" });
   };
   const handleError = (error: any) => {
+    console.log("Error: ", error);
     setError(error);
     setSnackbarState({
       _type: "error",
@@ -86,38 +88,32 @@ function OsoGlobalContext(props: OsoGlobalContextProps) {
   const actions = React.useMemo(
     () => ({
       updateMyUserProfile: (args: any) =>
-        osoClient
+        client!
           .updateMyUserProfile(args)
           .then(handleSuccess)
           .catch(handleError),
       createApiKey: (args: any) =>
-        osoClient.createApiKey(args).then(handleSuccess).catch(handleError),
+        client!.createApiKey(args).then(handleSuccess).catch(handleError),
       deleteApiKey: (args: any) =>
-        osoClient.deleteApiKey(args).then(handleSuccess).catch(handleError),
+        client!.deleteApiKey(args).then(handleSuccess).catch(handleError),
       createOrganization: (args: any) =>
-        osoClient
-          .createOrganization(args)
-          .then(handleSuccess)
-          .catch(handleError),
+        client!.createOrganization(args).then(handleSuccess).catch(handleError),
       addUserToOrganizationByEmail: (args: any) =>
-        osoClient
+        client!
           .addUserToOrganizationByEmail(args)
           .then(handleSuccess)
           .catch(handleError),
       changeUserRole: (args: any) =>
-        osoClient.changeUserRole(args).then(handleSuccess).catch(handleError),
+        client!.changeUserRole(args).then(handleSuccess).catch(handleError),
       removeUserFromOrganization: (args: any) =>
-        osoClient
+        client!
           .removeUserFromOrganization(args)
           .then(handleSuccess)
           .catch(handleError),
       deleteOrganization: (args: any) =>
-        osoClient
-          .deleteOrganization(args)
-          .then(handleSuccess)
-          .catch(handleError),
+        client!.deleteOrganization(args).then(handleSuccess).catch(handleError),
     }),
-    [osoClient],
+    [client],
   );
 
   return (

--- a/apps/frontend/components/dataprovider/supabase-query.tsx
+++ b/apps/frontend/components/dataprovider/supabase-query.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 import useSWR from "swr";
+import { SupabaseClient } from "@supabase/supabase-js";
 import { SupabaseQueryArgs, supabaseQuery } from "../../lib/clients/supabase";
+import { useSupabaseState } from "../hooks/supabase";
 import { RegistrationProps } from "../../lib/types/plasmic";
 import {
   CommonDataProviderProps,
@@ -71,13 +73,20 @@ function SupabaseQuery(props: SupabaseQueryProps) {
   // These props are set in the Plasmic Studio
   const { variableName, tableName, useTestData, testData } = props;
   const key = variableName ?? genKey(props);
+  const supabaseState = useSupabaseState();
   const { data, error, isLoading } = useSWR(key, async () => {
     if (useTestData) {
       return testData;
     } else if (!tableName) {
       return;
+    } else if (!supabaseState) {
+      return console.warn("Supabase not initialized yet");
     }
-    return await supabaseQuery({ ...props, tableName });
+    const supabaseClient = supabaseState.supabaseClient;
+    return await supabaseQuery(supabaseClient as SupabaseClient<any>, {
+      ...props,
+      tableName,
+    });
   });
 
   // Error messages are currently rendered in the component

--- a/apps/frontend/components/hooks/oso-app.ts
+++ b/apps/frontend/components/hooks/oso-app.ts
@@ -1,0 +1,15 @@
+"use client";
+
+import { useSupabaseState } from "./supabase";
+import { OsoAppClient } from "../../lib/clients/oso-app";
+
+function useOsoAppClient() {
+  const supabaseState = useSupabaseState();
+  return {
+    client: supabaseState?.supabaseClient
+      ? new OsoAppClient(supabaseState.supabaseClient)
+      : null,
+  };
+}
+
+export { useOsoAppClient };

--- a/apps/frontend/components/hooks/supabase.tsx
+++ b/apps/frontend/components/hooks/supabase.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { createContext, useContext, useState, useEffect } from "react";
+import { createNormalSupabaseClient } from "../../lib/clients/supabase";
+import { Session, SupabaseClient } from "@supabase/supabase-js";
+import { Database } from "../../lib/types/supabase";
+import { spawn } from "@opensource-observer/utils";
+
+type SupabaseState = {
+  supabaseClient?: SupabaseClient<Database> | null;
+  session?: Session | null;
+  revalidate: () => Promise<void>;
+  //isLoading?: boolean;
+  //error?: Error;
+} | null;
+
+const SupabaseContext = createContext<SupabaseState>(null);
+function useSupabaseState() {
+  return useContext<SupabaseState>(SupabaseContext);
+}
+
+function useSupabaseClient() {
+  const supabaseClient = createNormalSupabaseClient();
+  return {
+    supabaseClient,
+  };
+}
+
+function SupabaseProvider({ children }: { children: React.ReactNode }) {
+  const [state, setState] = useState<SupabaseState | null>(null);
+  const revalidate = async () => {
+    const supabaseClient = createNormalSupabaseClient();
+    const { data, error } = await supabaseClient.auth.getSession();
+    if (error) {
+      console.warn("Failed to get Supabase session, ", error);
+    }
+    setState({
+      supabaseClient: supabaseClient,
+      session: data.session,
+      revalidate,
+    });
+  };
+  useEffect(() => {
+    spawn(revalidate());
+  }, []);
+
+  return (
+    <SupabaseContext.Provider value={state}>
+      {children}
+    </SupabaseContext.Provider>
+  );
+}
+
+export {
+  useSupabaseClient,
+  SupabaseContext,
+  useSupabaseState,
+  SupabaseProvider,
+};

--- a/apps/frontend/components/widgets/apollo-sandbox.tsx
+++ b/apps/frontend/components/widgets/apollo-sandbox.tsx
@@ -1,8 +1,7 @@
 "use client";
 
 import { ApolloSandbox } from "@apollo/sandbox/react";
-import { useAsync } from "react-use";
-import { supabaseClient } from "../../lib/clients/supabase";
+import { useSupabaseState } from "../hooks/supabase";
 import { DOMAIN } from "../../lib/config";
 
 const API_PROTOCOL = "https://";
@@ -15,16 +14,9 @@ type EmbeddedSandboxProps = {
 };
 
 function EmbeddedSandbox(props: EmbeddedSandboxProps) {
-  const { value: data } = useAsync(async () => {
-    const {
-      data: { session },
-    } = await supabaseClient.auth.getSession();
-    return {
-      session,
-    };
-  }, []);
-  //console.log(data);
-  const token = data?.session?.access_token;
+  const supabaseState = useSupabaseState();
+  const token = supabaseState?.session?.access_token;
+  //console.log(session);
   //console.log("headers", headers);
 
   return (

--- a/apps/frontend/components/widgets/auth-form.tsx
+++ b/apps/frontend/components/widgets/auth-form.tsx
@@ -1,7 +1,8 @@
 "use client";
 import { Auth } from "@supabase/auth-ui-react";
 import { ThemeSupa } from "@supabase/auth-ui-shared";
-import { supabaseClient } from "../../lib/clients/supabase";
+import { SupabaseClient } from "@supabase/supabase-js";
+import { useSupabaseState } from "../hooks/supabase";
 
 const REDIRECT_URL = "http://localhost:3000/";
 
@@ -11,11 +12,16 @@ type AuthFormProps = {
 
 export function AuthForm(props: AuthFormProps) {
   const { className } = props;
+  const supabaseState = useSupabaseState();
+
+  if (!supabaseState) {
+    return <>Supabase not initialized yet</>;
+  }
 
   return (
     <div className={className}>
       <Auth
-        supabaseClient={supabaseClient}
+        supabaseClient={supabaseState?.supabaseClient as SupabaseClient<any>}
         appearance={{ theme: ThemeSupa }}
         providers={["google"]}
         queryParams={{

--- a/apps/frontend/components/widgets/oso-chat.tsx
+++ b/apps/frontend/components/widgets/oso-chat.tsx
@@ -2,7 +2,7 @@
 
 import { useChat } from "@ai-sdk/react";
 import { ReactElement, useEffect, useRef, useState } from "react";
-import { userSession } from "../../lib/clients/supabase";
+import { useSupabaseState } from "../hooks/supabase";
 import ReactMarkdown from "react-markdown";
 
 const CHAT_PATH = "/api/v1/chat";
@@ -14,6 +14,8 @@ interface OSOChatProps {
 
 export function OSOChat(props: OSOChatProps) {
   const { className, children } = props;
+  const supabaseState = useSupabaseState();
+  const session = supabaseState?.session;
   const {
     messages,
     input,
@@ -23,9 +25,9 @@ export function OSOChat(props: OSOChatProps) {
     setMessages,
   } = useChat({
     api: CHAT_PATH,
-    headers: userSession
+    headers: session
       ? {
-          Authorization: `Bearer ${userSession.access_token}`,
+          Authorization: `Bearer ${session.access_token}`,
         }
       : undefined,
   });

--- a/apps/frontend/components/widgets/supabase-write.tsx
+++ b/apps/frontend/components/widgets/supabase-write.tsx
@@ -7,7 +7,7 @@ import { HttpError, assertNever, spawn } from "@opensource-observer/utils";
 import { usePostHog } from "posthog-js/react";
 import { EVENTS } from "../../lib/types/posthog";
 import { RegistrationProps } from "../../lib/types/plasmic";
-import { supabaseClient } from "../../lib/clients/supabase";
+import { useSupabaseState } from "../hooks/supabase";
 
 type SnackbarState = ADT<{
   closed: Record<string, unknown>;
@@ -84,6 +84,7 @@ function SupabaseWrite(props: SupabaseWriteProps) {
     errorCodeMap,
   } = props;
   const posthog = usePostHog();
+  const supabaseState = useSupabaseState();
   const router = useRouter();
   const [snackbarState, setSnackbarState] = React.useState<SnackbarState>({
     _type: "closed",
@@ -99,7 +100,9 @@ function SupabaseWrite(props: SupabaseWriteProps) {
     setSnackbarState({ _type: "closed" });
   };
   const clickHandler = async () => {
-    if (!actionType) {
+    if (!supabaseState?.supabaseClient) {
+      return console.warn("SupabaseWrite: Supabase client not initialized yet");
+    } else if (!actionType) {
       return console.warn("SupabaseWrite: Select an actionType first");
     } else if (!tableName) {
       return console.warn("SupabaseWrite: Enter a tableName first");
@@ -110,6 +113,7 @@ function SupabaseWrite(props: SupabaseWriteProps) {
         "SupabaseWrite: This actionType requires valid filters",
       );
     }
+    const supabaseClient = supabaseState.supabaseClient;
 
     let query =
       actionType === "insert"

--- a/apps/frontend/lib/clients/oso-app.ts
+++ b/apps/frontend/lib/clients/oso-app.ts
@@ -1,9 +1,8 @@
 import _ from "lodash";
 import { SupabaseClient } from "@supabase/supabase-js";
-import { supabaseClient as defaultClient } from "./supabase";
+import { ensure } from "@opensource-observer/utils";
 import { Database, Tables } from "../types/supabase";
 import { MissingDataError, AuthError } from "../types/errors";
-import { ensure } from "@opensource-observer/utils";
 
 /**
  * OsoAppClient is the client library for the OSO app.
@@ -20,8 +19,8 @@ class OsoAppClient {
    * Otherwise default to the one stored as a global
    * @param inboundClient
    */
-  constructor(inboundClient?: SupabaseClient<Database>) {
-    this.supabaseClient = inboundClient || defaultClient;
+  constructor(inboundClient: SupabaseClient<Database>) {
+    this.supabaseClient = inboundClient;
   }
 
   /**
@@ -43,6 +42,7 @@ class OsoAppClient {
    * @returns
    */
   async getMyUserProfile() {
+    console.log("getMyUserProfile");
     const user = await this.getUser();
     const { data, error } = await this.supabaseClient
       .from("user_profiles")
@@ -68,6 +68,7 @@ class OsoAppClient {
       profile: Partial<Tables<"user_profiles">>;
     }>,
   ) {
+    console.log("updateMyUserProfile: ", args);
     const profile = ensure(args.profile, "Missing profile argument");
     const user = await this.getUser();
     const { error } = await this.supabaseClient
@@ -90,6 +91,7 @@ class OsoAppClient {
       apiKey: string;
     }>,
   ) {
+    console.log("createApiKey: ", args.name);
     const name = ensure(args.name, "Missing name argument");
     const apiKey = ensure(args.apiKey, "Missing apiKey argument");
     const user = await this.getUser();
@@ -108,6 +110,7 @@ class OsoAppClient {
    * @returns
    */
   async getMyApiKeys() {
+    console.log("getMyApiKeys");
     const user = await this.getUser();
     const { data, error } = await this.supabaseClient
       .from("api_keys")
@@ -132,6 +135,7 @@ class OsoAppClient {
       keyId: string;
     }>,
   ) {
+    console.log("deleteApiKey: ", args);
     const keyId = ensure(args.keyId, "Missing keyId argument");
     const { error } = await this.supabaseClient
       .from("api_keys")
@@ -151,6 +155,7 @@ class OsoAppClient {
       orgName: string;
     }>,
   ) {
+    console.log("createOrganization: ", args);
     const orgName = ensure(args.orgName, "Missing orgName argument");
     const user = await this.getUser();
     const { error } = await this.supabaseClient.from("organizations").insert({
@@ -167,6 +172,7 @@ class OsoAppClient {
    * @returns
    */
   async getMyOrganizations() {
+    console.log("getMyOrganizations");
     const user = await this.getUser();
     // Get the organizations that the user has created
     const { data: createdOrgs, error: createdError } = await this.supabaseClient
@@ -211,6 +217,7 @@ class OsoAppClient {
       orgId: string;
     }>,
   ) {
+    console.log("getOrganizationById: ", args);
     const orgId = ensure(args.orgId, "Missing orgId argument");
     const { data, error } = await this.supabaseClient
       .from("organizations")
@@ -237,6 +244,7 @@ class OsoAppClient {
       orgId: string;
     }>,
   ) {
+    console.log("getOrganizationMembers: ", args);
     const orgId = ensure(args.orgId, "Missing orgId argument");
     // Get the owner/creator of the organization
     const { data: creatorData, error: creatorError } = await this.supabaseClient
@@ -284,6 +292,7 @@ class OsoAppClient {
       role: string;
     }>,
   ) {
+    console.log("addUserToOrganizationByEmail: ", args);
     const orgId = ensure(args.orgId, "Missing orgId argument");
     const email = ensure(args.email, "Missing email argument");
     const role = ensure(args.role, "Missing role argument");
@@ -321,6 +330,7 @@ class OsoAppClient {
       role: string;
     }>,
   ) {
+    console.log("changeUserRole: ", args);
     const orgId = ensure(args.orgId, "Missing orgId argument");
     const userId = ensure(args.userId, "Missing userId argument");
     const role = ensure(args.role, "Missing role argument");
@@ -347,6 +357,7 @@ class OsoAppClient {
       userId: string;
     }>,
   ) {
+    console.log("removeUserFromOrganization: ", args);
     const orgId = ensure(args.orgId, "Missing orgId argument");
     const userId = ensure(args.userId, "Missing userId argument");
     const { error } = await this.supabaseClient
@@ -369,6 +380,7 @@ class OsoAppClient {
       orgId: string;
     }>,
   ) {
+    console.log("deleteOrganization: ", args);
     const orgId = ensure(args.orgId, "Missing orgId argument");
     const { error } = await this.supabaseClient
       .from("organizations")

--- a/apps/frontend/lib/clients/supabase.ts
+++ b/apps/frontend/lib/clients/supabase.ts
@@ -1,4 +1,4 @@
-import { createClient, Session } from "@supabase/supabase-js";
+import { createClient, SupabaseClient } from "@supabase/supabase-js";
 import { HttpError } from "@opensource-observer/utils";
 import {
   SUPABASE_URL,
@@ -14,9 +14,8 @@ function createNormalSupabaseClient() {
 function createPrivilegedSupabaseClient() {
   return createClient<Database>(SUPABASE_URL, SUPABASE_SERVICE_KEY);
 }
-// Supabase client for use in the browser
-const supabaseClient = createNormalSupabaseClient();
 
+/**
 // Get the user session
 let userSession: Session | null | undefined;
 supabaseClient.auth
@@ -27,6 +26,7 @@ supabaseClient.auth
   .catch((e) => {
     console.warn("Failed to get Supabase session, ", e);
   });
+*/
 
 type SupabaseQueryArgs = {
   tableName: string; // table to query
@@ -39,7 +39,10 @@ type SupabaseQueryArgs = {
   orderAscending?: boolean; // True if ascending, false if descending
 };
 
-async function supabaseQuery(args: SupabaseQueryArgs): Promise<any[]> {
+async function supabaseQuery(
+  supabaseClient: SupabaseClient,
+  args: SupabaseQueryArgs,
+): Promise<any[]> {
   const { tableName, columns, filters, limit, orderBy, orderAscending } = args;
   let query = supabaseClient.from(tableName as any).select(columns);
   // Iterate over the filters
@@ -75,8 +78,6 @@ async function supabaseQuery(args: SupabaseQueryArgs): Promise<any[]> {
 export {
   createNormalSupabaseClient,
   createPrivilegedSupabaseClient,
-  supabaseClient,
   supabaseQuery,
-  userSession,
 };
 export type { SupabaseQueryArgs };


### PR DESCRIPTION
* Previously, we had really hacky ways to store the Supabase client in global variables
* This properly fixes this up to store the client and session data in a Context Provider
* Also supports manually revalidating the Supabase session on log in/out
* Update all components to just read session/user data from the context, rather than spamming Supabase