### PR TITLE
refactor(sqlmesh): update SBOM models to incremental and maintain snapshot dates

### DIFF
--- a/warehouse/oso_sqlmesh/models/intermediate/entities/artifacts/packages/int_packages__current_maintainer_only.sql
+++ b/warehouse/oso_sqlmesh/models/intermediate/entities/artifacts/packages/int_packages__current_maintainer_only.sql
@@ -1,0 +1,18 @@
+MODEL (
+  name oso.int_packages__current_maintainer_only,
+  kind VIEW,
+  audits (
+    has_at_least_n_rows(threshold := 0)
+  )
+);
+
+
+SELECT DISTINCT
+  package_artifact_source,
+  sbom_artifact_source,
+  package_artifact_name,
+  package_github_owner,
+  package_github_repo,
+  package_url
+FROM oso.int_packages
+WHERE is_current_owner = TRUE

--- a/warehouse/oso_sqlmesh/models/intermediate/entities/artifacts/packages/int_sbom__latest_snapshot.sql
+++ b/warehouse/oso_sqlmesh/models/intermediate/entities/artifacts/packages/int_sbom__latest_snapshot.sql
@@ -1,0 +1,39 @@
+MODEL (
+  name oso.int_sbom__latest_snapshot,
+  description 'The most recent snapshot of SBOMs linked to package owner GitHub repos',
+  kind VIEW,
+  audits (
+    has_at_least_n_rows(threshold := 0)
+  )
+);
+
+WITH latest_repo_snapshot AS (
+  SELECT
+    dependent_repo_artifact_id,
+    MAX(snapshot_day) AS snapshot_day
+  FROM oso.int_sbom__snapshots
+  GROUP BY 1
+),
+
+latest_sboms AS (
+  SELECT *
+  FROM oso.int_sbom__snapshots AS sbom
+  JOIN latest_repo_snapshot AS latest
+    ON sbom.dependent_repo_artifact_id = latest.dependent_repo_artifact_id
+    AND sbom.snapshot_day >= (latest.snapshot_day - INTERVAL '1 DAY')
+)
+
+SELECT DISTINCT
+  snapshot_day,
+  artifact_source,
+  artifact_namespace,
+  artifact_name,
+  package_source,
+  package,
+  package_version,
+  package_github_owner,
+  package_github_repo,
+  dependent_repo_artifact_id,
+  dependency_repo_artifact_id,
+  dependency_package_artifact_id
+FROM latest_sboms

--- a/warehouse/oso_sqlmesh/models/intermediate/entities/artifacts/packages/int_sbom__latest_snapshot.sql
+++ b/warehouse/oso_sqlmesh/models/intermediate/entities/artifacts/packages/int_sbom__latest_snapshot.sql
@@ -13,27 +13,22 @@ WITH latest_repo_snapshot AS (
     MAX(snapshot_day) AS snapshot_day
   FROM oso.int_sbom__snapshots
   GROUP BY 1
-),
-
-latest_sboms AS (
-  SELECT *
-  FROM oso.int_sbom__snapshots AS sbom
-  JOIN latest_repo_snapshot AS latest
-    ON sbom.dependent_repo_artifact_id = latest.dependent_repo_artifact_id
-    AND sbom.snapshot_day >= (latest.snapshot_day - INTERVAL '1 DAY')
 )
 
 SELECT DISTINCT
-  snapshot_day,
-  artifact_source,
-  artifact_namespace,
-  artifact_name,
-  package_source,
-  package,
-  package_version,
-  package_github_owner,
-  package_github_repo,
-  dependent_repo_artifact_id,
-  dependency_repo_artifact_id,
-  dependency_package_artifact_id
-FROM latest_sboms
+  sbom.snapshot_day,
+  sbom.artifact_source,
+  sbom.artifact_namespace,
+  sbom.artifact_name,
+  sbom.package_source,
+  sbom.package,
+  sbom.package_version,
+  sbom.package_github_owner,
+  sbom.package_github_repo,
+  sbom.dependent_repo_artifact_id,
+  sbom.dependency_repo_artifact_id,
+  sbom.dependency_package_artifact_id
+FROM oso.int_sbom__snapshots AS sbom
+JOIN latest_repo_snapshot AS latest
+  ON sbom.dependent_repo_artifact_id = latest.dependent_repo_artifact_id
+  AND sbom.snapshot_day >= (latest.snapshot_day - INTERVAL '1 DAY')

--- a/warehouse/oso_sqlmesh/models/intermediate/entities/artifacts/packages/int_sbom__snapshots.sql
+++ b/warehouse/oso_sqlmesh/models/intermediate/entities/artifacts/packages/int_sbom__snapshots.sql
@@ -1,0 +1,45 @@
+MODEL (
+  name oso.int_sbom__snapshots,
+  description 'SBOMs linked to package owner GitHub repos',
+  dialect trino,
+  kind FULL,
+  partitioned_by (DAY("snapshot_day"), "package_source"),
+  audits (
+    has_at_least_n_rows(threshold := 0)
+  ),
+);
+
+WITH sboms AS (
+  SELECT DISTINCT
+    DATE_TRUNC('DAY', sbom.snapshot_at) AS snapshot_day,
+    sbom.artifact_source,
+    sbom.artifact_namespace,
+    sbom.artifact_name,
+    sbom.package_source,
+    sbom.package,
+    sbom.package_version,
+    packages.package_github_owner,
+    packages.package_github_repo
+  FROM oso.stg_ossd__current_sbom AS sbom
+  LEFT JOIN oso.int_packages__current_maintainer_only AS packages
+    ON sbom.package_source = packages.sbom_artifact_source
+    AND sbom.package = packages.package_artifact_name
+)
+
+SELECT
+  snapshot_day,
+  artifact_source,
+  artifact_namespace,
+  artifact_name,
+  package_source,
+  package,
+  package_version,
+  package_github_owner,
+  package_github_repo,
+  @oso_entity_id(artifact_source, artifact_namespace, artifact_name)
+    AS dependent_repo_artifact_id,
+  @oso_entity_id(artifact_source, package_github_owner, package_github_repo)
+    AS dependency_repo_artifact_id,
+  @oso_entity_id(package_source, '', package)
+    AS dependency_package_artifact_id
+FROM sboms

--- a/warehouse/oso_sqlmesh/models/intermediate/entities/artifacts/packages/int_sbom_artifacts.sql
+++ b/warehouse/oso_sqlmesh/models/intermediate/entities/artifacts/packages/int_sbom_artifacts.sql
@@ -35,9 +35,7 @@ WITH ranked_snapshots AS (
     package_artifact_name,
     package_github_owner,
     package_github_repo
-  FROM oso.int_packages
-  WHERE
-    is_current_owner = TRUE
+  FROM oso.int_packages__current_maintainer_only
 )
 SELECT
   all_repos.project_id, /*

--- a/warehouse/oso_sqlmesh/models/staging/oss-directory/stg_ossd__current_sbom.sql
+++ b/warehouse/oso_sqlmesh/models/staging/oss-directory/stg_ossd__current_sbom.sql
@@ -1,33 +1,36 @@
 MODEL (
   name oso.stg_ossd__current_sbom,
-  description 'The most recent view of sboms from the ossd dagster source',
+  description 'SBOM snapshots from the OSSD dagster source',
   dialect trino,
-  kind FULL,
+  kind INCREMENTAL_BY_TIME_RANGE (
+    time_column snapshot_at,
+    batch_size 180,
+    batch_concurrency 2,
+    lookback 31,
+    forward_only true,
+  ),
+  cron '@weekly',
+  partitioned_by (DAY("snapshot_at"), "package_source"),
   audits (
     has_at_least_n_rows(threshold := 0)
-  )
+  ),
+  ignored_rules (
+    "incrementalmustdefinenogapsaudit",
+  ),
+  tags (
+    "ossd",
+    "incremental",
+  ),
 );
 
-WITH ranked_sboms AS (
-  SELECT
-    snapshot_at,
-    LOWER(artifact_namespace) AS artifact_namespace,
-    LOWER(artifact_name) AS artifact_name,
-    UPPER(artifact_source) AS artifact_source,
-    LOWER(package) AS package,
-    UPPER(package_source) AS package_source,
-    LOWER(package_version) AS package_version,
-    ROW_NUMBER() OVER (PARTITION BY artifact_namespace, artifact_name, artifact_source, package, package_source ORDER BY snapshot_at DESC) AS row_num
-  FROM @oso_source('bigquery.ossd.sbom')
-)
-SELECT
-  artifact_namespace,
-  artifact_name,
-  artifact_source,
-  package,
-  package_source,
-  package_version,
-  snapshot_at
-FROM ranked_sboms
-WHERE
-  row_num = 1
+
+SELECT DISTINCT
+  snapshot_at::TIMESTAMP AS snapshot_at,
+  LOWER(artifact_namespace) AS artifact_namespace,
+  LOWER(artifact_name) AS artifact_name,
+  UPPER(artifact_source) AS artifact_source,
+  LOWER(package) AS package,
+  UPPER(package_source) AS package_source,
+  LOWER(package_version) AS package_version
+FROM @oso_source('bigquery.ossd.sbom')
+WHERE snapshot_at BETWEEN @start_dt AND @end_dt


### PR DESCRIPTION
### PR Summary

This pull request introduces new intermediate models and refactors how Software Bill of Materials (SBOM) snapshots and package maintainer data are processed within the SQLMesh data warehouse, specifically under the `warehouse/oso_sqlmesh/models/intermediate/entities/artifacts/packages/` directory. The main changes include:

1. **New Models Added:**
   - **`int_packages__current_maintainer_only.sql`**  
     - Extracts current maintainers from `oso.int_packages` into a dedicated view for easier and consistent downstream usage.
   - **`int_sbom__snapshots.sql`**  
     - Creates a partitioned, full model representing SBOMs linked to package owner GitHub repos, joining current maintainer info.
   - **`int_sbom__latest_snapshot.sql`**  
     - Provides a view of the most recent SBOM snapshot for each dependent repository artifact.

2. **Refactoring Existing Models:**
   - **`int_sbom_artifacts.sql`**  
     - Refactored to use the new `int_packages__current_maintainer_only` view instead of filtering directly on `is_current_owner` in `oso.int_packages`.
   - **`stg_ossd__current_sbom.sql`**  
     - Switched to an incremental model, partitioned by day and package source, with improved tags and ignored rules. The logic now selects distinct records within a date range, ensuring efficient incremental loads.

### Issues Addressed

- **Redundancy and Reusability:**  
  By extracting current maintainer logic into its own view (`int_packages__current_maintainer_only`), duplicate filtering logic is avoided and downstream models become easier to maintain.
- **Performance and Partitioning:**  
  The `stg_ossd__current_sbom` table now supports incremental loading and partitioned processing, improving performance and scalability for large SBOM datasets.
- **Data Freshness and Consistency:**  
  The introduction of `int_sbom__snapshots` and `int_sbom__latest_snapshot` ensures that downstream consumers can easily access both historical and latest SBOM data, joined with package maintainer info in a standardized way.

### Expected Impact on Downstream Models

- **Downstream models that previously read directly from `oso.int_packages` with `is_current_owner = TRUE` should now use `oso.int_packages__current_maintainer_only` for consistency.**
- **Models consuming SBOM data (`stg_ossd__current_sbom`, `int_sbom_artifacts`, etc.) will benefit from improved performance due to partitioning and incremental loading.**
- **The new intermediate models enable easier composition for reporting and analytics on SBOM and package maintainer relationships.**
- **Any model or dashboard relying on SBOM snapshots or package maintainer info will see more up-to-date and accurate data, with clearer lineage and reduced risk of stale joins.**

**Overall, this PR improves modularity, efficiency, and correctness in the processing pipeline for SBOM and package maintainer analytics.**