### PR TITLE
fix(oso_dagster): hotfix polars io manager with bq

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,7 @@ dependencies = [
     "gcloud-aio-storage<10.0.0,>=9.3.0",
     "kr8s==0.20.9",
     "structlog>=25.4.0",
+    "pandas-gbq>=0.29.2",
 ]
 name = "oso"
 version = "1.0.0"

--- a/uv.lock
+++ b/uv.lock
@@ -3692,6 +3692,7 @@ dependencies = [
     { name = "openrank-sdk" },
     { name = "oss-directory" },
     { name = "pandas" },
+    { name = "pandas-gbq" },
     { name = "pendulum" },
     { name = "polars" },
     { name = "pyarrow-stubs" },
@@ -3772,6 +3773,7 @@ requires-dist = [
     { name = "openrank-sdk", specifier = ">=0.4.0,<1.0.0" },
     { name = "oss-directory", specifier = "==0.2.5" },
     { name = "pandas", specifier = ">=2.2.3,<3.0.0" },
+    { name = "pandas-gbq", specifier = ">=0.29.2" },
     { name = "pendulum", specifier = ">=3.0.0,<4.0.0" },
     { name = "polars", specifier = "==1.31.0" },
     { name = "pyarrow-stubs", specifier = ">=17.16,<21.0" },
@@ -4085,6 +4087,28 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/d7/bf/0213986830a92d44d55153c1d69b509431a972eb73f204242988c4e66e86/pandas-2.3.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:404d681c698e3c8a40a61d0cd9412cc7364ab9a9cc6e144ae2992e11a2e77a20", size = 12470733 },
     { url = "https://files.pythonhosted.org/packages/a4/0e/21eb48a3a34a7d4bac982afc2c4eb5ab09f2d988bdf29d92ba9ae8e90a79/pandas-2.3.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:6021910b086b3ca756755e86ddc64e0ddafd5e58e076c72cb1585162e5ad259b", size = 13212406 },
     { url = "https://files.pythonhosted.org/packages/1f/d9/74017c4eec7a28892d8d6e31ae9de3baef71f5a5286e74e6b7aad7f8c837/pandas-2.3.0-cp312-cp312-win_amd64.whl", hash = "sha256:094e271a15b579650ebf4c5155c05dcd2a14fd4fdd72cf4854b2f7ad31ea30be", size = 10976199 },
+]
+
+[[package]]
+name = "pandas-gbq"
+version = "0.29.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "db-dtypes" },
+    { name = "google-api-core" },
+    { name = "google-auth" },
+    { name = "google-auth-oauthlib" },
+    { name = "google-cloud-bigquery" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "pandas" },
+    { name = "pyarrow" },
+    { name = "pydata-google-auth" },
+    { name = "setuptools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a5/ff/a81b01f9657b1c4b3b021e604b15a4ad1e5ac086977acf5ab74265a00a51/pandas_gbq-0.29.2.tar.gz", hash = "sha256:a3a28e7de4f8456fc4b8e9b7472b9bc470d2566f89c4cd997599e504f5a0a706", size = 65625 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5b/e5/8f3607a8827ff499ee4b841599c5e2998bf6bf8a7d997215726039d72747/pandas_gbq-0.29.2-py3-none-any.whl", hash = "sha256:99f6b642bd8340e96c2acdf7d717108aa0d31c703c2f284817ba7dc3b16110b2", size = 40971 },
 ]
 
 [[package]]
@@ -4499,6 +4523,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/67/1d/42628a2c33e93f8e9acbde0d5d735fa0850f3e6a2f8cb1eb6c40b9a732ac/pydantic_settings-2.9.1.tar.gz", hash = "sha256:c509bf79d27563add44e8446233359004ed85066cd096d8b510f715e6ef5d268", size = 163234 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b6/5f/d6d641b490fd3ec2c4c13b4244d68deea3a1b970a97be64f34fb5504ff72/pydantic_settings-2.9.1-py3-none-any.whl", hash = "sha256:59b4f431b1defb26fe620c71a7d3968a710d719f5f4cdbbdb7926edeb770f6ef", size = 44356 },
+]
+
+[[package]]
+name = "pydata-google-auth"
+version = "1.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-auth" },
+    { name = "google-auth-oauthlib" },
+    { name = "setuptools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3f/0d/455cb39f0d5a914412b57c55c6b16977c61a5ac74b615eea4fb0dc54e329/pydata-google-auth-1.9.1.tar.gz", hash = "sha256:0a51ce41c601ca0bc69b8795bf58bedff74b4a6a007c9106c7cbcdec00eaced2", size = 29814 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/cb/cdeaba62aa3c48f0d8834afb82b4a21463cd83df34fe01f9daa89a08ec6c/pydata_google_auth-1.9.1-py2.py3-none-any.whl", hash = "sha256:75ffce5d106e34b717b31844c1639ea505b7d9550dc23b96fb6c20d086b53fa3", size = 15552 },
 ]
 
 [[package]]

--- a/warehouse/oso_dagster/definitions/resources.py
+++ b/warehouse/oso_dagster/definitions/resources.py
@@ -1,6 +1,6 @@
-import logging
 import typing as t
 
+import structlog
 from dagster import ConfigurableIOManagerFactory
 from dagster_dlt import DagsterDltResource
 from dagster_gcp import BigQueryResource, GCSResource
@@ -45,7 +45,7 @@ from oso_dagster.utils.secrets import SecretResolver
 from ..config import DagsterConfig
 from ..utils import GCPSecretResolver, LocalSecretResolver
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 
 @resource_factory("global_config")

--- a/warehouse/oso_dagster/resources/io_manager.py
+++ b/warehouse/oso_dagster/resources/io_manager.py
@@ -1,9 +1,15 @@
+import structlog
 from dagster_duckdb_polars import DuckDBPolarsIOManager
 from dagster_polars import PolarsBigQueryIOManager
 from oso_dagster.config import DagsterConfig
 
+logger = structlog.get_logger(__name__)
+
 
 def load_io_manager(global_config: DagsterConfig):
     if global_config.enable_bigquery:
+        logger.info("Using PolarsBigQueryIOManager")
         return PolarsBigQueryIOManager(project=global_config.project_id)
+
+    logger.info("Using DuckDBPolarsIOManager")
     return DuckDBPolarsIOManager(database=global_config.local_duckdb_path)


### PR DESCRIPTION
This fixes an issue we ran into with ossd.projects not materializing with the correct schema. Updated packages must have caused this, but an error pointed me to the fact that the bq lib needs `pandas-gbq` to work properly because the dataframe goes polars -> pandas -> BQ insert job. 