### PR TITLE
feat: add `crypto_ecosystems` dasgter asset

### DIFF
--- a/warehouse/oso_dagster/assets/crypto_ecosystems.py
+++ b/warehouse/oso_dagster/assets/crypto_ecosystems.py
@@ -1,0 +1,23 @@
+from google.cloud.bigquery import SourceFormat
+from oso_dagster.config import DagsterConfig
+
+from ..factories import AssetFactoryResponse, early_resources_asset_factory
+from ..factories.archive2bq import Archive2BqAssetConfig, create_archive2bq_asset
+
+
+@early_resources_asset_factory()
+def crypto_ecosystems_data(global_config: DagsterConfig) -> AssetFactoryResponse:
+    asset = create_archive2bq_asset(
+        Archive2BqAssetConfig(
+            key_prefix="crypto_ecosystems",
+            dataset_id="crypto_ecosystems",
+            asset_name="taxonomy",
+            source_url="https://github.com/opensource-observer/crypto-ecosystems/archive/refs/heads/master.zip",
+            source_format=SourceFormat.NEWLINE_DELIMITED_JSON,
+            staging_bucket=global_config.staging_bucket_url,
+            filter_fn=lambda file: file.endswith(".jsonl"),
+            combine_files=True,
+            deps=[],
+        )
+    )
+    return asset

--- a/warehouse/oso_dagster/factories/archive2bq.py
+++ b/warehouse/oso_dagster/factories/archive2bq.py
@@ -6,7 +6,7 @@ import tempfile
 import urllib.request
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Callable, Dict, List, Optional, cast
+from typing import Callable, Dict, List, Optional, TypeAlias, Union, cast
 
 import pyarrow.parquet as pq
 from dagster import AssetExecutionContext, MaterializeResult, asset
@@ -46,6 +46,16 @@ BQ_ALLOWED_TYPES = [
     "JSON",
 ]
 
+FieldTypeOverride: TypeAlias = str
+FieldConfigOverride: TypeAlias = Dict[
+    str, str
+]  # {"type": "STRING", "mode": "NULLABLE"}
+SchemaOverride: TypeAlias = Union[FieldTypeOverride, FieldConfigOverride]
+SchemaOverridesDict: TypeAlias = Dict[str, SchemaOverride]
+TableSchemaOverrides: TypeAlias = Dict[
+    str, SchemaOverridesDict
+]  # {table_name: {field_name: override}}
+
 
 @dataclass(kw_only=True)
 class Archive2BqAssetConfig:
@@ -58,7 +68,10 @@ class Archive2BqAssetConfig:
     # The maximum depth of the files in the archive
     max_depth: int = 3
     # The schema overrides for the BigQuery table
-    schema_overrides: Optional[Dict[str, Dict[str, str | Dict[str, str]]]] = None
+    # Format: {"table_name": {"field_name": "STRING" | {"type": "STRING", "mode": "NULLABLE"}}}
+    # If None, BigQuery autodetect will be used. If specified, caller is responsible
+    # for ensuring the schema matches the actual data structure in the files.
+    schema_overrides: Optional[TableSchemaOverrides] = None
     # The GCS bucket to stage the data
     staging_bucket: str
     # The dataset in BigQuery
@@ -71,7 +84,7 @@ class Archive2BqAssetConfig:
     asset_name: str
     # Dagster dependencies
     deps: AssetDeps
-    # Combine all files into a single table (only for JSONL)
+    # Combine all files into a single table (works for JSONL and CSV)
     combine_files: bool = False
     # Dagster remaining args
     asset_kwargs: dict = field(default_factory=lambda: {})
@@ -116,16 +129,28 @@ def extract_to_tempdir(source_url: str, skip_uncompression: bool = False) -> str
 
 
 def combine_jsonl_files(files: List[str], output_path: str) -> None:
-    """
-    Combines multiple JSONL files into a single JSONL file.
-
-    Args:
-        files (List[str]): List of JSONL file paths to combine.
-        output_path (str): Path where the combined file should be written.
-    """
+    """Combines multiple JSONL files by concatenating them."""
     with open(output_path, "w", encoding="utf-8") as outfile:
         for file_path in files:
             outfile.write(Path(file_path).read_text(encoding="utf-8"))
+
+
+def combine_csv_files(files: List[str], output_path: str) -> None:
+    """Combines multiple CSV files, keeping only the first header."""
+    with open(output_path, "w", encoding="utf-8", newline="") as outfile:
+        writer = csv.writer(outfile)
+        for i, file_path in enumerate(files):
+            with open(file_path, "r", encoding="utf-8") as infile:
+                reader = csv.reader(infile)
+                if i > 0:
+                    next(reader, None)
+                writer.writerows(reader)
+
+
+COMBINE_STRATEGIES = {
+    SourceFormat.NEWLINE_DELIMITED_JSON: (combine_jsonl_files, ".jsonl"),
+    SourceFormat.CSV: (combine_csv_files, ".csv"),
+}
 
 
 def get_list_of_files(
@@ -215,22 +240,34 @@ def get_parquet_schema(file_path: str) -> List[SchemaField]:
 
 def get_jsonl_schema(file_path: str) -> List[SchemaField]:
     """
-    Gets the schema of the JSONL file by reading the first line and extracting keys.
+    Gets a rudimentary schema of the JSONL file by reading the first line.
+
+    WARNING: Simplified schema detection with limitations:
+    - Only reads first line, assumes all fields are strings
+    - May miss optional fields in later records
+    - Caller responsible for ensuring schema overrides match actual data
 
     Args:
-        file_path (str): The path to the JSONL file.
+        file_path (str): Path to the JSONL file.
 
     Returns:
-        List[SchemaField]: The schema of the JSONL file.
+        List[SchemaField]: Basic schema with all fields as STRING type.
     """
     with open(file_path, "r", encoding="utf-8") as f:
         first_line = f.readline().strip()
         if not first_line:
-            return []
+            raise ValueError(f"JSONL file {file_path} is empty")
 
-        first_record = json.loads(first_line)
-        if not isinstance(first_record, dict):
-            raise ValueError("JSONL file must contain JSON objects")
+        try:
+            first_record = json.loads(first_line)
+        except json.JSONDecodeError as e:
+            raise ValueError(f"Invalid JSON in first line of {file_path}: {e}") from e
+
+        if not isinstance(first_record, dict) or not first_record:
+            raise ValueError(
+                f"JSONL file {file_path} must contain non-empty JSON objects, "
+                f"got {type(first_record).__name__}"
+            )
 
         return [SchemaField(key, "STRING") for key in first_record.keys()]
 
@@ -330,46 +367,60 @@ def upload_file_to_bq(
 
     destination_table_name = os.path.splitext(os.path.basename(file_path))[0]
 
+    schema_extractors = {
+        SourceFormat.CSV: get_csv_schema,
+        SourceFormat.PARQUET: get_parquet_schema,
+        SourceFormat.NEWLINE_DELIMITED_JSON: get_jsonl_schema,
+    }
+
+    def make_csv_config(schema=None):
+        return LoadJobConfig(
+            schema=schema,
+            autodetect=schema is None,
+            skip_leading_rows=1,
+            source_format=SourceFormat.CSV,
+            allow_quoted_newlines=True,
+            write_disposition=WriteDisposition.WRITE_TRUNCATE,
+        )
+
+    def make_default_config(source_format, schema=None):
+        return LoadJobConfig(
+            schema=schema,
+            autodetect=schema is None,
+            source_format=source_format,
+            write_disposition=WriteDisposition.WRITE_TRUNCATE,
+        )
+
+    config_makers = {
+        SourceFormat.CSV: make_csv_config,
+        SourceFormat.PARQUET: lambda schema=None: make_default_config(
+            SourceFormat.PARQUET, schema
+        ),
+        SourceFormat.NEWLINE_DELIMITED_JSON: lambda schema=None: make_default_config(
+            SourceFormat.NEWLINE_DELIMITED_JSON, schema
+        ),
+    }
+
     with bigquery.get_client() as bq_client:
         table_id = f"{asset_config.dataset_id}.{destination_table_name}"
-        if asset_config.source_format == SourceFormat.CSV:
-            schema = get_csv_schema(file_path)
-        elif asset_config.source_format == SourceFormat.PARQUET:
-            schema = get_parquet_schema(file_path)
-        elif asset_config.source_format == SourceFormat.NEWLINE_DELIMITED_JSON:
-            schema = get_jsonl_schema(file_path)
-        else:
+
+        if asset_config.source_format not in schema_extractors:
             raise ValueError(f"Unsupported source format: {asset_config.source_format}")
 
-        if asset_config.source_format == SourceFormat.CSV:
-            job_config = LoadJobConfig(
-                schema=apply_schema_overrides(
-                    schema,
-                    (
-                        asset_config.schema_overrides.get(destination_table_name, {})
-                        if asset_config.schema_overrides
-                        else {}
-                    ),
-                ),
-                skip_leading_rows=1,
-                source_format=asset_config.source_format,
-                allow_quoted_newlines=True,
-                write_disposition=WriteDisposition.WRITE_TRUNCATE,
+        table_overrides = (asset_config.schema_overrides or {}).get(
+            destination_table_name, {}
+        )
+
+        schema = (
+            apply_schema_overrides(
+                schema_extractors[asset_config.source_format](file_path),
+                table_overrides,
             )
-        elif asset_config.source_format == SourceFormat.PARQUET:
-            job_config = LoadJobConfig(
-                autodetect=True,
-                source_format=asset_config.source_format,
-                write_disposition=WriteDisposition.WRITE_TRUNCATE,
-            )
-        elif asset_config.source_format == SourceFormat.NEWLINE_DELIMITED_JSON:
-            job_config = LoadJobConfig(
-                autodetect=True,
-                source_format=asset_config.source_format,
-                write_disposition=WriteDisposition.WRITE_TRUNCATE,
-            )
-        else:
-            raise ValueError(f"Unsupported source format: {asset_config.source_format}")
+            if table_overrides
+            else None
+        )
+
+        job_config = config_makers[asset_config.source_format](schema)
 
         load_job = bq_client.load_table_from_uri(
             gcs_url, table_id, job_config=job_config
@@ -481,17 +532,14 @@ def create_archive2bq_asset(
 
         create_dataset_if_not_exists(context, bigquery, asset_config.dataset_id)
 
-        should_combine = (
+        if (
             asset_config.combine_files
-            and asset_config.source_format == SourceFormat.NEWLINE_DELIMITED_JSON
-        )
-
-        if should_combine:
-            combined_file_path = os.path.join(
-                tempdir, f"{asset_config.asset_name}.jsonl"
-            )
-            combine_jsonl_files(files, combined_file_path)
-            files_to_process = [combined_file_path]
+            and asset_config.source_format in COMBINE_STRATEGIES
+        ):
+            combine_fn, ext = COMBINE_STRATEGIES[asset_config.source_format]
+            combined_path = os.path.join(tempdir, f"{asset_config.asset_name}{ext}")
+            combine_fn(files, combined_path)
+            files_to_process = [combined_path]
         else:
             files_to_process = files
 


### PR DESCRIPTION
This PR adds a dagster asset replicating the data from [`crypto-ecosystems.xyz`](https://crypto-ecosystems.xyz/#).

It uses an interesting toolchain with zig and data embedded in the WebAssembly, so we've had to jump through some hoops, like creating our own mirror at [`opensource-observer/crypto-ecosystems/`](http://github.com/opensource-observer/crypto-ecosystems/).