### PR TITLE
feat: add `OsoQueryEngineWorkflowMixin` with schema analysis and context retrieval steps

### DIFF
--- a/warehouse/oso_agent/oso_agent/workflows/default.py
+++ b/warehouse/oso_agent/oso_agent/workflows/default.py
@@ -38,7 +38,6 @@ async def workflow_resolver_factory(
     """Resolver factory that creates a resolver for dependant resources for workflows."""
     from oso_agent.clients.oso_client import OsoClient
     from oso_agent.tool.oso_semantic_query_tool import create_semantic_query_tool
-    from oso_agent.tool.query_engine_tool import create_default_query_engine_tool
 
     llm = resources.get_resource("llm")
 
@@ -46,21 +45,11 @@ async def workflow_resolver_factory(
         workflow_config.oso_api_key.get_secret_value(),
     )
 
-    query_engine_tool = await create_default_query_engine_tool(
-        config,
-        oso_client=oso_client,
-        llm=llm,
-        storage_context=resources.get_resource("storage_context"),
-        embedding=resources.get_resource("embedding"),
-        synthesize_response=False,
-    )
-
     semantic_query_tool = create_semantic_query_tool(
         llm=llm, registry_description=oso_client.client.semantic.describe()
     )
 
     return DefaultResourceResolver.from_resources(
-        query_engine_tool=query_engine_tool,
         semantic_query_tool=semantic_query_tool,
         oso_client=oso_client,
         registry=oso_client.client.semantic,

--- a/warehouse/oso_agent/oso_agent/workflows/text2sql/basic.py
+++ b/warehouse/oso_agent/oso_agent/workflows/text2sql/basic.py
@@ -1,42 +1,44 @@
 import hashlib
 import logging
 
-from llama_index.core.base.response.schema import Response as ToolResponse
 from llama_index.core.llms.function_calling import FunctionCallingLLM
-from llama_index.core.tools import QueryEngineTool
 from llama_index.core.workflow import Context, StartEvent, StopEvent, step
 from oso_agent.types.response import StrResponse
 from oso_agent.workflows.types import (
     RetrySemanticQueryEvent,
     SQLResultSummaryResponseEvent,
-    Text2SQLGenerationEvent,
+    StartQueryEngineEvent,
 )
 
 from ...resources import ResourceDependency
-from .mixins import GenericText2SQLRouter, OsoDBWorkflow, SQLRowsResponseSynthesisMixin
+from .mixins import (
+    GenericText2SQLRouter,
+    OsoDBWorkflow,
+    OsoQueryEngineWorkflowMixin,
+    SQLRowsResponseSynthesisMixin,
+)
 
 logger = logging.getLogger(__name__)
 
 
 class BasicText2SQL(
-    GenericText2SQLRouter, OsoDBWorkflow, SQLRowsResponseSynthesisMixin
+    GenericText2SQLRouter,
+    OsoDBWorkflow,
+    SQLRowsResponseSynthesisMixin,
+    OsoQueryEngineWorkflowMixin,
 ):
     """The basic text to sql agent that just uses the descriptions and a rag to
     retrieve row context
     """
 
-    query_engine_tool: ResourceDependency[QueryEngineTool]
     llm: ResourceDependency[FunctionCallingLLM]
     max_retries: int = 5
 
     @step
     async def handle_text2sql_query(
-        self, ctx: Context, event: StartEvent
-    ) -> Text2SQLGenerationEvent:
-        """Handle the start event of the workflow."""
-        # Here you would typically initialize the workflow, set up context, etc.
-        # For this basic example, we just return a StopEvent to end the workflow.
-
+        self, _ctx: Context, event: StartEvent
+    ) -> StartQueryEngineEvent:
+        """Handle the start event by initiating the QueryEngine workflow."""
         event_input_id = getattr(event, "id", "")
 
         if not event_input_id:
@@ -50,52 +52,14 @@ class BasicText2SQL(
             event.input,
         )
 
-        try:
-            tool_output = await self.query_engine_tool.acall(
-                input=event.input,
-                context=ctx,
-            )
-            logger.debug(
-                "query engine called successfully for query[%s]", event_input_id
-            )
-        except Exception as e:
-            logger.error(
-                "Error calling query engine tool query[%s]: %s", event_input_id, e
-            )
-            raise ValueError(
-                f"Failed to call query engine tool query[{event_input_id}]: {e}"
-            ) from e
-
-        raw_output = tool_output.raw_output
-        assert isinstance(raw_output, ToolResponse), (
-            "Expected a ToolResponse from the query engine tool"
-        )
-
-        if raw_output.metadata is None:
-            raise ValueError("No metadata in query engine tool output")
-
-        output_sql = raw_output.metadata.get("sql_query")
-
-        logger.debug(
-            "query engine tool created the following SQL query for query[%s]: %s",
-            event_input_id,
-            output_sql,
-        )
-        if not output_sql:
-            raise ValueError(
-                "No SQL query found in metadata of query engine tool output"
-            )
-
         synthesize_response = bool(getattr(event, "synthesize_response", True))
         execute_sql = bool(getattr(event, "execute_sql", True))
 
-        return Text2SQLGenerationEvent(
+        return StartQueryEngineEvent(
             id=event_input_id,
-            output_sql=output_sql,
             input_text=event.input,
             synthesize_response=synthesize_response,
             execute_sql=execute_sql,
-            remaining_tries=self.max_retries,
         )
 
     @step
@@ -103,8 +67,6 @@ class BasicText2SQL(
         self, response: SQLResultSummaryResponseEvent
     ) -> StopEvent:
         """Return the response from the SQL query."""
-        # This step can be used to process the response further or just return it.
-
         logger.debug(
             "Returning response for query[%s] with summary: %s",
             response.id,

--- a/warehouse/oso_agent/oso_agent/workflows/types.py
+++ b/warehouse/oso_agent/oso_agent/workflows/types.py
@@ -2,7 +2,9 @@ import typing as t
 
 import pandas as pd
 from llama_index.core.prompts import PromptTemplate
+from llama_index.core.retrievers import BaseRetriever
 from llama_index.core.workflow import Event
+from oso_agent.tool.oso_sql_db import OsoSqlDatabase
 from oso_semantic.definition import SemanticQuery
 
 
@@ -128,3 +130,35 @@ class RetrySemanticQueryEvent(Event):
     error: Exception
     remaining_tries: int
     error_context: list[str] = []
+
+
+class StartQueryEngineEvent(Event):
+    """Event to start the QueryEngine workflow steps."""
+
+    id: str
+    input_text: str
+    synthesize_response: bool = True
+    execute_sql: bool = True
+
+
+class SchemaAnalysisEvent(Event):
+    """Event carrying schema analysis results."""
+
+    id: str
+    input_text: str
+    sql_database: OsoSqlDatabase
+    relevant_tables: list[str]
+    synthesize_response: bool = True
+    execute_sql: bool = True
+
+
+class RowContextEvent(Event):
+    """Event carrying row context retrieval results."""
+
+    id: str
+    input_text: str
+    sql_database: OsoSqlDatabase
+    relevant_tables: list[str]
+    row_retrievers: dict[str, BaseRetriever]
+    synthesize_response: bool = True
+    execute_sql: bool = True


### PR DESCRIPTION
This PR closes #4412 and refactors the `QueryEngineTool` from an opaque tool abstraction into explicit workflow steps. The changes replace the single `QueryEngineTool` call with a multi-step workflow that breaks down SQL generation into three distinct phases: schema analysis to identify relevant tables, row context retrieval using embedding-based similarity search, and SQL generation using LLM with enriched context.

The new `OsoQueryEngineWorkflowMixin` exposes these previously hidden steps as workflow events (`StartQueryEngineEvent`, `SchemaAnalysisEvent`, `RowContextEvent`), making the entire SQL generation process transparent and inspectable for evaluation purposes. This refactoring enables better debugging, more granular testing of individual steps, and the ability to reuse specific components of the query engine functionality across different text2sql strategies while maintaining the same end-to-end functionality but with significantly improved observability.
