### PR TITLE
feat(cli): add option to keep Docker containers running after sqlmesh test

### DIFF
--- a/warehouse/oso_lets_go/cli.py
+++ b/warehouse/oso_lets_go/cli.py
@@ -769,7 +769,8 @@ def reset(
 )
 @click.pass_context
 @click.option("--duckdb/--no-duckdb", default=False)
-def sqlmesh_test(ctx: click.Context, duckdb: bool):
+@click.option("--keep-containers/--no-keep-containers", default=False, help="Keep Docker containers running after test completion")
+def sqlmesh_test(ctx: click.Context, duckdb: bool, keep_containers: bool):
     extra_args = ctx.args
     if not ctx.args:
         extra_args = []
@@ -811,7 +812,10 @@ def sqlmesh_test(ctx: click.Context, duckdb: bool):
             )
 
         finally:
-            docker_client.compose.down()
+            if not keep_containers:
+                docker_client.compose.down()
+            else:
+                logger.info("Keeping Docker containers running (--keep-containers flag set)")
 
 
 @local.command()

--- a/warehouse/oso_sqlmesh/README.md
+++ b/warehouse/oso_sqlmesh/README.md
@@ -172,6 +172,12 @@ docker compose up --wait
 This will open up a web server to interact with Trino directly at
 `http://127.0.0.1:8080`.
 
+Then, you can run sqlmesh with the test seed data again without shutting down the docker containers.
+
+```bash
+oso local sqlmesh-test plan dev --start '1 week' --end now --keep-containers
+```
+
 This is also a good way if you want to keep running sqlmesh on top of the same containers
 instead of recreating them every time. To initialize the data you can run:
 


### PR DESCRIPTION
# Why?

If the user want to debug on trino UI locally, the user would fail if using the following commands:

``` bash
cd warehouse
docker compose up --wait
oso local sqlmesh-test plan dev --start '1 week' --end now
```

This is because the sqlmesh-test will shutdown the docker containers by default as last step; however, this would be confusing to users who followed the readme and tried to debug (and frustrating since it took loooong to run, but all the logs are gone after the run)

# What the PR does

Add a flag `--keep-containers` and default value=false so wont affect the actions pipeline.