### PR TITLE
feat: start wiring the semantic agent

### DIFF
--- a/ops/k8s-apps/base/agent/agent.yaml
+++ b/ops/k8s-apps/base/agent/agent.yaml
@@ -40,3 +40,5 @@ spec:
         - "8000"
       hostEnvVar: "AGENT_HOST"
       portEnvVar: "AGENT_PORT"
+      envVars:
+        AGENT_EAGERLY_LOAD_ALL_AGENTS: "1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,7 @@ dependencies = [
     "pyarrow-stubs<18.0,>=17.16",
     "gcloud-aio-storage<10.0.0,>=9.3.0",
     "kr8s==0.20.7",
+    "arize-phoenix[evals]==10.0.4",
 ]
 name = "oso"
 version = "1.0.0"

--- a/uv.lock
+++ b/uv.lock
@@ -265,7 +265,7 @@ wheels = [
 
 [[package]]
 name = "arize-phoenix"
-version = "9.6.1"
+version = "10.0.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aioitertools" },
@@ -306,9 +306,9 @@ dependencies = [
     { name = "uvicorn" },
     { name = "wrapt" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ee/22/854333ac2d44371161aff40b253acad153c6b2940b426767925128694193/arize_phoenix-9.6.1.tar.gz", hash = "sha256:0e003ea0ac940a1207cdc9eae7d3205a8e6017094f2659e318d2fa611ab0d610", size = 3811208 }
+sdist = { url = "https://files.pythonhosted.org/packages/9d/2e/dc49124a6a8a708f85bcab4f43393f919573834706b2ea34e3e6457530db/arize_phoenix-10.0.4.tar.gz", hash = "sha256:852a2d0188f3b19741097cf1d79f3c37849bc7d7e886d7f998c5112e5c6d63e5", size = 3816298 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2b/6b/65c767b024a522da9c00973c47fb5f642e58b010e327199383fd1cb6b3fa/arize_phoenix-9.6.1-py3-none-any.whl", hash = "sha256:4aa0580e041c0546362bff7ab690ae2965f18669cf0e2cf8e0af0da913ab0aef", size = 3995641 },
+    { url = "https://files.pythonhosted.org/packages/a7/73/4492ab303f236a54668a64950a0b9539f87e335bc4af8c4ade10fddd37a0/arize_phoenix-10.0.4-py3-none-any.whl", hash = "sha256:6443ec7b60eb4cc4721204546745b10da4d5dab50a9f83c0cc81cbbf525e1c19", size = 4003370 },
 ]
 
 [[package]]
@@ -3884,6 +3884,7 @@ version = "1.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiotrino" },
+    { name = "arize-phoenix" },
     { name = "arrow" },
     { name = "bokeh" },
     { name = "boltons" },
@@ -3969,6 +3970,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "aiotrino", specifier = ">=0.2.3,<1.0.0" },
+    { name = "arize-phoenix", extras = ["evals"], specifier = "==10.0.4" },
     { name = "arrow", specifier = ">=1.3.0,<2.0.0" },
     { name = "bokeh", specifier = ">=3.6.1,<4.0.0" },
     { name = "boltons", specifier = ">=24.0.0,<25.0.0" },
@@ -4074,7 +4076,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "arize-phoenix", extras = ["evals"], specifier = "==9.6.1" },
+    { name = "arize-phoenix", extras = ["evals"], specifier = "==10.0.4" },
     { name = "arize-phoenix-otel", specifier = "==0.9.2" },
     { name = "discord-py", specifier = ">=2.5.2" },
     { name = "dotenv", specifier = ">=0.9.9" },
@@ -5872,7 +5874,7 @@ wheels = [
 
 [[package]]
 name = "strawberry-graphql"
-version = "0.269.0"
+version = "0.270.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "graphql-core" },
@@ -5880,9 +5882,9 @@ dependencies = [
     { name = "python-dateutil" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e0/2e/77446a370f3cd8f30f2baeeb4f64464c0fb0285aa94a8773ccf398c8b7c6/strawberry_graphql-0.269.0.tar.gz", hash = "sha256:67d5dd832a056e755fccb3a0d8476a710c9552d6199505d41d5357580bcde2ea", size = 205214 }
+sdist = { url = "https://files.pythonhosted.org/packages/67/aa/9d8a53fbf0271e7a5c5155b76d256caf4b94f422676226253648871cc7c1/strawberry_graphql-0.270.1.tar.gz", hash = "sha256:d64524a943851d83252e39b82ef768ee494259edecf9510b37bad9a46b745db8", size = 207190 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fd/ec/dea16b8bae63faad7a868701959b6be8b2ddc43149f3193ca2eaa01984c6/strawberry_graphql-0.269.0-py3-none-any.whl", hash = "sha256:e3322da5f6d2d57c7099a120d6002cccd7749ea7737f6bbc245a08a46781e957", size = 299187 },
+    { url = "https://files.pythonhosted.org/packages/99/e0/c45d74578e7b8cb7e082697d998cebd8ef97afa3d7aedc22e4acd8ae7163/strawberry_graphql-0.270.1-py3-none-any.whl", hash = "sha256:3593086dc08614ae241cb88f7691e90f90b01cab6ee6351cb3838fc5ba8bfab0", size = 301232 },
 ]
 
 [[package]]

--- a/warehouse/metrics_tools/semantic/testing.py
+++ b/warehouse/metrics_tools/semantic/testing.py
@@ -1,4 +1,6 @@
 # An example semantic model for testing
+import textwrap
+
 from .definition import (
     Dimension,
     Metric,
@@ -16,10 +18,23 @@ def setup_registry():
         Model(
             name="collection",
             table="oso.collections_v1",
-            description="A collection of projects",
+            description=textwrap.dedent("""
+                A collection is a group of related projects. A collection is an
+                arbitrary grouping of projects. Sometimes these groupings are
+                used to group things together by some common dependency tree or
+                some specific community known to OSO.
+            """),
             dimensions=[
-                Dimension(name="id", column_name="collection_id"),
-                Dimension(name="name", column_name="collection_name"),
+                Dimension(
+                    name="id",
+                    description="The unique identifier of the collection",
+                    column_name="collection_id",
+                ),
+                Dimension(
+                    name="name",
+                    description="The name of the collection",
+                    column_name="collection_name",
+                ),
             ],
             primary_key="collection_id",
             metrics=[
@@ -33,7 +48,7 @@ def setup_registry():
                 #     description="The number of related projects in the collection",
                 #     query="COUNT(project.id)",
                 # )
-            ]
+            ],
         )
     )
 
@@ -41,17 +56,21 @@ def setup_registry():
         Model(
             name="project",
             table="oso.projects_v1",
-            description="A project",
+            description=textwrap.dedent("""
+                A project is a collection of related artifacts. A project is
+                usually, but not limited to, some kind of organization, company,
+                or group that controls a set of artifacts.
+            """),
             dimensions=[
                 Dimension(
-                    name="id", 
+                    name="id",
                     description="The unique identifier of the project",
-                    column_name="project_id"
+                    column_name="project_id",
                 ),
                 Dimension(
                     name="name",
                     description="The name of the project",
-                    column_name="project_name"
+                    column_name="project_name",
                 ),
             ],
             primary_key="project_id",
@@ -75,7 +94,7 @@ def setup_registry():
                 #     description="The number of related artifacts in the project",
                 #     query="COUNT(artifact.id)",
                 # )
-            ]
+            ],
         )
     )
 
@@ -83,22 +102,27 @@ def setup_registry():
         Model(
             name="artifact",
             table="oso.artifacts_v1",
-            description="An artifact",
+            description=textwrap.dedent("""
+                An artifact. This is the smallest atom of an acting entity in
+                OSO. Artifacts are usually repositories, blockchain addresses,
+                or some representation of a user. Artifacts do not generally
+                represent a group of any kind, but rather a single entity.
+            """),
             dimensions=[
                 Dimension(
-                    name="id", 
+                    name="id",
                     description="The unique identifier of the artifact",
                     column_name="artifact_id",
                 ),
                 Dimension(
                     name="name",
                     description="The name of the artifact",
-                    column_name="artifact_name"
+                    column_name="artifact_name",
                 ),
                 Dimension(
                     name="url",
                     description="The URL of the artifact",
-                    column_name="artifact_url"
+                    column_name="artifact_url",
                 ),
             ],
             primary_key="artifact_id",
@@ -117,7 +141,7 @@ def setup_registry():
                     description="The number of artifacts",
                     query="COUNT(self.id)",
                 ),
-            ]
+            ],
         )
     )
 
@@ -125,7 +149,9 @@ def setup_registry():
         Model(
             name="github_event",
             table="oso.int_events__github",
-            description="An event",
+            description=textwrap.dedent("""
+                A github event. This could be any event that occurs on github.
+            """),
             dimensions=[
                 Dimension(
                     name="time",
@@ -166,7 +192,7 @@ def setup_registry():
                     name="event_type_classification",
                     description="The classification of the event type",
                     query="CASE WHEN self.event_type = 'COMMIT' THEN 'COMMIT' ELSE 'OTHER' END",
-                )
+                ),
             ],
             metrics=[
                 Metric(
@@ -185,12 +211,14 @@ def setup_registry():
             references=[
                 Relationship(
                     name="to",
+                    description="The artifact to which the event occurred",
                     model_ref="artifact",
                     type=RelationshipType.MANY_TO_ONE,
                     foreign_key_column="to_artifact_id",
                 ),
                 Relationship(
                     name="from",
+                    description="The artifact from which the event occurred",
                     model_ref="artifact",
                     type=RelationshipType.MANY_TO_ONE,
                     foreign_key_column="from_artifact_id",
@@ -198,5 +226,32 @@ def setup_registry():
             ],
         )
     )
+
+    # registry.register(
+    #     Model(
+    #         name="timeseries_metrics_by_artifact",
+    #         table="oso.timeseries_metrics_by_artifact_v0",
+    #         description="Time series metrics by artifact",
+    #         dimensions=[
+    #             Dimension(name="metric_id", column_name="metric_id"),
+    #             Dimension(name="artifact_id", column_name="artifact_id"),
+    #             Dimension(name="month", column_name="month"),
+    #             Dimension(name="year", column_name="year"),
+    #         ],
+    #         primary_key="collection_id",
+    #         metrics=[
+    #             Metric(
+    #                 name="count",
+    #                 description="The number of collections",
+    #                 query="COUNT(self.id)",
+    #             ),
+    #             # Metric(
+    #             #     name="number_of_projects",
+    #             #     description="The number of related projects in the collection",
+    #             #     query="COUNT(project.id)",
+    #             # )
+    #         ]
+    #     )
+    # )
     registry.complete()
     return registry

--- a/warehouse/oso_agent/oso_agent/agent/__init__.py
+++ b/warehouse/oso_agent/oso_agent/agent/__init__.py
@@ -1,4 +1,5 @@
 from .agent_registry import AgentRegistry
+from .default import setup_default_agent_registry
 from .react_agent import create_react_agent
 from .sql_agent import create_sql_agent
 
@@ -6,4 +7,5 @@ __all__ = [
     "AgentRegistry",
     "create_react_agent",
     "create_sql_agent",
+    "setup_default_agent_registry",
 ]

--- a/warehouse/oso_agent/oso_agent/agent/agent_registry.py
+++ b/warehouse/oso_agent/oso_agent/agent/agent_registry.py
@@ -2,6 +2,7 @@ import logging
 import typing as t
 
 from llama_index.core.agent.workflow.base_agent import BaseWorkflowAgent
+from oso_agent.agent.semantic_agent import create_semantic_agent
 
 from ..util.config import AgentConfig
 from ..util.errors import AgentConfigError, AgentMissingError
@@ -22,6 +23,7 @@ async def _create_agents(config: AgentConfig) -> AgentDict:
         logger.info("Creating all agents...")
         registry["react"] = await create_react_agent(config)
         registry["sql"] = await create_sql_agent(config)
+        registry["semantic"] = await create_semantic_agent(config)
         return registry
     except Exception as e:
         logger.error(f"Failed to create agent: {e}")

--- a/warehouse/oso_agent/oso_agent/agent/agent_registry.py
+++ b/warehouse/oso_agent/oso_agent/agent/agent_registry.py
@@ -44,3 +44,10 @@ class AgentRegistry:
             self.agents[name] = agent
             logger.info(f"Agent '{name}' lazily created and added to the registry.")
         return self.agents[name]
+    
+    async def eager_load_all_agents(self):
+        """Eagerly load all agents in the registry."""
+        logger.info("Eagerly loading all agents in the registry...")
+        for name in self.agent_factories.keys():
+            await self.get_agent(name)
+        logger.info("All agents have been eagerly loaded.")

--- a/warehouse/oso_agent/oso_agent/agent/agent_registry.py
+++ b/warehouse/oso_agent/oso_agent/agent/agent_registry.py
@@ -1,55 +1,46 @@
 import logging
 import typing as t
 
-from llama_index.core.agent.workflow.base_agent import BaseWorkflowAgent
-from oso_agent.agent.semantic_agent import create_semantic_agent
+from oso_agent.types.response import WrappedResponse
 
+from ..types import WrappedResponseAgent
 from ..util.config import AgentConfig
 from ..util.errors import AgentConfigError, AgentMissingError
-from .react_agent import create_react_agent
-from .sql_agent import create_sql_agent
 
 # Setup logging
 logger = logging.getLogger(__name__)
 
 # Type alias for a dictionary of agents
-AgentDict = t.Dict[str, BaseWorkflowAgent]
+AgentDict = t.Dict[str, WrappedResponseAgent]
 
-async def _create_agents(config: AgentConfig) -> AgentDict:
-    """Create and configure the ReAct agent."""
-    registry: AgentDict = {}
-
-    try:
-        logger.info("Creating all agents...")
-        registry["react"] = await create_react_agent(config)
-        registry["sql"] = await create_sql_agent(config)
-        registry["semantic"] = await create_semantic_agent(config)
-        return registry
-    except Exception as e:
-        logger.error(f"Failed to create agent: {e}")
-        raise AgentConfigError(f"Failed to create agent: {e}") from e
+AgentFactory = t.Callable[[AgentConfig], t.Awaitable[WrappedResponseAgent]]
+ResponseWrapper = t.Callable[[t.Any], WrappedResponse]
 
 class AgentRegistry:
     """Registry of all agents."""
     def __init__(
         self,
         config: AgentConfig,
-        agents: AgentDict = {},
     ):
         """Initialize registry."""
         self.config = config
-        self.agents  = agents
+        self.agent_factories: dict[str, AgentFactory] = {}
+        self.agents: AgentDict = {}
 
-    @classmethod
-    async def create(cls, config: AgentConfig):
-        logger.info("Initializing the OSO agent registry...")
-        agents = await _create_agents(config)
-        registry = cls(config, agents)
-        logger.info("... agent registry ready")
-        return registry
+    def add_agent(self, name: str, factory: AgentFactory):
+        """Add an agent to the registry."""
+        if name in self.agent_factories:
+            raise AgentConfigError(f"Agent '{name}' already exists in the registry.")
+        self.agent_factories[name] = factory
+        logger.info(f"Agent factory '{name}' added to the registry.")
 
-    def get_agent(self, name: str) -> BaseWorkflowAgent:
+    async def get_agent(self, name: str) -> WrappedResponseAgent:
         agent = self.agents.get(name)
-        if agent is None:
+        if agent is None and name not in self.agent_factories:
             raise AgentMissingError(f"Agent '{name}' not found in the registry.")
+        if agent is None:
+            factory = self.agent_factories[name]
+            agent = await factory(self.config)
+            self.agents[name] = agent
+            logger.info(f"Agent '{name}' lazily created and added to the registry.")
         return self.agents[name]

--- a/warehouse/oso_agent/oso_agent/agent/base.py
+++ b/warehouse/oso_agent/oso_agent/agent/base.py
@@ -1,0 +1,36 @@
+import typing as t
+
+from llama_index.core.agent.workflow.base_agent import BaseWorkflowAgent
+
+from ..types import ErrorResponse, WrappedResponse
+
+ResponseWrapper = t.Callable[[t.Any], WrappedResponse]
+
+class GenericWrappedAgent:
+    def __init__(self, agent: BaseWorkflowAgent, response_wrapper: ResponseWrapper):
+        self._agent = agent
+        self._response_wrapper = response_wrapper
+
+    def get_agent(self) -> BaseWorkflowAgent:
+        return self._agent
+    
+    async def run(self, *args, **kwargs) -> WrappedResponse:
+        """Run the agent with the given arguments and return the response."""
+        raw_response = await self._agent.run(*args, **kwargs)
+        return self._response_wrapper(raw_response)
+    
+    async def run_safe(self, *args, **kwargs) -> WrappedResponse:
+        """Run the agent with the given arguments and return the response,
+        handling errors and returning a wrapped error response."""
+        try:
+            return await self.run(*args, **kwargs)
+        except Exception as e:
+            # Handle exceptions and return a wrapped error response
+            return self._wrap_error(e)
+        
+    def _wrap_error(self, error: Exception) -> WrappedResponse:
+        """Wrap an error into a response."""
+        response = ErrorResponse(
+            message=str(error),
+        )
+        return WrappedResponse(response=response)

--- a/warehouse/oso_agent/oso_agent/agent/basic_agent.py
+++ b/warehouse/oso_agent/oso_agent/agent/basic_agent.py
@@ -96,3 +96,4 @@ class BasicAgent(SingleAgentRunnerMixin, BaseWorkflowAgent):
         await ctx.set(self.scratchpad_key, [])
 
         return output
+    

--- a/warehouse/oso_agent/oso_agent/agent/decorator.py
+++ b/warehouse/oso_agent/oso_agent/agent/decorator.py
@@ -1,0 +1,28 @@
+import typing as t
+
+from llama_index.core.agent.workflow.base_agent import BaseWorkflowAgent
+from oso_agent.types.response import StrResponse, WrappedResponse
+
+from ..util.config import AgentConfig
+from .base import GenericWrappedAgent, ResponseWrapper
+
+
+def str_response_wrapper(response: t.Any) -> WrappedResponse:
+    """Wrap a string response in a WrappedAgentResponse."""
+    return WrappedResponse(response=StrResponse(blob=str(response)))
+    
+AgentFactory = t.Callable[[AgentConfig], t.Awaitable[BaseWorkflowAgent]]
+
+def wrapped_agent(wrapper_function: ResponseWrapper | None = None):
+    """A decorator to wrap an agent's run method with a response wrapper."""
+
+    if not wrapper_function:
+        wrapper_function = str_response_wrapper
+
+    def _factory(decorated: AgentFactory) -> t.Callable[[AgentConfig], t.Awaitable[GenericWrappedAgent]]:
+        async def wrapper(config: AgentConfig) -> GenericWrappedAgent:
+            """Wrapper function to call the agent's run method."""
+            agent = await decorated(config)
+            return GenericWrappedAgent(agent, wrapper_function)
+        return wrapper
+    return _factory

--- a/warehouse/oso_agent/oso_agent/agent/default.py
+++ b/warehouse/oso_agent/oso_agent/agent/default.py
@@ -1,0 +1,23 @@
+"""
+The default agent registry for the oso agent.
+"""
+import logging
+
+from ..util.config import AgentConfig
+from .agent_registry import AgentRegistry
+from .react_agent import create_react_agent
+from .semantic_agent import create_semantic_agent
+from .sql_agent import create_sql_agent
+
+logger = logging.getLogger(__name__)
+
+def setup_default_agent_registry(config: AgentConfig) -> AgentRegistry:
+    logger.info("Setting up the default agent registry...")
+    registry = AgentRegistry(config)
+
+    registry.add_agent("react", create_react_agent)
+    registry.add_agent("sql", create_sql_agent)
+    registry.add_agent("semantic", create_semantic_agent)
+
+    logger.info("Default agent registry setup complete.")
+    return registry

--- a/warehouse/oso_agent/oso_agent/agent/default.py
+++ b/warehouse/oso_agent/oso_agent/agent/default.py
@@ -11,13 +11,17 @@ from .sql_agent import create_sql_agent
 
 logger = logging.getLogger(__name__)
 
-def setup_default_agent_registry(config: AgentConfig) -> AgentRegistry:
+async def setup_default_agent_registry(config: AgentConfig) -> AgentRegistry:
     logger.info("Setting up the default agent registry...")
     registry = AgentRegistry(config)
 
     registry.add_agent("react", create_react_agent)
     registry.add_agent("sql", create_sql_agent)
     registry.add_agent("semantic", create_semantic_agent)
+
+    if config.eagerly_load_all_agents:
+        logger.info("Eagerly loading all agents in the registry...")
+        await registry.eager_load_all_agents()
 
     logger.info("Default agent registry setup complete.")
     return registry

--- a/warehouse/oso_agent/oso_agent/agent/react_agent.py
+++ b/warehouse/oso_agent/oso_agent/agent/react_agent.py
@@ -12,6 +12,7 @@ from ..types.sql_query import SqlQuery
 #from llama_index.core.tools import BaseTool, FunctionTool
 from ..util.config import AgentConfig
 from ..util.errors import AgentConfigError
+from .decorator import wrapped_agent
 
 logger = logging.getLogger(__name__)
 
@@ -27,6 +28,7 @@ Do not include any other text or explanation.
 Make sure that any tables or columns you reference in your SQL query actually exist in the database.
 """
 
+@wrapped_agent()
 async def create_react_agent(config: AgentConfig) -> BaseWorkflowAgent:
     """Create and configure the ReAct agent."""
 

--- a/warehouse/oso_agent/oso_agent/agent/semantic_agent.py
+++ b/warehouse/oso_agent/oso_agent/agent/semantic_agent.py
@@ -1,0 +1,49 @@
+import logging
+
+#from llama_index.core.agent.workflow import FunctionAgent
+from llama_index.core.agent.workflow.base_agent import BaseWorkflowAgent
+
+#from ..tool.oso_mcp import create_oso_mcp_tools
+from metrics_tools.semantic.definition import SemanticQuery
+from metrics_tools.semantic.testing import setup_registry
+
+from ..tool.llm import create_llm
+from ..util.config import AgentConfig
+from ..util.errors import AgentConfigError
+from .basic_agent import BasicAgent
+
+logger = logging.getLogger(__name__)
+
+SYSTEM_PROMPT: str = """
+You are a text to SemanticQuery translator. You will be given a natural language
+query and you should return a valid SemanticQuery object that represents the
+query based on a given semantic model.
+
+Make sure that your response only contains only the correct SemanticQuery object.
+
+The Semantic Model is as follows
+---
+
+"""
+
+async def create_semantic_agent(config: AgentConfig) -> BaseWorkflowAgent:
+    """Create and configure the SQL agent."""
+
+    semantic_registry = setup_registry()
+    prompt = SYSTEM_PROMPT + semantic_registry.describe()
+
+    try:
+        # Create a structured LLM for generating SQL queries
+        llm = create_llm(config)
+        sllm = llm.as_structured_llm(SemanticQuery)
+        tools = []
+
+        logger.info("Initializing Semantic agent")
+        return BasicAgent(
+            tools=tools,
+            llm=sllm,
+            system_prompt=prompt,
+        )
+    except Exception as e:
+        logger.error(f"Failed to create agent: {e}")
+        raise AgentConfigError(f"Failed to create agent: {e}") from e

--- a/warehouse/oso_agent/oso_agent/agent/semantic_agent.py
+++ b/warehouse/oso_agent/oso_agent/agent/semantic_agent.py
@@ -1,6 +1,8 @@
 import logging
 
 #from llama_index.core.agent.workflow import FunctionAgent
+import typing as t
+
 from llama_index.core.agent.workflow.base_agent import BaseWorkflowAgent
 
 #from ..tool.oso_mcp import create_oso_mcp_tools
@@ -8,9 +10,11 @@ from metrics_tools.semantic.definition import SemanticQuery
 from metrics_tools.semantic.testing import setup_registry
 
 from ..tool.llm import create_llm
+from ..types.response import SemanticResponse, WrappedResponse
 from ..util.config import AgentConfig
 from ..util.errors import AgentConfigError
 from .basic_agent import BasicAgent
+from .decorator import wrapped_agent
 
 logger = logging.getLogger(__name__)
 
@@ -26,6 +30,14 @@ The Semantic Model is as follows
 
 """
 
+def as_semantic_response(raw_response: t.Any) -> WrappedResponse:
+    """Wrap a SemanticQuery response in a WrappedAgentResponse."""
+    query = SemanticQuery.model_validate_json(str(raw_response))
+    response = SemanticResponse(query=query)
+    return WrappedResponse(response=response)
+
+
+@wrapped_agent(as_semantic_response)
 async def create_semantic_agent(config: AgentConfig) -> BaseWorkflowAgent:
     """Create and configure the SQL agent."""
 

--- a/warehouse/oso_agent/oso_agent/agent/sql_agent.py
+++ b/warehouse/oso_agent/oso_agent/agent/sql_agent.py
@@ -1,15 +1,18 @@
 import logging
+import typing as t
 
 #from llama_index.core.agent.workflow import FunctionAgent
 from llama_index.core.agent.workflow.base_agent import BaseWorkflowAgent
 
 from ..tool.llm import create_llm
+from ..types.response import SqlResponse, WrappedResponse
 
 #from ..tool.oso_mcp import create_oso_mcp_tools
 from ..types.sql_query import SqlQuery
 from ..util.config import AgentConfig
 from ..util.errors import AgentConfigError
 from .basic_agent import BasicAgent
+from .decorator import wrapped_agent
 
 logger = logging.getLogger(__name__)
 
@@ -22,6 +25,14 @@ Make sure that your response only contains a single valid SQL query.
 Do not include any other text or explanation.
 """
 
+    
+def as_sql_response(raw_response: t.Any) -> WrappedResponse:
+    query = SqlQuery.model_validate_json(raw_response)
+    response = SqlResponse(query=query)
+    return WrappedResponse(response=response)
+
+
+@wrapped_agent(as_sql_response)
 async def create_sql_agent(config: AgentConfig) -> BaseWorkflowAgent:
     """Create and configure the SQL agent."""
 

--- a/warehouse/oso_agent/oso_agent/cli/commands.py
+++ b/warehouse/oso_agent/oso_agent/cli/commands.py
@@ -22,7 +22,7 @@ load_dotenv()
 logger = logging.getLogger("oso-agent")
 
 async def create_agent(config: AgentConfig):
-    registry = setup_default_agent_registry(config)
+    registry = await setup_default_agent_registry(config)
     agent = await registry.get_agent(config.agent_name)
     return agent
 

--- a/warehouse/oso_agent/oso_agent/cli/commands.py
+++ b/warehouse/oso_agent/oso_agent/cli/commands.py
@@ -6,10 +6,11 @@ import click
 from dotenv import load_dotenv
 from llama_index.core.llms import ChatMessage, MessageRole
 
-from ..agent.agent_registry import AgentRegistry
+from ..agent import setup_default_agent_registry
 from ..eval.experiment_registry import get_experiments
 from ..server.bot import setup_bot
 from ..server.definition import BotConfig
+from ..types import ErrorResponse, SemanticResponse, SqlResponse, StrResponse
 from ..util.config import AgentConfig
 from ..util.errors import AgentConfigError, AgentError, AgentRuntimeError
 from ..util.log import setup_logging
@@ -21,8 +22,8 @@ load_dotenv()
 logger = logging.getLogger("oso-agent")
 
 async def create_agent(config: AgentConfig):
-    registry = await AgentRegistry.create(config)
-    agent = registry.get_agent(config.agent_name)
+    registry = setup_default_agent_registry(config)
+    agent = await registry.get_agent(config.agent_name)
     return agent
 
 @click.group(context_settings={"help_option_names": ["-h", "--help"]})
@@ -85,11 +86,27 @@ def query(config, query, agent_name, ollama_model, ollama_url):
 
 async def _run_query(query: str, config: AgentConfig) -> str:
     """Run a query through the agent asynchronously."""
+
     agent = await create_agent(config)
     click.echo(
         f"Query started with agent={config.agent_name} and model={config.llm.type}"
     )
-    return await agent.run(query)
+    wrapped_response = await agent.run(query)
+    match wrapped_response.response:
+        case StrResponse(blob=blob):
+            return blob
+        case SemanticResponse(query=semantic_query):
+            return str(semantic_query)
+        case SqlResponse(query=sql_query):
+            return str(sql_query)
+        case ErrorResponse(message=message, details=details):
+            raise AgentRuntimeError(
+                f"Error from agent: {message}. Details: {details}"
+            )
+        case _:
+            raise AgentRuntimeError(
+                f"Unexpected response type from agent: {wrapped_response.response.type}"
+            )
 
 @cli.command()
 @click.argument("experiment_name", required=True)

--- a/warehouse/oso_agent/oso_agent/eval/experiment_registry.py
+++ b/warehouse/oso_agent/oso_agent/eval/experiment_registry.py
@@ -2,9 +2,9 @@ import logging
 import typing as t
 from typing import Awaitable, Callable
 
-from llama_index.core.agent.workflow.base_agent import BaseWorkflowAgent
 from phoenix.experiments.types import RanExperiment
 
+from ..types import WrappedResponseAgent
 from ..util.config import AgentConfig
 from .text2sql import text2sql_experiment
 
@@ -12,7 +12,7 @@ from .text2sql import text2sql_experiment
 logger = logging.getLogger(__name__)
 
 # Type alias for a dictionary of agents
-ExperimentDict = t.Dict[str, Callable[[AgentConfig, BaseWorkflowAgent], Awaitable[RanExperiment]]]
+ExperimentDict = t.Dict[str, Callable[[AgentConfig, WrappedResponseAgent], Awaitable[RanExperiment]]]
 
 def get_experiments() -> ExperimentDict:
     """Create and configure the ReAct agent."""

--- a/warehouse/oso_agent/oso_agent/eval/text2sql.py
+++ b/warehouse/oso_agent/oso_agent/eval/text2sql.py
@@ -22,9 +22,12 @@ except ValueError:
 
 async def text2sql_experiment(config: AgentConfig, agent: BaseWorkflowAgent):
     print("Running text2sql experiment with:", config)
+    api_key = config.arize_phoenix_api_key.get_secret_value()
     phoenix_client = px.Client(
         endpoint=config.arize_phoenix_base_url,
-        api_key=config.arize_phoenix_api_key.get_secret_value(),
+        headers={
+            "api_key": api_key,
+        }
     )
     dataset = upload_dataset(phoenix_client, config.eval_dataset_text2sql, TEXT2SQL_DATASET)
 

--- a/warehouse/oso_agent/oso_agent/eval/text2sql.py
+++ b/warehouse/oso_agent/oso_agent/eval/text2sql.py
@@ -1,9 +1,9 @@
-import json
+import logging
 from typing import Any, Dict
 
 import nest_asyncio
 import phoenix as px
-from llama_index.core.agent.workflow.base_agent import BaseWorkflowAgent
+from metrics_tools.semantic.testing import setup_registry
 from phoenix.experiments import run_experiment
 from phoenix.experiments.evaluators import ContainsAnyKeyword
 from phoenix.experiments.types import Example
@@ -11,6 +11,13 @@ from phoenix.experiments.types import Example
 from ..datasets.text2sql import TEXT2SQL_DATASET
 from ..datasets.uploader import upload_dataset
 from ..tool.oso_mcp import create_oso_mcp_tools
+from ..types import (
+    ErrorResponse,
+    SemanticResponse,
+    SqlResponse,
+    StrResponse,
+    WrappedResponseAgent,
+)
 from ..util.config import AgentConfig
 from ..util.jaccard import jaccard_similarity_str
 
@@ -20,9 +27,15 @@ try:
 except ValueError:
     pass
 
-async def text2sql_experiment(config: AgentConfig, agent: BaseWorkflowAgent):
-    print("Running text2sql experiment with:", config)
+logger = logging.getLogger(__name__)
+
+
+async def text2sql_experiment(config: AgentConfig, agent: WrappedResponseAgent):
+    logger.info("Running text2sql experiment with:", config)
     api_key = config.arize_phoenix_api_key.get_secret_value()
+
+    # We pass in the API key directly to the Phoenix client but it's likely 
+    # ignored. See oso_agent/util/config.py
     phoenix_client = px.Client(
         endpoint=config.arize_phoenix_base_url,
         headers={
@@ -37,27 +50,48 @@ async def text2sql_experiment(config: AgentConfig, agent: BaseWorkflowAgent):
         # print(f"Question: {question}")
         # expected = str(example.output["answer"])
         # print(f"Expected: {expected}")
-        response = await agent.run(question)
-        response_dict = json.loads(str(response))
-        # print(f"Response: {response_dict}")
-        response_query = response_dict["query"]
-        # print(f"Response Query: {response_query}")
-        return response_query
+        agent_response = await agent.run_safe(question)
+        logger.debug(f"Agent response: {agent_response}")
+
+        match agent_response.response:
+            case StrResponse(blob=blob):
+                return blob
+            case SemanticResponse(query=query):
+                # hacky way for now to load the semantic registry
+                semantic_registry = setup_registry()
+                try:
+                    return semantic_registry.query(query).sql(dialect="trino", pretty=True)
+                except Exception as e:
+                    return f"Error rendering semantic query: {e}"
+            case SqlResponse(query=query):
+                return query.query
+            case ErrorResponse(message=message):
+                return message
 
     contains_select = ContainsAnyKeyword(keywords=["SELECT"])
+
+    def load_expected_sql_answer(expected: Dict[str, Any]) -> str:
+        """Load the expected answer from the example."""
+        expected_answer = expected.get("answer")
+        if not expected_answer:
+            logger.warning("No expected answer provided, defaulting to 'SELECT 1'")
+            expected_answer = "SELECT 1"
+        return expected_answer
 
     def sql_query_similarity(output: str, expected: Dict[str, Any]) -> float:
         """Evaluate the similarity between the output and expected SQL query using Jaccard similarity."""
         # print(f"Output: {output}")
         # print(f"Expected: {expected["answer"]}")
-        return jaccard_similarity_str(output, expected["answer"])
+        expected_answer = load_expected_sql_answer(expected)
+        return jaccard_similarity_str(output, expected_answer)
 
     mcp_tools = await create_oso_mcp_tools(config, ["query_oso"])
     query_tool = mcp_tools[0]
 
     def sql_result_similarity(output: str, expected: Dict[str, Any]) -> float:
         """Evaluate the similarity between results post-query"""
-        expected_response = query_tool.call(sql=expected["answer"])
+        expected_answer = load_expected_sql_answer(expected)
+        expected_response = query_tool.call(sql=expected_answer)
         expected_str = expected_response.content
         # print(f"Expected Str: {expected_str}")
 

--- a/warehouse/oso_agent/oso_agent/server/app.py
+++ b/warehouse/oso_agent/oso_agent/server/app.py
@@ -30,7 +30,7 @@ def default_lifecycle(config: AgentServerConfig):
     @asynccontextmanager
     async def initialize_app(app: FastAPI):
         setup_telemetry(config)
-        registry = setup_default_agent_registry(config)
+        registry = await setup_default_agent_registry(config)
         agent = await registry.get_agent(config.agent_name)
 
         bot_config = BotConfig()

--- a/warehouse/oso_agent/oso_agent/server/app.py
+++ b/warehouse/oso_agent/oso_agent/server/app.py
@@ -10,7 +10,7 @@ from fastapi import FastAPI, Request
 from fastapi.datastructures import State
 from fastapi.responses import PlainTextResponse
 from llama_index.core.agent.workflow.base_agent import BaseWorkflowAgent
-from oso_agent.agent.agent_registry import AgentRegistry
+from oso_agent.agent import setup_default_agent_registry
 from oso_agent.server.bot import setup_bot
 from oso_agent.server.definition import (
     AgentServerConfig,
@@ -30,8 +30,8 @@ def default_lifecycle(config: AgentServerConfig):
     @asynccontextmanager
     async def initialize_app(app: FastAPI):
         setup_telemetry(config)
-        registry = await AgentRegistry.create(config)
-        agent = registry.get_agent(config.agent_name)
+        registry = setup_default_agent_registry(config)
+        agent = await registry.get_agent(config.agent_name)
 
         bot_config = BotConfig()
         bot = await setup_bot(bot_config, agent)

--- a/warehouse/oso_agent/oso_agent/server/bot.py
+++ b/warehouse/oso_agent/oso_agent/server/bot.py
@@ -3,16 +3,16 @@ from typing import Optional
 
 from discord import Intents, Member
 from discord.ext.commands import Bot
-from llama_index.core.agent.workflow.base_agent import BaseWorkflowAgent
 
 from ..eval.experiment_registry import get_experiments
+from ..types import WrappedResponseAgent
 from .definition import BotConfig
 
 logger = logging.getLogger(__name__)
 
 COMMAND_PREFIX = "!"
 
-async def setup_bot(config: BotConfig, agent: BaseWorkflowAgent):
+async def setup_bot(config: BotConfig, agent: WrappedResponseAgent):
     intents = Intents.default()
     intents.message_content = True
 

--- a/warehouse/oso_agent/oso_agent/types/__init__.py
+++ b/warehouse/oso_agent/oso_agent/types/__init__.py
@@ -1,0 +1,4 @@
+# ruff: noqa: F403
+from .agent import *
+from .response import *
+from .sql_query import *

--- a/warehouse/oso_agent/oso_agent/types/agent.py
+++ b/warehouse/oso_agent/oso_agent/types/agent.py
@@ -1,0 +1,23 @@
+import typing as t
+
+from llama_index.core.agent.workflow.base_agent import BaseWorkflowAgent
+
+from .response import WrappedResponse
+
+
+class WrappedResponseAgent(t.Protocol):
+    """A wrapper for the agent that provides a consistent interface for responses from the agents
+    """
+
+    def get_agent(self) -> BaseWorkflowAgent:
+        """Get the underlying agent."""
+        ...
+
+    async def run(self, *args, **kwargs) -> WrappedResponse:
+        """Run the agent with the given arguments and return the response."""
+        ...
+
+    async def run_safe(self, *args, **kwargs) -> WrappedResponse:
+        """Run the agent with the given arguments and return the response,
+        handling errors and returning a wrapped error response."""
+        ...

--- a/warehouse/oso_agent/oso_agent/types/response.py
+++ b/warehouse/oso_agent/oso_agent/types/response.py
@@ -1,0 +1,49 @@
+import typing as t
+
+from metrics_tools.semantic.definition import SemanticQuery
+from pydantic import BaseModel, Field
+
+from .sql_query import SqlQuery
+
+
+class ErrorResponse(BaseModel):
+    type: t.Literal["error"] = "error"
+
+    message: str = Field(
+        description="Error message from the agent."
+    )
+
+    details: str = Field(
+        default="",
+        description="Optional details about the error, if available."
+    )
+
+class StrResponse(BaseModel):
+    type: t.Literal["str"] = "str"
+
+    blob: str = Field(
+        description="A string response from the agent, typically used for simple text responses."
+    )
+
+class SemanticResponse(BaseModel):
+    type: t.Literal["semantic"] = "semantic"
+
+    query: SemanticQuery
+
+class SqlResponse(BaseModel):
+    type: t.Literal["sql"] = "sql"
+
+    query: SqlQuery
+
+ResponseTypes = t.Union[
+    StrResponse,
+    SemanticResponse,
+    SqlResponse,
+    ErrorResponse
+]
+
+class WrappedResponse(BaseModel):
+    """A wrapper for the response from an agent"""
+
+    response: ResponseTypes = Field(discriminator="type")
+

--- a/warehouse/oso_agent/oso_agent/types/sql_query.py
+++ b/warehouse/oso_agent/oso_agent/types/sql_query.py
@@ -1,4 +1,4 @@
-from typing import Annotated, Any, Dict, List, Optional
+from typing import Annotated
 
 from pydantic import AfterValidator, BaseModel, Field, ValidationError
 from sqlglot import parse_one
@@ -16,6 +16,3 @@ def is_valid_sql(text: str, dialect: str = DEFAULT_SQL_DIALECT) -> str:
 
 class SqlQuery(BaseModel):
     query: Annotated[str, Field(description="A valid SQL query that will be executed on a query engine."), AfterValidator(is_valid_sql)]
-
-class SqlQueryResponse(SqlQuery):
-    response: Optional[List[Dict[str, Any]]] = Field(description="The response from the SQL query engine")

--- a/warehouse/oso_agent/oso_agent/util/config.py
+++ b/warehouse/oso_agent/oso_agent/util/config.py
@@ -108,6 +108,16 @@ class AgentConfig(BaseSettings):
             self.arize_phoenix_traces_url = f"{self.arize_phoenix_base_url}/v1/traces"
         if not self.arize_phoenix_traces_url.endswith("/"):
             self.arize_phoenix_traces_url += "/"
+
+        # This is a terrible hack because arize phoenix's libraries don't 
+        # consistently handle passing in api key or endpoint so we need to 
+        # inject it into the environment
+        if self.arize_phoenix_api_key.get_secret_value():
+            import os
+            os.environ["PHOENIX_CLIENT_HEADERS"] = f"api_key={self.arize_phoenix_api_key.get_secret_value()}"
+            os.environ["PHOENIX_COLLECTOR_ENDPOINT"] = self.arize_phoenix_base_url
+            os.environ["OTEL_EXPORTER_OTLP_HEADER"] = f"api_key={self.arize_phoenix_api_key.get_secret_value()}"
+
         return self
 
     def update(self, **kwargs) -> "AgentConfig":

--- a/warehouse/oso_agent/oso_agent/util/config.py
+++ b/warehouse/oso_agent/oso_agent/util/config.py
@@ -59,6 +59,11 @@ class AgentConfig(BaseSettings):
 
     model_config = agent_config_dict()
 
+    eagerly_load_all_agents: bool = Field(
+        default=False,
+        description="Whether to eagerly load all agents in the registry"
+    )
+
     agent_name: str = Field(default="react", description="Name of the agent to use")
 
     llm: LLMConfig = Field(discriminator="type", default_factory=lambda: LocalLLMConfig())

--- a/warehouse/oso_agent/pyproject.toml
+++ b/warehouse/oso_agent/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.10"
 authors = [{ name = "OSO Team", email = "opensource-observer@googlegroups.com" }]
 dependencies = [
     "arize-phoenix-otel==0.9.2",
-    "arize-phoenix[evals]==9.6.1",
+    "arize-phoenix[evals]==10.0.4",
     "discord-py>=2.5.2",
     "dotenv>=0.9.9",
     "llama-index>=0.12.29",


### PR DESCRIPTION
TODOs:

* [x] - Add the post processing step to turn the semantic query into SQL for the eval.

Implementation Notes:
* Added a new `WrappedResponse` type
    * This is used as the common response object from the agents. Currently the response types are:
        * `StrResponse` - The default
        * `SqlResponse` - A SQL Response (using the `SqlQuery` type)
        * `SemanticResponse` - A semantic query response
        * `ErrorResponse` - If an error is detected we wrap all errors in this type
    * This is done so that any experiment should be able to target any agent and handle their respective responses through pattern matching in a `match...case` stanza. 
* Makes the agent loading lazy (for server startup this is by default forced into eager mode)

Closes #3863 