### PR TITLE
fix: make stg_github__releases use a larger batch_size

### DIFF
--- a/warehouse/oso_sqlmesh/models/staging/github/stg_github__releases.sql
+++ b/warehouse/oso_sqlmesh/models/staging/github/stg_github__releases.sql
@@ -2,7 +2,7 @@ MODEL (
   name oso.stg_github__releases,
   kind INCREMENTAL_BY_TIME_RANGE (
     time_column created_at,
-    batch_size 90,
+    batch_size 365,
     batch_concurrency 3,
     lookback 31,
     forward_only true,


### PR DESCRIPTION
Small fix to make this in sync with my debugging changes that I had manually run on sqlmesh. 