### PR TITLE
fix: include better errors when ending queries with semicolons in pyoso

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -4844,6 +4844,7 @@ version = "0.4.0"
 source = { editable = "warehouse/pyoso" }
 dependencies = [
     { name = "pandas" },
+    { name = "sqlglot" },
 ]
 
 [package.dev-dependencies]
@@ -4852,7 +4853,10 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "pandas", specifier = ">=1.2.0" }]
+requires-dist = [
+    { name = "pandas", specifier = ">=1.2.0" },
+    { name = "sqlglot", specifier = ">=26.16.4" },
+]
 
 [package.metadata.requires-dev]
 dev = [{ name = "pandas-stubs", specifier = ">=2.2.3.250308" }]

--- a/warehouse/pyoso/pyoso/client.py
+++ b/warehouse/pyoso/pyoso/client.py
@@ -38,7 +38,9 @@ class Client:
             if not self.__base_url.endswith("/"):
                 self.__base_url += "/"
 
-    def __query(self, query: str, input_dialect="trino", output_dialect="trino") -> QueryData:
+    def __query(
+        self, query: str, input_dialect="trino", output_dialect="trino"
+    ) -> QueryData:
         # The following checks are only for providing better error messages as
         # the oso api does _not_ support multiple queries nor the use of
         # semicolons.
@@ -51,7 +53,7 @@ class Client:
             )
         query_expression = parsed_query[0]
         assert query_expression is not None, "query could not be parsed"
-        
+
         headers = {
             "Content-Type": "application/json",
         }
@@ -61,7 +63,10 @@ class Client:
             response = requests.post(
                 f"{self.__base_url}sql",
                 headers=headers,
-                json={"query": query_expression.sql(dialect=output_dialect), "format": "minimal"},
+                json={
+                    "query": query_expression.sql(dialect=output_dialect),
+                    "format": "minimal",
+                },
                 stream=True,
             )
             response.raise_for_status()

--- a/warehouse/pyoso/pyoso/client.py
+++ b/warehouse/pyoso/pyoso/client.py
@@ -6,6 +6,7 @@ from typing import Any, Optional
 import pandas as pd
 import requests
 from pyoso.exceptions import OsoError, OsoHTTPError
+from sqlglot import parse
 
 _DEFAULT_BASE_URL = "https://www.opensource.observer/api/v1/"
 OSO_API_KEY = "OSO_API_KEY"
@@ -37,7 +38,20 @@ class Client:
             if not self.__base_url.endswith("/"):
                 self.__base_url += "/"
 
-    def __query(self, query: str):
+    def __query(self, query: str, input_dialect="trino", output_dialect="trino") -> QueryData:
+        # The following checks are only for providing better error messages as
+        # the oso api does _not_ support multiple queries nor the use of
+        # semicolons.
+        if not query:
+            raise OsoError("Query cannot be empty.")
+        parsed_query = parse(query, dialect=input_dialect)
+        if len(parsed_query) != 1:
+            raise OsoError(
+                "Only single queries are supported. Please provide a single SQL statement."
+            )
+        query_expression = parsed_query[0]
+        assert query_expression is not None, "query could not be parsed"
+        
         headers = {
             "Content-Type": "application/json",
         }
@@ -47,7 +61,7 @@ class Client:
             response = requests.post(
                 f"{self.__base_url}sql",
                 headers=headers,
-                json={"query": query, "format": "minimal"},
+                json={"query": query_expression.sql(dialect=output_dialect), "format": "minimal"},
                 stream=True,
             )
             response.raise_for_status()

--- a/warehouse/pyoso/pyproject.toml
+++ b/warehouse/pyoso/pyproject.toml
@@ -9,6 +9,7 @@ authors = [
 ]
 dependencies = [
     "pandas>=1.2.0",
+    "sqlglot>=26.16.4",
 ]
 
 [build-system]


### PR DESCRIPTION
Stupid bug I ran into yesterday when the agent started generating queries with semicolons and the error returned was confusing. This will prevent that from happening to users of the pyoso library but doesn't necessarily make the errors any better on the server. Though the error _directly_ from the api does say that `;` is not expected. I'm not sure we fix this on the server though, most people should be using pyoso so I'm fine only changing it here for now. 

On the server, the limitation appears to be the trino client which doesn't accept the semicolons at the end of the query. Instead of not accepting it, we accept it here but also ensure that you've only included a _single_ query. 