### PR TITLE
fix: make Plasmic components resistent to CSS re-ordering

### DIFF
--- a/apps/docs/docs/index.mdx
+++ b/apps/docs/docs/index.mdx
@@ -4,6 +4,9 @@ sidebar_position: 0
 hide_title: true
 ---
 
-import Overview from '@site/src/components/plasmic/Overview';
+import { PlasmicRootProvider } from "@plasmicapp/react-web";
+import Overview from "@site/src/components/plasmic/Overview";
 
-<Overview />
+<PlasmicRootProvider>
+  <Overview /> 
+</PlasmicRootProvider>

--- a/apps/docs/docusaurus.config.ts
+++ b/apps/docs/docusaurus.config.ts
@@ -53,11 +53,12 @@ const config: Config = {
           blogSidebarCount: "ALL",
           blogTagsPostsComponent: "@site/src/components/BlogTagsPostsPage.tsx",
         },
-        theme: {
-          customCss: "./src/css/custom.css",
-        },
         gtag: {
           trackingID: GOOGLE_ANALYTICS_KEY,
+          //anonymizeIP: true, // Should we anonymize the IP?
+        },
+        theme: {
+          customCss: "./src/css/custom.css",
         },
       } satisfies Preset.Options,
     ],

--- a/apps/docs/plasmic.lock
+++ b/apps/docs/plasmic.lock
@@ -2,7 +2,7 @@
   "projects": [
     {
       "projectId": "2CtczDeUz9jL9qnFi6NWuQ",
-      "version": "1.0.1",
+      "version": "1.0.6",
       "dependencies": {
         "caTPwKxj5ZrD9LQ7DMdK4Z": "3.42.0"
       },
@@ -16,12 +16,12 @@
         {
           "type": "renderModule",
           "assetId": "z50hW5Ihi9k5",
-          "checksum": "5b7a69da4bc697b84c3dadd74f17db10"
+          "checksum": "a5b4233f7fae6f91ddc04c192205c3b5"
         },
         {
           "type": "cssRules",
           "assetId": "z50hW5Ihi9k5",
-          "checksum": "5b7a69da4bc697b84c3dadd74f17db10"
+          "checksum": "a5b4233f7fae6f91ddc04c192205c3b5"
         },
         {
           "type": "renderModule",
@@ -36,12 +36,12 @@
         {
           "type": "renderModule",
           "assetId": "XdMR0R8lmSdz",
-          "checksum": "f2a3e47f155a5a26bf2bd9c3413a239c"
+          "checksum": "7e4ac15881686ce7f5933c3d46a8256d"
         },
         {
           "type": "cssRules",
           "assetId": "XdMR0R8lmSdz",
-          "checksum": "f2a3e47f155a5a26bf2bd9c3413a239c"
+          "checksum": "7e4ac15881686ce7f5933c3d46a8256d"
         },
         {
           "type": "icon",
@@ -66,12 +66,12 @@
         {
           "type": "renderModule",
           "assetId": "_F-nuwBX0XMK",
-          "checksum": "abac8c64769ed0b7fa8fb9c4149e29e2"
+          "checksum": "4f80293959dfd18268378ff04fb6ebca"
         },
         {
           "type": "cssRules",
           "assetId": "_F-nuwBX0XMK",
-          "checksum": "abac8c64769ed0b7fa8fb9c4149e29e2"
+          "checksum": "4f80293959dfd18268378ff04fb6ebca"
         },
         {
           "type": "image",

--- a/apps/docs/src/components/plasmic/Overview.tsx
+++ b/apps/docs/src/components/plasmic/Overview.tsx
@@ -25,6 +25,7 @@ export interface OverviewProps extends DefaultOverviewProps {}
 
 function Overview_(props: OverviewProps, ref: HTMLElementRefOf<"div">) {
   const color = useColorMode();
+  console.log(color.colorMode);
   // Use PlasmicOverview to render this component as it was
   // designed in Plasmic, by activating the appropriate variants,
   // attaching the appropriate event handlers, etc.  You

--- a/apps/docs/src/components/plasmic/Overview.tsx
+++ b/apps/docs/src/components/plasmic/Overview.tsx
@@ -25,7 +25,7 @@ export interface OverviewProps extends DefaultOverviewProps {}
 
 function Overview_(props: OverviewProps, ref: HTMLElementRefOf<"div">) {
   const color = useColorMode();
-  console.log(color.colorMode);
+  //console.log(color.colorMode);
   // Use PlasmicOverview to render this component as it was
   // designed in Plasmic, by activating the appropriate variants,
   // attaching the appropriate event handlers, etc.  You

--- a/apps/docs/src/components/plasmic/generated/docs_opensource_observer/PlasmicCard.tsx
+++ b/apps/docs/src/components/plasmic/generated/docs_opensource_observer/PlasmicCard.tsx
@@ -183,6 +183,7 @@ function PlasmicCard__RenderFunc(props: {
           data-plasmic-override={overrides.freeBox}
           className={classNames(projectcss.all, sty.freeBox, {
             [sty.freeBoxnoTitle]: hasVariant($state, "noTitle", "noTitle"),
+            [sty.freeBoxtheme_dark]: hasVariant($state, "theme", "dark"),
           })}
         >
           {renderPlasmicSlot({

--- a/apps/docs/src/components/plasmic/generated/docs_opensource_observer/PlasmicLinkCard.module.css
+++ b/apps/docs/src/components/plasmic/generated/docs_opensource_observer/PlasmicLinkCard.module.css
@@ -9,10 +9,11 @@
   background: #ffffffcc;
   box-shadow: 0px 0px 4px 0px #0000001a;
   min-height: 64px;
+  color: var(--token-gN119pN46HXv);
   border-radius: 8px;
 }
 .roottheme_dark {
-  background: var(--token-7AdcKFArKr7V);
+  background: #ffffff1a;
 }
 .icon {
   display: flex;
@@ -74,7 +75,6 @@
 }
 .slotTargetTitle {
   font-weight: 700;
-  font-size: var(--antd-fontSizeHeading5);
 }
 .slotTargetTitletheme_dark {
   color: var(--token-WcqAzrLgrO6X);
@@ -96,21 +96,13 @@
   align-items: flex-start;
   justify-content: flex-start;
 }
+.slotTargetChildrentheme_dark {
+  color: var(--token-WcqAzrLgrO6X);
+}
 .text___2AACg {
   position: relative;
   width: 100%;
   height: auto;
   max-width: 100%;
-  color: var(--antd-colorBgContainer);
-  font-size: var(--antd-fontSizeSM);
   min-width: 0;
-}
-.text__m0Woh {
-  position: relative;
-  width: 100%;
-  height: auto;
-  max-width: 100%;
-  color: var(--token-gN119pN46HXv);
-  min-width: 0;
-  display: none;
 }

--- a/apps/docs/src/components/plasmic/generated/docs_opensource_observer/PlasmicLinkCard.tsx
+++ b/apps/docs/src/components/plasmic/generated/docs_opensource_observer/PlasmicLinkCard.tsx
@@ -232,6 +232,7 @@ function PlasmicLinkCard__RenderFunc(props: {
         data-plasmic-override={overrides.header}
         className={classNames(projectcss.all, sty.header, {
           [sty.headernoTitle]: hasVariant($state, "noTitle", "noTitle"),
+          [sty.headertheme_dark]: hasVariant($state, "theme", "dark"),
         })}
       >
         <div
@@ -240,6 +241,11 @@ function PlasmicLinkCard__RenderFunc(props: {
               $state,
               "noTitle",
               "noTitle",
+            ),
+            [sty.freeBoxtheme_dark__djG7FGyFc5]: hasVariant(
+              $state,
+              "theme",
+              "dark",
             ),
           })}
         >
@@ -261,32 +267,29 @@ function PlasmicLinkCard__RenderFunc(props: {
         data-plasmic-override={overrides.body}
         className={classNames(projectcss.all, sty.body, {
           [sty.bodynoTitle]: hasVariant($state, "noTitle", "noTitle"),
+          [sty.bodytheme_dark]: hasVariant($state, "theme", "dark"),
         })}
       >
         {renderPlasmicSlot({
           defaultContents: (
-            <React.Fragment>
-              <div
-                className={classNames(
-                  projectcss.all,
-                  projectcss.__wab_text,
-                  sty.text___2AACg,
-                )}
-              >
-                {"something here"}
-              </div>
-              <div
-                className={classNames(
-                  projectcss.all,
-                  projectcss.__wab_text,
-                  sty.text__m0Woh,
-                )}
-              >
-                {"something here"}
-              </div>
-            </React.Fragment>
+            <div
+              className={classNames(
+                projectcss.all,
+                projectcss.__wab_text,
+                sty.text___2AACg,
+              )}
+            >
+              {"something here"}
+            </div>
           ),
           value: args.children,
+          className: classNames(sty.slotTargetChildren, {
+            [sty.slotTargetChildrentheme_dark]: hasVariant(
+              $state,
+              "theme",
+              "dark",
+            ),
+          }),
         })}
       </div>
     </PlasmicLink__>

--- a/apps/docs/src/components/plasmic/generated/docs_opensource_observer/PlasmicOverview.module.css
+++ b/apps/docs/src/components/plasmic/generated/docs_opensource_observer/PlasmicOverview.module.css
@@ -281,9 +281,7 @@
   width: 100%;
   height: auto;
   max-width: 100%;
-  color: var(--token-gN119pN46HXv);
   padding-bottom: 0px;
-  font-size: var(--antd-fontSizeSM);
   min-width: 0;
 }
 .texttheme_dark__dW9MzswWww {
@@ -326,9 +324,7 @@
   width: 100%;
   height: auto;
   max-width: 100%;
-  color: var(--token-gN119pN46HXv);
   padding-bottom: 0px;
-  font-size: var(--antd-fontSizeSM);
   min-width: 0;
 }
 .texttheme_dark__p4QzWswWww {
@@ -371,9 +367,7 @@
   width: 100%;
   height: auto;
   max-width: 100%;
-  color: var(--token-gN119pN46HXv);
   padding-bottom: 0px;
-  font-size: var(--antd-fontSizeSM);
   padding-left: 0px;
   min-width: 0;
 }
@@ -531,9 +525,7 @@
   width: 100%;
   height: auto;
   max-width: 100%;
-  color: var(--antd-colorInfoText);
   font-weight: 700;
-  font-size: var(--antd-fontSizeHeading5);
   padding-left: 14px;
   min-width: 0;
 }
@@ -545,103 +537,46 @@
   width: 100%;
   min-width: 0;
 }
-.img__a4DW {
-  object-fit: cover;
-  max-width: 50px;
-  height: 50px;
-}
-.img__a4DW > picture > img {
-  object-fit: cover;
-}
 .text__zAjRu {
   position: relative;
   width: 100%;
   height: auto;
   max-width: 100%;
-  color: var(--token-gN119pN46HXv);
-  font-size: var(--antd-fontSizeSM);
   min-width: 0;
 }
 .texttheme_dark__zAjRUswWww {
   color: var(--token-WcqAzrLgrO6X);
-}
-.text__b8GL5 {
-  position: relative;
-  width: 100%;
-  height: auto;
-  max-width: 100%;
-  color: var(--token-gN119pN46HXv);
-  min-width: 0;
-  display: none;
 }
 .linkCard__vc6Kd:global(.__wab_instance) {
   max-width: 100%;
   width: 100%;
   min-width: 0;
 }
-.img__tsEwp {
-  object-fit: cover;
-  max-width: 50px;
-  height: 50px;
-}
-.img__tsEwp > picture > img {
-  object-fit: cover;
-}
 .text__beYh {
   position: relative;
   width: 100%;
   height: auto;
   max-width: 100%;
-  color: var(--token-gN119pN46HXv);
-  font-size: var(--antd-fontSizeSM);
   padding-left: 0px;
   min-width: 0;
 }
 .texttheme_dark__beYhSwWww {
   color: var(--token-WcqAzrLgrO6X);
 }
-.text__mj707 {
-  position: relative;
-  width: 100%;
-  height: auto;
-  max-width: 100%;
-  color: var(--token-gN119pN46HXv);
-  min-width: 0;
-  display: none;
-}
 .linkCard__dOuOh:global(.__wab_instance) {
   max-width: 100%;
   width: 100%;
   min-width: 0;
-}
-.img___3VGyQ {
-  object-fit: cover;
-  max-width: 50px;
-  height: 50px;
-}
-.img___3VGyQ > picture > img {
-  object-fit: cover;
 }
 .text__tl9Lj {
   position: relative;
   width: 100%;
   height: auto;
   max-width: 100%;
-  color: var(--token-gN119pN46HXv);
-  font-size: var(--antd-fontSizeSM);
   min-width: 0;
 }
 .texttheme_dark__tl9LJswWww {
   color: var(--token-WcqAzrLgrO6X);
-}
-.text___9DsmD {
-  position: relative;
-  width: 100%;
-  height: auto;
-  max-width: 100%;
-  color: var(--token-gN119pN46HXv);
-  min-width: 0;
-  display: none;
 }
 .column__luYg1 {
   display: flex;
@@ -688,9 +623,7 @@
   width: 100%;
   height: auto;
   max-width: 100%;
-  color: var(--antd-colorInfoText);
   font-weight: 700;
-  font-size: var(--antd-fontSizeHeading5);
   padding-left: 14px;
   min-width: 0;
 }
@@ -702,102 +635,45 @@
   width: 100%;
   min-width: 0;
 }
-.img__lz2T6 {
-  object-fit: cover;
-  max-width: 50px;
-  height: 50px;
-}
-.img__lz2T6 > picture > img {
-  object-fit: cover;
-}
 .text__sqxQf {
   position: relative;
   width: 100%;
   height: auto;
   max-width: 100%;
-  color: var(--token-gN119pN46HXv);
-  font-size: var(--antd-fontSizeSM);
   min-width: 0;
 }
 .texttheme_dark__sqxQfswWww {
   color: var(--token-WcqAzrLgrO6X);
-}
-.text__fllMb {
-  position: relative;
-  width: 100%;
-  height: auto;
-  max-width: 100%;
-  color: var(--token-gN119pN46HXv);
-  min-width: 0;
-  display: none;
 }
 .linkCard___6OUB:global(.__wab_instance) {
   max-width: 100%;
   width: 100%;
   min-width: 0;
 }
-.img__asTHd {
-  object-fit: cover;
-  max-width: 50px;
-  height: 50px;
-}
-.img__asTHd > picture > img {
-  object-fit: cover;
-}
 .text__gcly2 {
   position: relative;
   width: 100%;
   height: auto;
   max-width: 100%;
-  color: var(--token-gN119pN46HXv);
-  font-size: var(--antd-fontSizeSM);
   min-width: 0;
 }
 .texttheme_dark__gcly2SwWww {
   color: var(--token-WcqAzrLgrO6X);
-}
-.text__u7QRc {
-  position: relative;
-  width: 100%;
-  height: auto;
-  max-width: 100%;
-  color: var(--token-gN119pN46HXv);
-  min-width: 0;
-  display: none;
 }
 .linkCard___3ZeVt:global(.__wab_instance) {
   max-width: 100%;
   width: 100%;
   min-width: 0;
 }
-.img__tosI {
-  object-fit: cover;
-  max-width: 50px;
-  height: 50px;
-}
-.img__tosI > picture > img {
-  object-fit: cover;
-}
 .text__pEtRo {
   position: relative;
   width: 100%;
   height: auto;
   max-width: 100%;
-  color: var(--token-gN119pN46HXv);
-  font-size: var(--antd-fontSizeSM);
   min-width: 0;
 }
 .texttheme_dark__pEtRoswWww {
   color: var(--token-WcqAzrLgrO6X);
-}
-.text__fFg9B {
-  position: relative;
-  width: 100%;
-  height: auto;
-  max-width: 100%;
-  color: var(--token-gN119pN46HXv);
-  min-width: 0;
-  display: none;
 }
 .column__cfwvN {
   display: flex;
@@ -844,9 +720,7 @@
   width: 100%;
   height: auto;
   max-width: 100%;
-  color: var(--antd-colorInfoText);
   font-weight: 700;
-  font-size: var(--antd-fontSizeHeading5);
   padding-left: 14px;
   min-width: 0;
 }
@@ -858,104 +732,47 @@
   width: 100%;
   min-width: 0;
 }
-.img__rypMy {
-  object-fit: cover;
-  max-width: 50px;
-  height: 50px;
-}
-.img__rypMy > picture > img {
-  object-fit: cover;
-}
 .text__bj3Bk {
   position: relative;
   width: 100%;
   height: auto;
   max-width: 100%;
-  color: var(--token-gN119pN46HXv);
-  font-size: var(--antd-fontSizeSM);
   min-width: 0;
 }
 .texttheme_dark__bj3BkswWww {
   color: var(--token-WcqAzrLgrO6X);
-}
-.text___96W6 {
-  position: relative;
-  width: 100%;
-  height: auto;
-  max-width: 100%;
-  color: var(--token-gN119pN46HXv);
-  min-width: 0;
-  display: none;
 }
 .linkCard__lEk64:global(.__wab_instance) {
   max-width: 100%;
   width: 100%;
   min-width: 0;
 }
-.img__ccWz0 {
-  object-fit: cover;
-  max-width: 50px;
-  height: 50px;
-}
-.img__ccWz0 > picture > img {
-  object-fit: cover;
-}
 .text__ixNym {
   position: relative;
   width: 100%;
   height: auto;
   max-width: 100%;
-  color: var(--token-gN119pN46HXv);
-  font-size: var(--antd-fontSizeSM);
   padding-left: 0px;
   min-width: 0;
 }
 .texttheme_dark__ixNyMswWww {
   color: var(--token-WcqAzrLgrO6X);
 }
-.text__tknnv {
-  position: relative;
-  width: 100%;
-  height: auto;
-  max-width: 100%;
-  color: var(--token-gN119pN46HXv);
-  min-width: 0;
-  display: none;
-}
 .linkCard__tylXm:global(.__wab_instance) {
   max-width: 100%;
   width: 100%;
   min-width: 0;
-}
-.img___2Hit {
-  object-fit: cover;
-  max-width: 50px;
-  height: 50px;
-}
-.img___2Hit > picture > img {
-  object-fit: cover;
 }
 .text__tMoc9 {
   position: relative;
   width: 100%;
   height: auto;
   max-width: 100%;
-  color: var(--token-gN119pN46HXv);
-  font-size: var(--antd-fontSizeSM);
   padding-left: 0px;
   min-width: 0;
 }
 .texttheme_dark__tMoc9SwWww {
   color: var(--token-WcqAzrLgrO6X);
-}
-.text__nQkmU {
-  position: relative;
-  width: 100%;
-  height: auto;
-  max-width: 100%;
-  color: var(--token-gN119pN46HXv);
-  min-width: 0;
-  display: none;
 }
 .link__fxHBm {
   position: relative;

--- a/apps/docs/src/components/plasmic/generated/docs_opensource_observer/PlasmicOverview.tsx
+++ b/apps/docs/src/components/plasmic/generated/docs_opensource_observer/PlasmicOverview.tsx
@@ -547,14 +547,13 @@ function PlasmicOverview__RenderFunc(props: {
                         ),
                       },
                     )}
-                    link={
-                      "https://docs.opensource.observer/docs/guides/notebooks/"
-                    }
+                    image={null}
+                    link={"/docs/guides/notebooks/"}
                     noTitle={true}
                     theme={
                       hasVariant($state, "theme", "dark") ? "dark" : undefined
                     }
-                    title={"Get started"}
+                    title={null}
                   >
                     <div
                       className={classNames(
@@ -572,15 +571,6 @@ function PlasmicOverview__RenderFunc(props: {
                     >
                       {"\ud83d\udcd3 \nConnect to notebooks"}
                     </div>
-                    <div
-                      className={classNames(
-                        projectcss.all,
-                        projectcss.__wab_text,
-                        sty.text__b8GL5,
-                      )}
-                    >
-                      {"something here"}
-                    </div>
                   </LinkCard>
                   <LinkCard
                     className={classNames(
@@ -594,12 +584,13 @@ function PlasmicOverview__RenderFunc(props: {
                         ),
                       },
                     )}
-                    link={"https://docs.opensource.observer/docs/tutorials/"}
+                    image={null}
+                    link={"/docs/tutorials/"}
                     noTitle={true}
                     theme={
                       hasVariant($state, "theme", "dark") ? "dark" : undefined
                     }
-                    title={"Get started"}
+                    title={null}
                   >
                     <div
                       className={classNames(
@@ -617,15 +608,6 @@ function PlasmicOverview__RenderFunc(props: {
                     >
                       {"\ud83d\udcda \nSee tutorials"}
                     </div>
-                    <div
-                      className={classNames(
-                        projectcss.all,
-                        projectcss.__wab_text,
-                        sty.text__mj707,
-                      )}
-                    >
-                      {"something here"}
-                    </div>
                   </LinkCard>
                   <LinkCard
                     className={classNames(
@@ -639,14 +621,13 @@ function PlasmicOverview__RenderFunc(props: {
                         ),
                       },
                     )}
-                    link={
-                      "https://docs.opensource.observer/docs/contribute-models/"
-                    }
+                    image={null}
+                    link={"/docs/contribute-models/"}
                     noTitle={true}
                     theme={
                       hasVariant($state, "theme", "dark") ? "dark" : undefined
                     }
-                    title={"Get started"}
+                    title={null}
                   >
                     <div
                       className={classNames(
@@ -663,15 +644,6 @@ function PlasmicOverview__RenderFunc(props: {
                       )}
                     >
                       {"\ud83e\udd16 \nContribute models"}
-                    </div>
-                    <div
-                      className={classNames(
-                        projectcss.all,
-                        projectcss.__wab_text,
-                        sty.text___9DsmD,
-                      )}
-                    >
-                      {"something here"}
                     </div>
                   </LinkCard>
                 </Stack__>
@@ -710,12 +682,13 @@ function PlasmicOverview__RenderFunc(props: {
                         ),
                       },
                     )}
-                    link={"https://docs.opensource.observer/docs/integrate/api"}
+                    image={null}
+                    link={"/docs/integrate/api"}
                     noTitle={true}
                     theme={
                       hasVariant($state, "theme", "dark") ? "dark" : undefined
                     }
-                    title={"Get started"}
+                    title={null}
                   >
                     <div
                       className={classNames(
@@ -733,15 +706,6 @@ function PlasmicOverview__RenderFunc(props: {
                     >
                       {"\u26a1 \nUse the GraphQL API"}
                     </div>
-                    <div
-                      className={classNames(
-                        projectcss.all,
-                        projectcss.__wab_text,
-                        sty.text__fllMb,
-                      )}
-                    >
-                      {"something here"}
-                    </div>
                   </LinkCard>
                   <LinkCard
                     className={classNames(
@@ -755,14 +719,13 @@ function PlasmicOverview__RenderFunc(props: {
                         ),
                       },
                     )}
-                    link={
-                      "https://docs.opensource.observer/docs/guides/dagster/"
-                    }
+                    image={null}
+                    link={"/docs/guides/dagster/"}
                     noTitle={true}
                     theme={
                       hasVariant($state, "theme", "dark") ? "dark" : undefined
                     }
-                    title={"Get started"}
+                    title={null}
                   >
                     <div
                       className={classNames(
@@ -780,15 +743,6 @@ function PlasmicOverview__RenderFunc(props: {
                     >
                       {"\ud83d\udcc8 \nView the entire pipeline"}
                     </div>
-                    <div
-                      className={classNames(
-                        projectcss.all,
-                        projectcss.__wab_text,
-                        sty.text__u7QRc,
-                      )}
-                    >
-                      {"something here"}
-                    </div>
                   </LinkCard>
                   <LinkCard
                     className={classNames(
@@ -802,14 +756,13 @@ function PlasmicOverview__RenderFunc(props: {
                         ),
                       },
                     )}
-                    link={
-                      "https://docs.opensource.observer/docs/contribute-data/"
-                    }
+                    image={null}
+                    link={"/docs/contribute-data/"}
                     noTitle={true}
                     theme={
                       hasVariant($state, "theme", "dark") ? "dark" : undefined
                     }
-                    title={"Get started"}
+                    title={null}
                   >
                     <div
                       className={classNames(
@@ -826,15 +779,6 @@ function PlasmicOverview__RenderFunc(props: {
                       )}
                     >
                       {"\ud83d\udd0c \nConnect your data"}
-                    </div>
-                    <div
-                      className={classNames(
-                        projectcss.all,
-                        projectcss.__wab_text,
-                        sty.text__fFg9B,
-                      )}
-                    >
-                      {"something here"}
                     </div>
                   </LinkCard>
                 </Stack__>
@@ -873,12 +817,13 @@ function PlasmicOverview__RenderFunc(props: {
                         ),
                       },
                     )}
-                    link={"https://docs.opensource.observer/docs/projects/"}
+                    image={null}
+                    link={"/docs/projects/"}
                     noTitle={true}
                     theme={
                       hasVariant($state, "theme", "dark") ? "dark" : undefined
                     }
-                    title={"Get started"}
+                    title={null}
                   >
                     <div
                       className={classNames(
@@ -896,15 +841,6 @@ function PlasmicOverview__RenderFunc(props: {
                     >
                       {"\u2795 \nAdd your project"}
                     </div>
-                    <div
-                      className={classNames(
-                        projectcss.all,
-                        projectcss.__wab_text,
-                        sty.text___96W6,
-                      )}
-                    >
-                      {"something here"}
-                    </div>
                   </LinkCard>
                   <LinkCard
                     className={classNames(
@@ -918,14 +854,13 @@ function PlasmicOverview__RenderFunc(props: {
                         ),
                       },
                     )}
-                    link={
-                      "https://docs.opensource.observer/docs/projects/view-artifacts"
-                    }
+                    image={null}
+                    link={"/docs/projects/view-artifacts"}
                     noTitle={true}
                     theme={
                       hasVariant($state, "theme", "dark") ? "dark" : undefined
                     }
-                    title={"Get started"}
+                    title={null}
                   >
                     <div
                       className={classNames(
@@ -943,15 +878,6 @@ function PlasmicOverview__RenderFunc(props: {
                     >
                       {"\ud83d\udce6 \nView project artifacts"}
                     </div>
-                    <div
-                      className={classNames(
-                        projectcss.all,
-                        projectcss.__wab_text,
-                        sty.text__tknnv,
-                      )}
-                    >
-                      {"something here"}
-                    </div>
                   </LinkCard>
                   <LinkCard
                     className={classNames(
@@ -965,14 +891,13 @@ function PlasmicOverview__RenderFunc(props: {
                         ),
                       },
                     )}
-                    link={
-                      "https://docs.opensource.observer/docs/projects/troubleshoot"
-                    }
+                    image={null}
+                    link={"/docs/projects/troubleshoot"}
                     noTitle={true}
                     theme={
                       hasVariant($state, "theme", "dark") ? "dark" : undefined
                     }
-                    title={"Get started"}
+                    title={null}
                   >
                     <div
                       className={classNames(
@@ -989,15 +914,6 @@ function PlasmicOverview__RenderFunc(props: {
                       )}
                     >
                       {"\ud83d\udd27 \nTroubleshoot data issues"}
-                    </div>
-                    <div
-                      className={classNames(
-                        projectcss.all,
-                        projectcss.__wab_text,
-                        sty.text__nQkmU,
-                      )}
-                    >
-                      {"something here"}
                     </div>
                   </LinkCard>
                 </Stack__>

--- a/apps/docs/src/pages/index.mdx
+++ b/apps/docs/src/pages/index.mdx
@@ -4,6 +4,9 @@ description: "Open Source Observer (OSO) Documentation site"
 sidebar_position: 0
 ---
 
-import Overview from '@site/src/components/plasmic/Overview';
+import { PlasmicRootProvider } from "@plasmicapp/react-web";
+import Overview from "@site/src/components/plasmic/Overview";
 
-<Overview />
+<PlasmicRootProvider>
+  <Overview /> 
+</PlasmicRootProvider>


### PR DESCRIPTION
* Previously Docusaurus lazy-loading of CSS caused reordering and weird behavior.
* This will make the CSS conventions closer to what the Kariba docs do, making it more resistent to re-ordering
* Also fixes to use PlasmicRootProvider