### PR TITLE
feat(tutorials/semantic-layer): add semantic layer tab scaffolding to tutorials

### DIFF
--- a/apps/docs/docs/tutorials/quickstart.md
+++ b/apps/docs/docs/tutorials/quickstart.md
@@ -304,8 +304,8 @@ query = (
         "timeseries_metrics_by_project.unit",
     )
     .where(
-        "projects_v1.project_name = 'opensource-observer'",
-        "metrics_v0.metric_name = 'GITHUB_stars_daily'"
+        "projects.project_name = 'opensource-observer'",
+        "metrics.metric_name = 'GITHUB_stars_daily'"
     )
 )
 ```

--- a/apps/docs/docs/tutorials/quickstart.md
+++ b/apps/docs/docs/tutorials/quickstart.md
@@ -146,9 +146,9 @@ client.to_pandas("SELECT * FROM projects_v1 WHERE project_name = 'opensource-obs
 
 ```python
 query = oso.semantic.select(
-    "projects_v1",
+    "projects",
 ).where(
-    "projects_v1.project_name = 'opensource-observer'"
+    "projects.project_name = 'opensource-observer'"
 )
 ```
 

--- a/apps/docs/docs/tutorials/quickstart.md
+++ b/apps/docs/docs/tutorials/quickstart.md
@@ -77,9 +77,9 @@ client.to_pandas("SELECT * FROM models_v0 WHERE model_name LIKE '%_v1'")
 
 ```python
 query = oso.semantic.select(
-    "models_v0",                 
+    "models",                 
 ).where(
-    "models_v0.model_name LIKE '%_v1'"
+    "models.model_name LIKE '%_v1'"
 )
 ```
 

--- a/apps/docs/docs/tutorials/quickstart.md
+++ b/apps/docs/docs/tutorials/quickstart.md
@@ -106,6 +106,7 @@ query = oso.semantic.select(
 )
 ```
 
+
 </TabItem>
 </Tabs>
 

--- a/apps/docs/docs/tutorials/quickstart.md
+++ b/apps/docs/docs/tutorials/quickstart.md
@@ -106,7 +106,6 @@ query = oso.semantic.select(
 )
 ```
 
-
 </TabItem>
 </Tabs>
 

--- a/apps/docs/docs/tutorials/quickstart.md
+++ b/apps/docs/docs/tutorials/quickstart.md
@@ -56,7 +56,7 @@ client.to_pandas("SELECT * FROM models_v0 LIMIT 5")
 
 ```python
 query = semantic.select(
-    "models_v0"
+    "models"
 ).limit(5)
 ```
 

--- a/apps/docs/docs/tutorials/quickstart.md
+++ b/apps/docs/docs/tutorials/quickstart.md
@@ -125,7 +125,7 @@ client.to_pandas("SELECT * FROM projects_v1 LIMIT 5")
 
 ```python
 query = oso.semantic.select(
-    "projects_v1",
+    "projects",
 ).limit(5)
 ```
 

--- a/apps/docs/docs/tutorials/quickstart.md
+++ b/apps/docs/docs/tutorials/quickstart.md
@@ -56,7 +56,7 @@ client.to_pandas("SELECT * FROM models_v0 LIMIT 5")
 
 ```python
 query = semantic.select(
-    "models_v0.*"
+    "models_v0"
 ).limit(5)
 ```
 
@@ -169,9 +169,9 @@ client.to_pandas("SELECT * FROM artifacts_by_project_v1 WHERE project_name = 'op
 
 ```python
 query = oso.semantic.select(
-    "artifacts_by_project_v1",
+    "artifacts_by_project",
 ).where(
-    "artifacts_by_project_v1.project_name = 'opensource-observer'"
+    "artifacts_by_project.project_name = 'opensource-observer'"
 )
 ```
 
@@ -203,17 +203,14 @@ client.to_pandas("""
 
 ```python
 query = oso.semantic.select(
-    "key_metrics_by_project_v0.metric_id",
-    "metrics_v0.metric_name",
-    "metrics_v0.display_name",
-    "key_metrics_by_project_v0.sample_date",
-    "key_metrics_by_project_v0.amount",
-    "key_metrics_by_project_v0.unit",
-).join(
-    "metrics_v0", 
-    on="key_metrics_by_project_v0.metric_id = metrics_v0.metric_id"
+    "metrics.id",
+    "metrics.name",
+    "metrics.display_name",
+    "key_metrics_by_project.sample_date",
+    "key_metrics_by_project.amount",
+    "key_metrics_by_project.unit",
 ).where(
-    "key_metrics_by_project_v0.project_id = 'UuWbpo5bpL5QsYvlukUWNm2uE8HFjxQxzCM0e+HMZfk='"
+    "key_metrics_by_project.unit.project_id = 'UuWbpo5bpL5QsYvlukUWNm2uE8HFjxQxzCM0e+HMZfk='"
 )
 ```
 
@@ -254,26 +251,15 @@ MY_METRICS = ['GITHUB_stars_over_all_time', 'GITHUB_forks_over_all_time']
 
 oso = Client()  # ensure OSO_API_KEY is set
 
-query = (
-    oso.semantic.select(
-        "projects_v1.display_name",
-        "metrics_v0.display_name",
-        "key_metrics_by_project_v0.sample_date",
-        "key_metrics_by_project_v0.amount",
-    )
-    .join(
-        "metrics_v0",
-        on="metrics_v0.metric_id = key_metrics_by_project_v0.metric_id"
-    )
-    .join(
-        "projects_v1",
-        on="projects_v1.project_id = key_metrics_by_project_v0.project_id"
-    )
-    .where(
-        f"projects_v1.project_name IN ({', '.join(repr(p) for p in MY_PROJECTS)})",
-        f"metrics_v0.metric_name IN ({', '.join(repr(m) for m in MY_METRICS)})",
-    )
-    .order_by("projects_v1.display_name", "metrics_v0.display_name")
+query = oso.semantic.select(
+    "metrics.id",
+    "metrics.name",
+    "metrics.display_name",
+    "key_metrics_by_project.sample_date",
+    "key_metrics_by_project.amount",
+    "key_metrics_by_project.unit",
+).where(
+    "key_metrics_by_project.unit.project_id = MY_PROJECTS"
 )
 ```
 
@@ -310,26 +296,17 @@ df_stars = client.to_pandas("""
 ```python
 query = (
     oso.semantic.select(
-        "timeseries_metrics_by_project_v0.metric_id",
-        "metrics_v0.metric_name",
-        "metrics_v0.display_name",
-        "timeseries_metrics_by_project_v0.sample_date",
-        "timeseries_metrics_by_project_v0.amount",
-        "timeseries_metrics_by_project_v0.unit",
-    )
-    .join(
-        "metrics_v0",
-        on="metrics_v0.metric_id = timeseries_metrics_by_project_v0.metric_id"
-    )
-    .join(
-        "projects_v1",
-        on="projects_v1.project_id = timeseries_metrics_by_project_v0.project_id"
+        "timeseries_metrics_by_project.metric_id",
+        "metrics.metric_name",
+        "metrics.display_name",
+        "timeseries_metrics_by_project.sample_date",
+        "timeseries_metrics_by_project.amount",
+        "timeseries_metrics_by_project.unit",
     )
     .where(
         "projects_v1.project_name = 'opensource-observer'",
         "metrics_v0.metric_name = 'GITHUB_stars_daily'"
     )
-    .order_by("timeseries_metrics_by_project_v0.sample_date")
 )
 ```
 

--- a/apps/docs/docs/tutorials/quickstart.md
+++ b/apps/docs/docs/tutorials/quickstart.md
@@ -100,9 +100,9 @@ client.to_pandas("SELECT * FROM models_v0 WHERE model_name LIKE '%_v0'")
 
 ```python
 query = oso.semantic.select(
-    "models_v0",
+    "models",
 ).where(
-    "models_v0.model_name LIKE '%_v0'"
+    "models.model_name LIKE '%_v0'"
 )
 ```
 

--- a/apps/docs/docs/tutorials/quickstart.md
+++ b/apps/docs/docs/tutorials/quickstart.md
@@ -45,14 +45,14 @@ def stringify(arr):
 Get a preview of all available models:
 
 <Tabs>
-<TabItem value="python" label="Python">
+<TabItem value="python-sql" label="Python">
 
 ```python
 client.to_pandas("SELECT * FROM models_v0 LIMIT 5")
 ```
 
 </TabItem>
-<TabItem value="python" label="Semantic Layer">
+<TabItem value="python-semantic" label="Semantic Layer">
 
 ```python
 query = semantic.select(
@@ -66,18 +66,18 @@ query = semantic.select(
 Get the list of stable production models:
 
 <Tabs>
-<TabItem value="python" label="Python">
+<TabItem value="python-sql" label="Python">
 
 ```python
 client.to_pandas("SELECT * FROM models_v0 WHERE model_name LIKE '%_v1'")
 ```
 
 </TabItem>
-<TabItem value="python" label="Semantic Layer">
+<TabItem value="python-semantic" label="Semantic Layer">
 
 ```python
 query = oso.semantic.select(
-    "models",                 
+    "models",
 ).where(
     "models.model_name LIKE '%_v1'"
 )
@@ -89,14 +89,14 @@ query = oso.semantic.select(
 Get the list of less stable models:
 
 <Tabs>
-<TabItem value="python" label="Python">
+<TabItem value="python-sql" label="Python">
 
 ```python
 client.to_pandas("SELECT * FROM models_v0 WHERE model_name LIKE '%_v0'")
 ```
 
 </TabItem>
-<TabItem value="python" label="Semantic Layer">
+<TabItem value="python-semantic" label="Semantic Layer">
 
 ```python
 query = oso.semantic.select(
@@ -114,14 +114,14 @@ query = oso.semantic.select(
 Get a list of projects:
 
 <Tabs>
-<TabItem value="python" label="Python">
+<TabItem value="python-sql" label="Python">
 
 ```python
 client.to_pandas("SELECT * FROM projects_v1 LIMIT 5")
 ```
 
 </TabItem>
-<TabItem value="python" label="Semantic Layer">
+<TabItem value="python-semantic" label="Semantic Layer">
 
 ```python
 query = oso.semantic.select(
@@ -135,14 +135,14 @@ query = oso.semantic.select(
 Look up a specific project:
 
 <Tabs>
-<TabItem value="python" label="Python">
+<TabItem value="python-sql" label="Python">
 
 ```python
 client.to_pandas("SELECT * FROM projects_v1 WHERE project_name = 'opensource-observer'")
 ```
 
 </TabItem>
-<TabItem value="python" label="Semantic Layer">
+<TabItem value="python-semantic" label="Semantic Layer">
 
 ```python
 query = oso.semantic.select(
@@ -158,14 +158,14 @@ query = oso.semantic.select(
 Get all artifacts owned by a project:
 
 <Tabs>
-<TabItem value="python" label="Python">
+<TabItem value="python-sql" label="Python">
 
 ```python
 client.to_pandas("SELECT * FROM artifacts_by_project_v1 WHERE project_name = 'opensource-observer'")
 ```
 
 </TabItem>
-<TabItem value="python" label="Semantic Layer">
+<TabItem value="python-semantic" label="Semantic Layer">
 
 ```python
 query = oso.semantic.select(
@@ -181,7 +181,7 @@ query = oso.semantic.select(
 Get available key metrics for OSO:
 
 <Tabs>
-<TabItem value="python" label="Python">
+<TabItem value="python-sql" label="Python">
 
 ```python
 client.to_pandas("""
@@ -199,7 +199,7 @@ client.to_pandas("""
 ```
 
 </TabItem>
-<TabItem value="python" label="Semantic Layer">
+<TabItem value="python-semantic" label="Semantic Layer">
 
 ```python
 query = oso.semantic.select(
@@ -220,7 +220,7 @@ query = oso.semantic.select(
 Get a set of key metrics for a few projects:
 
 <Tabs>
-<TabItem value="python" label="Python">
+<TabItem value="python-sql" label="Python">
 
 ```python
 MY_PROJECTS = ['opensource-observer', 'huggingface', 'wevm']
@@ -243,7 +243,7 @@ client.to_pandas(f"""
 ```
 
 </TabItem>
-<TabItem value="python" label="Semantic Layer">
+<TabItem value="python-semantic" label="Semantic Layer">
 
 ```python
 MY_PROJECTS = ['opensource-observer', 'huggingface', 'wevm']
@@ -269,7 +269,7 @@ query = oso.semantic.select(
 Get timeseries metrics for OSO:
 
 <Tabs>
-<TabItem value="python" label="Python">
+<TabItem value="python-sql" label="Python">
 
 ```python
 df_stars = client.to_pandas("""
@@ -291,7 +291,7 @@ df_stars = client.to_pandas("""
 ```
 
 </TabItem>
-<TabItem value="python" label="Semantic Layer">
+<TabItem value="python-semantic" label="Semantic Layer">
 
 ```python
 query = (


### PR DESCRIPTION
### Summary

This PR introduces the initial scaffolding for adding **semantic layer query tabs** to each tutorial. This is part of the effort to improve semantic layer reference documentation as discussed in [#4448](https://github.com/opensource-observer/oso/issues/4448).

### Changes Made

- Added semantic layer tab UI elements to tutorials
- Wrote semantic layer equivalent for all query in [quickstart](https://docs.opensource.observer/docs/tutorials/quickstart) (yet to be tested)
- Laid structural foundation to support tab switching and content rendering

### Next Steps

- Finalize semantic query examples for each tutorial
- Adjust styles and layout if needed based on design feedback
- Refactor the semantic layer getting started (0 to 1)
- Create reference documentation on the current entities that are registered with the semantic layer

### Challenges
- Having issues running the semantic layer codes. 
for example:
`from pyoso import Client 
oso = Client()
print(oso.semantic.describe())`

I got this error:
`AttributeError: 'Client' object has no attribute 'semantic'`

### References

Refs #4448

cc: @ryscheng 