### PR TITLE
Instrument timing in logs for dagster `load_definitions` 

### DIFF
--- a/lib/oso-core/oso_core/logging/decorators.py
+++ b/lib/oso-core/oso_core/logging/decorators.py
@@ -1,0 +1,24 @@
+"""
+Some potentially useful logging decorators
+"""
+
+import logging
+
+
+def time_function(logger: logging.Logger):
+    """Decorator to time a function and log the duration."""
+
+    def decorator(func):
+        def wrapper(*args, **kwargs):
+            import time
+
+            start_time = time.time()
+            result = func(*args, **kwargs)
+            end_time = time.time()
+            duration = end_time - start_time
+            logger.info(f"Function {func.__name__} took {duration:.4f} seconds")
+            return result
+
+        return wrapper
+
+    return decorator

--- a/warehouse/metrics-service/metrics_service/test_app.py
+++ b/warehouse/metrics-service/metrics_service/test_app.py
@@ -8,7 +8,7 @@ from metrics_service.app import app_factory, default_lifecycle
 from metrics_service.client import BaseWebsocketConnector, Client
 from metrics_service.types import AppConfig
 from metrics_tools.definition import MetricModelDefinition
-from metrics_tools.utils.logging import setup_module_logging
+from oso_core.logging import setup_module_logging
 from starlette.testclient import WebSocketTestSession
 
 

--- a/warehouse/metrics-service/metrics_service/worker.py
+++ b/warehouse/metrics-service/metrics_service/worker.py
@@ -13,7 +13,7 @@ import polars as pl
 from dask.distributed import Worker, WorkerPlugin, get_worker
 from google.cloud import storage
 from metrics_service.types import ExportReference, ExportType
-from metrics_tools.utils.logging import setup_module_logging
+from oso_core.logging import setup_module_logging
 from sqlglot import exp
 
 logger = logging.getLogger(__name__)
@@ -115,9 +115,9 @@ class DuckDBMetricsWorkerPlugin(MetricsWorkerPlugin):
             f"[{self._uuid}] got a cache request for {table_ref_name}:{export_reference.table.table_name}"
         )
         assert export_reference.type == ExportType.GCS, "Only GCS exports are supported"
-        assert (
-            export_reference.payload.get("gcs_path") is not None
-        ), "A gcs_path is required"
+        assert export_reference.payload.get("gcs_path") is not None, (
+            "A gcs_path is required"
+        )
 
         if self._cache_status.get(table_ref_name):
             return

--- a/warehouse/metrics_tools/factory/factory.py
+++ b/warehouse/metrics_tools/factory/factory.py
@@ -36,7 +36,7 @@ from metrics_tools.transformer import (
     SQLTransformer,
 )
 from metrics_tools.transformer.qualify import QualifyTransform
-from metrics_tools.utils.logging import add_metrics_tools_to_sqlmesh_logging
+from oso_core.logging import add_oso_core_to_current_application_logging
 from sqlglot import exp
 from sqlmesh.core.dialect import parse_one
 from sqlmesh.core.macros import MacroEvaluator
@@ -850,7 +850,7 @@ def timeseries_metrics(
 ):
     from metrics_tools.utils.testing import ENABLE_TIMESERIES_DEBUG
 
-    add_metrics_tools_to_sqlmesh_logging()
+    add_oso_core_to_current_application_logging()
     logger.info("loading timeseries metrics")
     frame_info = inspect.stack()[1]
     calling_file = frame_info.filename

--- a/warehouse/metrics_tools/utils/gcs.py
+++ b/warehouse/metrics_tools/utils/gcs.py
@@ -34,7 +34,7 @@ async def delete_gcs_folders(
         import logging
         from metrics_tools.utils.gcs import delete_gcs_folders
         from gcloud.aio import storage
-        from metrics_tools.utils.logging import setup_module_logging
+        from oso_core.logging import setup_module_logging
 
 
         async def main():

--- a/warehouse/oso_dagster/assets/sqlmesh_export.py
+++ b/warehouse/oso_dagster/assets/sqlmesh_export.py
@@ -4,11 +4,10 @@ import typing as t
 from dagster import AssetKey, ResourceParam
 from dagster_sqlmesh import DagsterSQLMeshController, SQLMeshContextConfig
 from dagster_sqlmesh.controller.base import DEFAULT_CONTEXT_FACTORY
-from oso_dagster.definitions import PrefixedSQLMeshTranslator
 from sqlmesh.core.model import Model
 
 from ..factories import AssetFactoryResponse, early_resources_asset_factory
-from ..resources import SQLMeshExporter
+from ..resources import PrefixedSQLMeshTranslator, SQLMeshExporter
 
 logger = logging.getLogger(__name__)
 

--- a/warehouse/oso_dagster/definitions.py
+++ b/warehouse/oso_dagster/definitions.py
@@ -1,55 +1,8 @@
 import logging
 import os
 
-from dagster import Definitions
-from dagster_embedded_elt.dlt import DagsterDltResource
-from dagster_gcp import BigQueryResource, GCSResource
-from dagster_k8s import k8s_job_executor
-from dagster_sqlmesh import SQLMeshContextConfig, SQLMeshResource
 from dotenv import find_dotenv, load_dotenv
-from metrics_tools.utils.logging import setup_module_logging
-from oso_dagster.resources.bq import BigQueryImporterResource
-from oso_dagster.resources.clickhouse import ClickhouseImporterResource
-from oso_dagster.resources.duckdb import (
-    DuckDBExporterResource,
-    DuckDBImporterResource,
-    DuckDBResource,
-)
-from oso_dagster.resources.storage import (
-    GCSTimeOrderedStorageResource,
-    TimeOrderedStorageResource,
-)
-from oso_dagster.resources.trino import TrinoExporterResource
-
-from . import assets
-from .cbt import CBTResource
-from .config import DagsterConfig
-from .factories import load_all_assets_from_package
-from .factories.alerts import setup_alert_sensors
-from .resources import (
-    BigQueryDataTransferResource,
-    ClickhouseResource,
-    K8sApiResource,
-    K8sResource,
-    MCSK8sResource,
-    MCSRemoteResource,
-    PrefixedSQLMeshTranslator,
-    Trino2BigQuerySQLMeshExporter,
-    Trino2ClickhouseSQLMeshExporter,
-    TrinoK8sResource,
-    TrinoRemoteResource,
-    load_dlt_staging,
-    load_dlt_warehouse_destination,
-    load_io_manager,
-)
-from .schedules import get_partitioned_schedules, schedules
-from .utils import (
-    CanvasDiscordWebhookAlertManager,
-    GCPSecretResolver,
-    LocalSecretResolver,
-    LogAlertManager,
-    setup_chunked_state_cleanup_sensor,
-)
+from oso_core.logging.decorators import time_function
 
 logger = logging.getLogger(__name__)
 
@@ -60,7 +13,57 @@ elif os.environ.get("ENV") == "production":
 load_dotenv()
 
 
+@time_function(logger)
 def load_definitions():
+    from dagster import Definitions
+    from dagster_embedded_elt.dlt import DagsterDltResource
+    from dagster_gcp import BigQueryResource, GCSResource
+    from dagster_k8s import k8s_job_executor
+    from dagster_sqlmesh import SQLMeshContextConfig, SQLMeshResource
+    from oso_core.logging import setup_module_logging
+    from oso_dagster.resources.bq import BigQueryImporterResource
+    from oso_dagster.resources.clickhouse import ClickhouseImporterResource
+    from oso_dagster.resources.duckdb import (
+        DuckDBExporterResource,
+        DuckDBImporterResource,
+        DuckDBResource,
+    )
+    from oso_dagster.resources.storage import (
+        GCSTimeOrderedStorageResource,
+        TimeOrderedStorageResource,
+    )
+    from oso_dagster.resources.trino import TrinoExporterResource
+
+    from . import assets
+    from .cbt import CBTResource
+    from .config import DagsterConfig
+    from .factories import load_all_assets_from_package
+    from .factories.alerts import setup_alert_sensors
+    from .resources import (
+        BigQueryDataTransferResource,
+        ClickhouseResource,
+        K8sApiResource,
+        K8sResource,
+        MCSK8sResource,
+        MCSRemoteResource,
+        PrefixedSQLMeshTranslator,
+        Trino2BigQuerySQLMeshExporter,
+        Trino2ClickhouseSQLMeshExporter,
+        TrinoK8sResource,
+        TrinoRemoteResource,
+        load_dlt_staging,
+        load_dlt_warehouse_destination,
+        load_io_manager,
+    )
+    from .schedules import get_partitioned_schedules, schedules
+    from .utils import (
+        CanvasDiscordWebhookAlertManager,
+        GCPSecretResolver,
+        LocalSecretResolver,
+        LogAlertManager,
+        setup_chunked_state_cleanup_sensor,
+    )
+
     setup_module_logging("oso_dagster")
     # Load the configuration for the project
     global_config = DagsterConfig()  # type: ignore


### PR DESCRIPTION
First part of #4519 

Keeping this one very simple. It moves some of the logging utilities to a new place and also adds a timing function for the `load_definitions` dagster function. 

I'm making a larger PR after this that instruments all of the assets but for now I wanted to make this a small PR and try to get this in first. 

