### PR TITLE
chore: run uv sync

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -2487,7 +2487,7 @@ wheels = [
 
 [[package]]
 name = "kr8s"
-version = "0.20.7"
+version = "0.20.9"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -2500,9 +2500,9 @@ dependencies = [
     { name = "pyyaml" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/05/f5/cda575c218d331cbf6fa3b8dd992f3b8f908bf13d1b7a4ba6afd97535cd4/kr8s-0.20.7.tar.gz", hash = "sha256:ac45e966beea0f6f92f635b3e61e64b8e27962b4825d77b814a663e819a8ec16", size = 2858691, upload-time = "2025-04-28T10:05:47.199Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/66/a8114ac587439c328f1c12ead34e58620a680ccdf89cb82c671e882dcbfa/kr8s-0.20.9.tar.gz", hash = "sha256:e8a840a4ecffa6bfe3351d47aeb6b5824dbb7eed9938593c2327d5253f7b13a3", size = 2888491, upload-time = "2025-07-08T17:31:02.399Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2a/66/92a695d3640073cec7469db1583034b0fb742629cb502c58bda5de985b8b/kr8s-0.20.7-py3-none-any.whl", hash = "sha256:e489b97ff513c167f427f479ad5420c78adffd1a6ce5033b079109374200c0c6", size = 77300, upload-time = "2025-04-28T10:05:45.696Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/10/8dd3f680054f6384141c61dc33b96ce47824e91546e235cceeeff3dfcc73/kr8s-0.20.9-py3-none-any.whl", hash = "sha256:f176ea23b4bde3a5ae559610c960321b4d309d5a29b4c82592a349beb1cbc30d", size = 78770, upload-time = "2025-07-08T17:31:00.636Z" },
 ]
 
 [[package]]
@@ -3158,7 +3158,7 @@ requires-dist = [
     { name = "aiotrino", specifier = ">=0.2.3,<1.0.0" },
     { name = "arrow", specifier = ">=1.3.0,<2.0.0" },
     { name = "bokeh", specifier = ">=3.6.1,<4.0.0" },
-    { name = "boltons", specifier = ">=24.0.0,<25.0.0" },
+    { name = "boltons", specifier = ">=24.0.0,<26.0.0" },
     { name = "click", specifier = ">=8.1.7,<9.0.0" },
     { name = "clickhouse-connect", specifier = ">=0.7.16,<1.0.0" },
     { name = "cloud-sql-python-connector", extras = ["pg8000"], specifier = ">=1.6.0,<2.0.0" },
@@ -3173,7 +3173,7 @@ requires-dist = [
     { name = "dagster-polars", specifier = ">=0.24.0,<1.0.0" },
     { name = "dagster-postgres", specifier = ">=0.24.0,<1.0.0" },
     { name = "dagster-webserver", specifier = ">=1.7.16,<2.0.0" },
-    { name = "dask", extras = ["distributed"], specifier = ">=2024.4.2,<2025.5.0" },
+    { name = "dask", extras = ["distributed"], specifier = ">=2024.4.2,<2025.6.0" },
     { name = "dask-kubernetes", specifier = ">=2024.4.2,<2025.5.0" },
     { name = "discord-webhook", specifier = ">=1.3.1,<2.0.0" },
     { name = "dlt", specifier = ">=1.3.0,<2.0.0" },
@@ -3181,7 +3181,7 @@ requires-dist = [
     { name = "duckdb", specifier = ">=1.1.0,<2.0.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.115.6,<1.0.0" },
     { name = "gcloud-aio-storage", specifier = ">=9.3.0,<10.0.0" },
-    { name = "gcsfs", specifier = ">=2024.6.1,<2025.0.0" },
+    { name = "gcsfs", specifier = ">=2024.6.1,<2026.0.0" },
     { name = "githubkit", specifier = ">=0.12.4,<1.0.0" },
     { name = "gitpython", specifier = ">=3.1.44,<4.0.0" },
     { name = "google-api-python-client", specifier = ">=2.116.0,<3.0.0" },
@@ -3195,7 +3195,7 @@ requires-dist = [
     { name = "google-cloud-service-usage", specifier = ">=1.10.3,<2.0.0" },
     { name = "google-cloud-storage", specifier = ">=2.14.0,<3.0.0" },
     { name = "isort", specifier = ">=5.13.2,<6.0.0" },
-    { name = "kr8s", specifier = "==0.20.7" },
+    { name = "kr8s", specifier = "==0.20.9" },
     { name = "lz4", specifier = ">=4.3.3,<5.0.0" },
     { name = "minio", specifier = ">=7.2.15,<8.0.0" },
     { name = "openrank-sdk", specifier = ">=0.4.0,<1.0.0" },
@@ -3727,7 +3727,7 @@ requires-dist = [
     { name = "aiotrino", specifier = ">=0.2.3,<1.0.0" },
     { name = "arrow", specifier = ">=1.3.0,<2.0.0" },
     { name = "bokeh", specifier = ">=3.6.1,<4.0.0" },
-    { name = "boltons", specifier = ">=24.0.0,<25.0.0" },
+    { name = "boltons", specifier = ">=24.0.0,<26.0.0" },
     { name = "click", specifier = ">=8.1.7,<9.0.0" },
     { name = "clickhouse-connect", specifier = ">=0.7.16,<1.0.0" },
     { name = "cloud-sql-python-connector", extras = ["pg8000"], specifier = ">=1.6.0,<2.0.0" },
@@ -3743,7 +3743,7 @@ requires-dist = [
     { name = "dagster-postgres", specifier = ">=0.24.0,<1.0.0" },
     { name = "dagster-sqlmesh", specifier = "==0.17.0" },
     { name = "dagster-webserver", specifier = ">=1.7.16,<2.0.0" },
-    { name = "dask", extras = ["distributed"], specifier = ">=2024.4.2,<2025.5.0" },
+    { name = "dask", extras = ["distributed"], specifier = ">=2024.4.2,<2025.6.0" },
     { name = "dask-kubernetes", specifier = ">=2024.4.2,<2025.5.0" },
     { name = "discord-webhook", specifier = ">=1.3.1,<2.0.0" },
     { name = "dlt", specifier = ">=1.3.0,<2.0.0" },
@@ -3751,7 +3751,7 @@ requires-dist = [
     { name = "duckdb", specifier = ">=1.1.0,<2.0.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.115.6,<1.0.0" },
     { name = "gcloud-aio-storage", specifier = ">=9.3.0,<10.0.0" },
-    { name = "gcsfs", specifier = ">=2024.6.1,<2025.0.0" },
+    { name = "gcsfs", specifier = ">=2024.6.1,<2026.0.0" },
     { name = "githubkit", specifier = ">=0.12.13,<1.0.0" },
     { name = "gitpython", specifier = ">=3.1.44,<4.0.0" },
     { name = "google-api-python-client", specifier = ">=2.116.0,<3.0.0" },
@@ -3765,7 +3765,7 @@ requires-dist = [
     { name = "google-cloud-service-usage", specifier = ">=1.10.3,<2.0.0" },
     { name = "google-cloud-storage", specifier = ">=2.14.0,<3.0.0" },
     { name = "isort", specifier = ">=5.13.2,<6.0.0" },
-    { name = "kr8s", specifier = "==0.20.7" },
+    { name = "kr8s", specifier = "==0.20.9" },
     { name = "lz4", specifier = ">=4.3.3,<5.0.0" },
     { name = "minio", specifier = ">=7.2.15,<8.0.0" },
     { name = "openrank-sdk", specifier = ">=0.4.0,<1.0.0" },
@@ -3926,7 +3926,7 @@ requires-dist = [
     { name = "aiotrino", specifier = ">=0.2.3,<1.0.0" },
     { name = "arrow", specifier = ">=1.3.0,<2.0.0" },
     { name = "bokeh", specifier = ">=3.6.1,<4.0.0" },
-    { name = "boltons", specifier = ">=24.0.0,<25.0.0" },
+    { name = "boltons", specifier = ">=24.0.0,<26.0.0" },
     { name = "click", specifier = ">=8.1.7,<9.0.0" },
     { name = "clickhouse-connect", specifier = ">=0.7.16,<1.0.0" },
     { name = "cloud-sql-python-connector", extras = ["pg8000"], specifier = ">=1.6.0,<2.0.0" },
@@ -3941,7 +3941,7 @@ requires-dist = [
     { name = "dagster-polars", specifier = ">=0.24.0,<1.0.0" },
     { name = "dagster-postgres", specifier = ">=0.24.0,<1.0.0" },
     { name = "dagster-webserver", specifier = ">=1.7.16,<2.0.0" },
-    { name = "dask", extras = ["distributed"], specifier = ">=2024.4.2,<2025.5.0" },
+    { name = "dask", extras = ["distributed"], specifier = ">=2024.4.2,<2025.6.0" },
     { name = "dask-kubernetes", specifier = ">=2024.4.2,<2025.5.0" },
     { name = "discord-webhook", specifier = ">=1.3.1,<2.0.0" },
     { name = "dlt", specifier = ">=1.3.0,<2.0.0" },
@@ -3949,7 +3949,7 @@ requires-dist = [
     { name = "duckdb", specifier = ">=1.1.0,<2.0.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.115.6,<1.0.0" },
     { name = "gcloud-aio-storage", specifier = ">=9.3.0,<10.0.0" },
-    { name = "gcsfs", specifier = ">=2024.6.1,<2025.0.0" },
+    { name = "gcsfs", specifier = ">=2024.6.1,<2026.0.0" },
     { name = "githubkit", specifier = ">=0.12.4,<1.0.0" },
     { name = "gitpython", specifier = ">=3.1.44,<4.0.0" },
     { name = "google-api-python-client", specifier = ">=2.116.0,<3.0.0" },
@@ -3963,7 +3963,7 @@ requires-dist = [
     { name = "google-cloud-service-usage", specifier = ">=1.10.3,<2.0.0" },
     { name = "google-cloud-storage", specifier = ">=2.14.0,<3.0.0" },
     { name = "isort", specifier = ">=5.13.2,<6.0.0" },
-    { name = "kr8s", specifier = "==0.20.7" },
+    { name = "kr8s", specifier = "==0.20.9" },
     { name = "lz4", specifier = ">=4.3.3,<5.0.0" },
     { name = "minio", specifier = ">=7.2.15,<8.0.0" },
     { name = "openrank-sdk", specifier = ">=0.4.0,<1.0.0" },


### PR DESCRIPTION
When merging PR's from dependabot, since we use uv, we need to run `uv sync` to update the `uv.lock` file. This will change when dependabot supports more uv features (e.g: https://github.com/dependabot/dependabot-core/issues/12072)