### PR TITLE
fix: relax `credit` enforcement checks

### DIFF
--- a/apps/frontend/app/api/v1/chat/route.ts
+++ b/apps/frontend/app/api/v1/chat/route.ts
@@ -4,6 +4,7 @@ import { getUser } from "@/lib/auth/auth";
 import { OSO_AGENT_URL } from "@/lib/config";
 import { trackServerEvent } from "@/lib/analytics/track";
 import { EVENTS } from "@/lib/types/posthog";
+import { CreditsService, TransactionType } from "@/lib/services/credits";
 
 export const maxDuration = 60;
 
@@ -19,6 +20,7 @@ const getLatestMessage = (messages: any[]) => {
 export async function POST(req: NextRequest) {
   const user = await getUser(req);
   const prompt = await req.json();
+  const orgId = prompt.orgId;
   await using tracker = trackServerEvent(user);
 
   if (user.role === "anonymous") {
@@ -29,31 +31,30 @@ export async function POST(req: NextRequest) {
     );
   }
 
-  // const orgId = await CreditsService.getUserPrimaryOrganization(user.userId);
-  // if (!orgId) {
-  //   logger.log(`/api/chat: User ${user.userId} has no organization`);
-  //   return NextResponse.json(
-  //     { error: "User must be part of an organization" },
-  //     { status: 403 },
-  //   );
-  // }
+  if (!orgId) {
+    logger.log(`/api/chat: Missing orgId`);
+    return NextResponse.json(
+      { error: "Organization ID is required" },
+      { status: 400 },
+    );
+  }
 
-  // const creditsDeducted =
-  //   await CreditsService.checkAndDeductOrganizationCredits(
-  //     user,
-  //     orgId,
-  //     TransactionType.CHAT_QUERY,
-  //     "/api/v1/chat",
-  //     { message: getLatestMessage(prompt.messages) },
-  //   );
+  const creditsDeducted =
+    await CreditsService.checkAndDeductOrganizationCredits(
+      user,
+      orgId,
+      TransactionType.CHAT_QUERY,
+      "/api/v1/chat",
+      { message: getLatestMessage(prompt.messages) },
+    );
 
-  // if (!creditsDeducted) {
-  //   logger.log(`/api/chat: Insufficient credits for user ${user.userId}`);
-  //   return NextResponse.json(
-  //     { error: "Insufficient credits" },
-  //     { status: 402 },
-  //   );
-  // }
+  if (!creditsDeducted) {
+    logger.log(`/api/chat: Insufficient credits for user ${user.userId}`);
+    return NextResponse.json(
+      { error: "Insufficient credits" },
+      { status: 402 },
+    );
+  }
 
   try {
     tracker.track(EVENTS.API_CALL, {

--- a/apps/frontend/app/api/v1/graphql/route.ts
+++ b/apps/frontend/app/api/v1/graphql/route.ts
@@ -13,6 +13,7 @@ import { EVENTS } from "@/lib/types/posthog";
 import { getUser } from "@/lib/auth/auth";
 import { trackServerEvent } from "@/lib/analytics/track";
 import { logger } from "@/lib/logger";
+import { CreditsService, TransactionType } from "@/lib/services/credits";
 
 // https://vercel.com/guides/loading-static-file-nextjs-api-route
 const supergraphPath = path.join(
@@ -90,10 +91,12 @@ const customHandler = async (req: NextRequest) => {
 
   let operation = "unknown";
   let query = "";
+  let orgId = "";
 
   try {
     const body = await requestClone.json();
     query = body.query || "";
+    orgId = body.variables?.orgId || "";
 
     // TODO(jabolo): Use a real parser to extract operation type and name
     if (query.includes("query")) {
@@ -106,40 +109,32 @@ const customHandler = async (req: NextRequest) => {
   } catch (error) {
     logger.error("Error parsing GraphQL request body:", error);
   }
-  console.log(operation);
-  // if (user.role === "anonymous") {
-  //   logger.log(`/api/graphql: User is anonymous`);
-  //   return NextResponse.json(
-  //     { errors: [{ message: "Authentication required" }] },
-  //     { status: 401 },
-  //   );
-  // }
-  //
-  // const orgId = await CreditsService.getUserPrimaryOrganization(user.userId);
-  // if (!orgId) {
-  //   logger.log(`/api/graphql: User ${user.userId} has no organization`);
-  //   return NextResponse.json(
-  //     { errors: [{ message: "User must be part of an organization" }] },
-  //     { status: 403 },
-  //   );
-  // }
+  if (user.role !== "anonymous") {
+    if (!orgId) {
+      logger.log(`/api/graphql: Missing orgId`);
+      return NextResponse.json(
+        { errors: [{ message: "Organization ID is required" }] },
+        { status: 400 },
+      );
+    }
 
-  // const creditsDeducted =
-  //   await CreditsService.checkAndDeductOrganizationCredits(
-  //     user,
-  //     orgId,
-  //     TransactionType.GRAPHQL_QUERY,
-  //     "/api/v1/graphql",
-  //     { operation, query },
-  //   );
+    const creditsDeducted =
+      await CreditsService.checkAndDeductOrganizationCredits(
+        user,
+        orgId,
+        TransactionType.GRAPHQL_QUERY,
+        "/api/v1/graphql",
+        { operation, query },
+      );
 
-  // if (!creditsDeducted) {
-  //   logger.log(`/api/graphql: Insufficient credits for user ${user.userId}`);
-  //   return NextResponse.json(
-  //     { errors: [{ message: "Insufficient credits" }] },
-  //     { status: 402 },
-  //   );
-  // }
+    if (!creditsDeducted) {
+      logger.log(`/api/graphql: Insufficient credits for user ${user.userId}`);
+      return NextResponse.json(
+        { errors: [{ message: "Insufficient credits" }] },
+        { status: 402 },
+      );
+    }
+  }
 
   const apolloHandler = startServerAndCreateNextHandler<NextRequest>(server, {
     context: async () => {


### PR DESCRIPTION
This PR closes #4209 and fixes #4207 by adding back tracking, without enforcing org belonging