### PR TITLE
fix(sqlmesh): change github history model type to full

### DIFF
--- a/warehouse/oso_sqlmesh/models/intermediate/entities/artifacts/github/int_github_repositories.sql
+++ b/warehouse/oso_sqlmesh/models/intermediate/entities/artifacts/github/int_github_repositories.sql
@@ -12,8 +12,9 @@ SELECT
   artifact_id,
   artifact_namespace,
   artifact_name,
-  MIN(first_commit_time) AS first_commit_time,
-  MAX(last_commit_time) AS last_commit_time
+  'REPOSITORY' AS artifact_type,
+  'https://github.com/' || artifact_namespace || '/' || artifact_name
+    AS artifact_url
 FROM oso.int_first_last_commit_to_github_repository
 GROUP BY
   artifact_source_id,

--- a/warehouse/oso_sqlmesh/models/intermediate/entities/users/github/int_github_users.sql
+++ b/warehouse/oso_sqlmesh/models/intermediate/entities/users/github/int_github_users.sql
@@ -11,11 +11,8 @@ MODEL (
 SELECT
   artifact_source_id,
   artifact_id,
+  artifact_namespace,
   artifact_name,
-  MIN(first_commit_time) AS first_commit_time,
-  MAX(last_commit_time) AS last_commit_time
+  'GIT_USER' AS artifact_type,
+  'https://github.com/' || artifact_name AS artifact_url
 FROM oso.int_first_last_commit_from_github_user
-GROUP BY
-  artifact_source_id,
-  artifact_id,
-  artifact_name

--- a/warehouse/oso_sqlmesh/models/intermediate/events/github/first-last/int_first_last_commit_from_github_user.sql
+++ b/warehouse/oso_sqlmesh/models/intermediate/events/github/first-last/int_first_last_commit_from_github_user.sql
@@ -1,70 +1,47 @@
 MODEL (
   name oso.int_first_last_commit_from_github_user,
   description 'First and last commit from a GitHub user',
-  kind SCD_TYPE_2_BY_TIME (
-    unique_key artifact_source_id,
-    updated_at_name last_commit_time
-  ),
-  start @github_incremental_start,
-  cron '@daily',
+  kind FULL,
   dialect trino,
   partitioned_by DAY("first_commit_time"),
   grain (
     artifact_id,
-    artifact_source_id,
-    artifact_name,
-    first_commit_time
+    artifact_source_id
   ),
   columns (
     artifact_id TEXT,
     artifact_source_id TEXT,
+    artifact_namespace TEXT,
     artifact_name TEXT,
     first_commit_time TIMESTAMP,
     last_commit_time TIMESTAMP
   ),
   audits (
     has_at_least_n_rows(threshold := 0),
-    no_gaps(
-      time_column := first_commit_time,
-      no_gap_date_part := 'day'
-    )
   )
 );
 
-WITH new_events AS (
+WITH aggregated AS (
   SELECT
     from_artifact_id AS artifact_id,
     from_artifact_source_id AS artifact_source_id,
+    from_artifact_namespace AS artifact_namespace,
     from_artifact_name AS artifact_name,
-    time AS commit_time
-  FROM  oso.int_events__github
+    MIN(time) AS first_commit_time,
+    MAX(time) AS last_commit_time,
+  FROM oso.int_events__github
   WHERE event_type = 'COMMIT_CODE'
-    AND time BETWEEN @start_dt AND @end_dt
-),
-
-aggregated AS (
-  SELECT
-    ne.artifact_id,
-    ne.artifact_source_id,
-    ne.artifact_name,
-    LEAST(
-      MIN(ne.commit_time),
-      COALESCE(MIN(hist.first_commit_time), MIN(ne.commit_time))
-    ) AS first_commit_time,
-    MAX(ne.commit_time) AS last_commit_time
-  FROM new_events AS ne
-  LEFT JOIN @this_model AS hist
-    ON hist.artifact_source_id = ne.artifact_source_id
-    AND hist.artifact_id = ne.artifact_id
   GROUP BY
-    ne.artifact_id,
-    ne.artifact_source_id,
-    ne.artifact_name
+    from_artifact_id,
+    from_artifact_source_id,
+    from_artifact_namespace,
+    from_artifact_name
 )
 
 SELECT
-  artifact_id::TEXT,
   artifact_source_id::TEXT,
+  artifact_id::TEXT,  
+  artifact_namespace::TEXT,
   artifact_name::TEXT,
   first_commit_time::TIMESTAMP,
   last_commit_time::TIMESTAMP

--- a/warehouse/oso_sqlmesh/models/intermediate/events/github/int_events_weekly__github.sql
+++ b/warehouse/oso_sqlmesh/models/intermediate/events/github/int_events_weekly__github.sql
@@ -6,7 +6,6 @@ MODEL (
     batch_concurrency 2,
     lookback 31,
     forward_only true,
-    on_destructive_change 'allow',
   ),
   start @github_incremental_start,
   cron '@daily',


### PR DESCRIPTION
The Type 2 models continue to create issues; at this point probably easiest just to do standard full materializations and we can optimize at some point in the future.