### PR TITLE
fix: improve dagster load times

### DIFF
--- a/ops/helm-charts/generic/Chart.yaml
+++ b/ops/helm-charts/generic/Chart.yaml
@@ -3,4 +3,4 @@ name: generic
 description: Deploys a generic application
 
 type: application
-version: 0.3.0
+version: 0.4.0

--- a/ops/helm-charts/generic/templates/app.yaml
+++ b/ops/helm-charts/generic/templates/app.yaml
@@ -55,6 +55,8 @@ spec:
           {{- toYaml . | nindent 10 }}
         {{- end }}
         env:
+          - name: OSO_ENABLE_JSON_LOGS
+            value: "{{ .Values.app.enableJsonLogs }}"
           - name: {{ .Values.app.hostEnvVar }}
             value: "{{ .Values.app.host }}"
           - name: {{ .Values.app.portEnvVar }}

--- a/ops/helm-charts/generic/templates/app.yaml
+++ b/ops/helm-charts/generic/templates/app.yaml
@@ -56,7 +56,7 @@ spec:
         {{- end }}
         env:
           - name: OSO_ENABLE_JSON_LOGS
-            value: "{{ .Values.app.enableJsonLogs }}"
+            value: "{{- if .Values.app.enableJsonLogs -}}1{{- else -}}0{{- end -}}"
           - name: {{ .Values.app.hostEnvVar }}
             value: "{{ .Values.app.host }}"
           - name: {{ .Values.app.portEnvVar }}

--- a/ops/helm-charts/generic/values.yaml
+++ b/ops/helm-charts/generic/values.yaml
@@ -4,6 +4,8 @@ app:
   # name: "oso" # This must be set
   # command: []
   # args: []
+  # By default we enable json logs via the OSO_ENABLE_JSON_LOGS env var
+  enableJsonLogs: true
   ingress:
     enabled: false
     className: "default"

--- a/ops/helm-charts/oso-dagster/Chart.yaml
+++ b/ops/helm-charts/oso-dagster/Chart.yaml
@@ -3,7 +3,7 @@ name: oso-dagster
 description: Extension of the dagster template
 
 type: application
-version: 0.21.0
+version: 0.22.0
 appVersion: "1.0.0"
 dependencies:
 - name: dagster

--- a/ops/helm-charts/oso-dagster/templates/config-map.yaml
+++ b/ops/helm-charts/oso-dagster/templates/config-map.yaml
@@ -49,3 +49,4 @@ data:
   SQLMESH_MCS_DEFAULT_SLOTS: "{{ .Values.sqlmesh.mcs.defaultSlots }}"
   SQLMESH_MCS_SKIP_ROLLING: "{{- if .Values.sqlmesh.mcs.skipRolling -}}1{{- else -}}0{{- end -}}"
   DAGSTER_ASSET_CACHE_DIR: "{{ .Values.osoDagster.assetCacheDir }}"
+  OSO_ENABLE_JSON_LOGS: "{{- if .Values.osoDagster.enableJsonLogs -}}1{{- else -}}0{{- end -}}"

--- a/ops/helm-charts/oso-dagster/values.yaml
+++ b/ops/helm-charts/oso-dagster/values.yaml
@@ -15,6 +15,7 @@ osoDagster:
   verboseLogs: 0
   eagerlyLoadSqlTables: 0
   assetCacheDir: /dagster_assets_cache
+  enableJsonLogs: true
 
 global:
   dagsterInternalName: "dagster"

--- a/ops/k8s-apps/production/dagster/custom-helm-values.yaml
+++ b/ops/k8s-apps/production/dagster/custom-helm-values.yaml
@@ -7,7 +7,7 @@ spec:
     # We should eventually set this to 0, but we are setting it to 1 to gather
     # timing data
     osoDagster:
-      eagerlyLoadSqlTables: 1
+      eagerlyLoadSqlTables: 0
     pg:
       host: production-cloudsql-proxy-gcloud-sqlproxy.production-cloudsql-proxy.svc.cluster.local
       port: "5432"


### PR DESCRIPTION
These are some settings we need to set to get the best load times, I had previously left the sql eager loading on but now we can turn it off. Additionally this fixes an issue with json logs no longer being the default. So we make that the case for deployments now. 

