### PR TITLE
Fix Typos in Documentation and Comments

### DIFF
--- a/ops/external-prs/src/github.ts
+++ b/ops/external-prs/src/github.ts
@@ -79,7 +79,7 @@ export class GithubOutput {
 }
 
 /**
- * StatusPRComment continously updates a single comment with the status of a PR.
+ * StatusPRComment continuously updates a single comment with the status of a PR.
  */
 export class StatusPRComment {
   private app: App;

--- a/ops/k8s-infrastructure/gke/cloudsql-proxy-operator.yaml
+++ b/ops/k8s-infrastructure/gke/cloudsql-proxy-operator.yaml
@@ -1613,7 +1613,7 @@ spec:
                       unixSocketPath:
                         description: |-
                           UnixSocketPath is the path to the unix socket where the proxy will listen
-                          for connnections. This will be mounted to all containers in the pod.
+                          for connections. This will be mounted to all containers in the pod.
                         type: string
                       unixSocketPathEnvName:
                         description: |-


### PR DESCRIPTION


Description:  
This pull request corrects minor typos in the codebase:
- In ops/external-prs/src/github.ts, the word "continously" was corrected to "continuously" in a comment.
- In ops/k8s-infrastructure/gke/cloudsql-proxy-operator.yaml, the word "connnections" was corrected to "connections" in the description for unixSocketPath.

