### PR TITLE
fix: encode new lines in the chat interface

### DIFF
--- a/warehouse/oso_agent/oso_agent/datasets/uploader.py
+++ b/warehouse/oso_agent/oso_agent/datasets/uploader.py
@@ -58,6 +58,7 @@ def upload_dataset(phoenix_client: px.Client, code_examples: ExampleList, datase
         # if it does and we aren't running on a subset, diff and append
         if example_ids is None:
             diff = diff_datasets(dataset, selected_code_examples)
+            logger.info(f"Found {len(diff.examples)} new examples to append to dataset '{dataset_name}'")
             if len(diff) > 0:
                 dataset = phoenix_client.append_to_dataset(
                     dataset_name=dataset_name,

--- a/warehouse/oso_agent/oso_agent/server/app.py
+++ b/warehouse/oso_agent/oso_agent/server/app.py
@@ -123,9 +123,12 @@ def setup_app(config: AgentServerConfig, lifespan: t.Callable[[FastAPI], t.Any])
         message_id = str(uuid.uuid4())
         lines.append(f'f:{{"messageId":"{message_id}"}}\n')
 
-        for line in response_str.split("\n"):
-            escaped_line = json.dumps(line)
-            lines.append(f"0:{escaped_line}\n")
+        # Split the response into substrings of N characters and escape
+        # newlines for json
+        for i in range(0, len(response_str), config.chat_line_length):
+            substring = response_str[i:i + config.chat_line_length]
+            escaped_substring = json.dumps(substring)
+            lines.append(f"0:{escaped_substring}\n")
 
         lines.append(
             'd:{"finishReason":"stop","usage":{"promptTokens":0,"completionTokens":0}}\n'

--- a/warehouse/oso_agent/oso_agent/util/config.py
+++ b/warehouse/oso_agent/oso_agent/util/config.py
@@ -107,6 +107,11 @@ class AgentConfig(BaseSettings):
         description="Arize Phoenix dataset for text2sql evaluations",
     )
 
+    chat_line_length: int = Field(
+        default=50,
+        description="Maximum number of characters per line in chat messages",
+    )
+
     @model_validator(mode="after")
     def validate_urls(self) -> "AgentConfig":
         """Ensure URLs are properly formatted."""


### PR DESCRIPTION
I _think_ this might work to get new lines in the chat protocol. We just need to encode them as they're json parsed strings. 