### PR TITLE
fix: add forceError and forceLoading into DataProviderView

### DIFF
--- a/apps/frontend/components/dataprovider/auth-router.tsx
+++ b/apps/frontend/components/dataprovider/auth-router.tsx
@@ -43,7 +43,6 @@ function AuthRouter(props: AuthRouterProps) {
     className,
     variableName,
     useTestData,
-    testData,
     noAuthChildren,
     ignoreNoAuth,
     testNoAuth,
@@ -52,13 +51,11 @@ function AuthRouter(props: AuthRouterProps) {
   const supabaseState = useSupabaseState();
   const posthog = usePostHog();
 
-  const data = useTestData
-    ? testData
-    : {
-        user: supabaseState?.session?.user,
-        session: supabaseState?.session,
-        supabase: supabaseState?.supabaseClient,
-      };
+  const data = {
+    user: supabaseState?.session?.user,
+    session: supabaseState?.session,
+    supabase: supabaseState?.supabaseClient,
+  };
 
   if (!useTestData && data.user) {
     posthog?.identify(data.user.id, {

--- a/apps/frontend/components/dataprovider/oso-chat-provider.tsx
+++ b/apps/frontend/components/dataprovider/oso-chat-provider.tsx
@@ -37,7 +37,7 @@ const OsoChatProviderRegistration: RegistrationProps<OsoChatProviderProps> = {
 };
 
 function OsoChatProvider(props: OsoChatProviderProps) {
-  const { agentName, chatId, variableName, testData, useTestData } = props;
+  const { agentName, chatId, variableName, useTestData } = props;
   const supabaseState = useSupabaseState();
   const [firstLoad, setFirstLoad] = React.useState<boolean>(true);
   const { client } = useOsoAppClient();
@@ -94,7 +94,6 @@ function OsoChatProvider(props: OsoChatProviderProps) {
   }, [firstLoad, client, useTestData, chatId, chatData.messages]);
 
   const key = variableName ?? DEFAULT_PLASMIC_KEY;
-  const displayMessages = useTestData ? testData : chatData.messages;
   //console.log(data);
   //console.log(JSON.stringify(data, null, 2));
   //console.log(error);
@@ -105,7 +104,7 @@ function OsoChatProvider(props: OsoChatProviderProps) {
       variableName={key}
       formattedData={{
         ...chatData,
-        messages: displayMessages,
+        messages: chatData.messages,
       }}
       loading={false}
     />

--- a/apps/frontend/components/dataprovider/oso-data-provider.tsx
+++ b/apps/frontend/components/dataprovider/oso-data-provider.tsx
@@ -48,13 +48,11 @@ const OsoDataProviderRegistration: RegistrationProps<OsoDataProviderProps> = {
 };
 
 function OsoDataProvider(props: OsoDataProviderProps) {
-  const { dataFetches, variableName, testData, useTestData } = props;
+  const { dataFetches, variableName } = props;
   const key = genKey(props);
   const { client } = useOsoAppClient();
   const { data, mutate, error, isLoading } = useSWR(key, async () => {
-    if (useTestData) {
-      return testData;
-    } else if (!dataFetches || _.isEmpty(dataFetches)) {
+    if (!dataFetches || _.isEmpty(dataFetches)) {
       return;
     } else if (!client) {
       throw new Error("No Supabase client found");

--- a/apps/frontend/components/dataprovider/provider-view.tsx
+++ b/apps/frontend/components/dataprovider/provider-view.tsx
@@ -11,8 +11,10 @@ type CommonDataProviderProps = {
   children?: ReactNode; // Show this
   loadingChildren?: ReactNode; // Show during loading if !ignoreLoading
   ignoreLoading?: boolean; // Skip the loading visual
+  forceLoading?: boolean; // Display the loadingChildren (Studio only)
   errorChildren?: ReactNode; // Show if error
   ignoreError?: boolean; // Skip the error visual
+  forceError?: boolean; // Display errorChildren (Studio only)
   useTestData?: boolean; // Use the testData prop instead of querying database
   testData?: any;
 };
@@ -50,6 +52,12 @@ const CommonDataProviderRegistration: RegistrationProps<CommonDataProviderProps>
       helpText: "Don't show 'loadingChildren' even if we're still loading data",
       advanced: true,
     },
+    forceLoading: {
+      type: "boolean",
+      helpText: "Render loadingChildren",
+      editOnly: true,
+      advanced: true,
+    },
     errorChildren: {
       type: "slot",
       defaultValue: {
@@ -60,6 +68,12 @@ const CommonDataProviderRegistration: RegistrationProps<CommonDataProviderProps>
     ignoreError: {
       type: "boolean",
       helpText: "Don't show 'errorChildren' even if we get an error",
+      advanced: true,
+    },
+    forceError: {
+      type: "boolean",
+      helpText: "Render errorChildren",
+      editOnly: true,
       advanced: true,
     },
     useTestData: {
@@ -82,9 +96,21 @@ const CommonDataProviderRegistration: RegistrationProps<CommonDataProviderProps>
 function DataProviderView(props: DataProviderViewProps) {
   const key = props.variableName ?? DEFAULT_VARIABLE_NAME;
   // Show when loading or error
-  if (props.loading && !props.ignoreLoading && !!props.loadingChildren) {
+  if (
+    props.forceLoading ||
+    (!props.useTestData &&
+      props.loading &&
+      !props.ignoreLoading &&
+      !!props.loadingChildren)
+  ) {
     return <div className={props.className}> {props.loadingChildren} </div>;
-  } else if (props.error && !props.ignoreError && !!props.errorChildren) {
+  } else if (
+    props.forceError ||
+    (!props.useTestData &&
+      props.error &&
+      !props.ignoreError &&
+      !!props.errorChildren)
+  ) {
     return (
       <div className={props.className}>
         <DataProvider name={key} data={props.error}>
@@ -93,9 +119,10 @@ function DataProviderView(props: DataProviderViewProps) {
       </div>
     );
   }
+  const data = props.useTestData ? props.testData : props.formattedData;
   return (
     <div className={props.className}>
-      <DataProvider name={key} data={props.formattedData}>
+      <DataProvider name={key} data={data}>
         {props.children}
       </DataProvider>
     </div>

--- a/apps/frontend/components/dataprovider/supabase-query.tsx
+++ b/apps/frontend/components/dataprovider/supabase-query.tsx
@@ -71,13 +71,11 @@ const SupabaseQueryRegistration: RegistrationProps<SupabaseQueryProps> = {
 
 function SupabaseQuery(props: SupabaseQueryProps) {
   // These props are set in the Plasmic Studio
-  const { variableName, tableName, useTestData, testData } = props;
+  const { variableName, tableName } = props;
   const key = variableName ?? genKey(props);
   const supabaseState = useSupabaseState();
   const { data, error, isLoading } = useSWR(key, async () => {
-    if (useTestData) {
-      return testData;
-    } else if (!tableName) {
+    if (!tableName) {
       return;
     } else if (!supabaseState) {
       return console.warn("Supabase not initialized yet");


### PR DESCRIPTION
* These are studio only props that allow us to render those children for design purposes
* Also changes the behavior of useTestData so that we automatically replace the data in the common DataProviderView, rather than expect the consumer to pass in the right thing