### PR TITLE
chore: bump size for dagster pods

### DIFF
--- a/ops/k8s-apps/production/dagster/custom-helm-values.yaml
+++ b/ops/k8s-apps/production/dagster/custom-helm-values.yaml
@@ -34,17 +34,17 @@ spec:
             value: "1"
         resources:
           limits:
-            memory: 768Mi
+            memory: 1280Mi
           requests:
-            cpu: 100m
-            memory: 512Mi
+            cpu: 200m
+            memory: 640Mi
       dagsterWebserver:
         env:
           - name: DAGSTER_DBT_GENERATE_AND_AUTH_GCP
             value: "1"
         resources:
           limits:
-            memory: 768Mi
+            memory: 1024Mi
           requests:
             cpu: 100m
             memory: 512Mi


### PR DESCRIPTION
I couldn't quite tell if this was related to the `failed to start` issues but I know I was a bit too conservative with these values before. I also didn't do much investigation yet, as it's not fully disruptive, just a nuissance. If this doesn't help we should just increase the start timeout on the helm chart at `dagsterDaemon.runMonitoring.startTimeoutSeconds` which is currently set to 300 seconds (or decrease to improve responsiveness?)