### PR TITLE
fix(sqlmesh): make timeseries_metrics_by_artifact_v0 a view

### DIFF
--- a/warehouse/oso_sqlmesh/models/marts/metrics/timeseries_metrics_by_artifact_v0.sql
+++ b/warehouse/oso_sqlmesh/models/marts/metrics/timeseries_metrics_by_artifact_v0.sql
@@ -1,6 +1,6 @@
 MODEL (
   name oso.timeseries_metrics_by_artifact_v0,
-  kind FULL,
+  kind VIEW,
   partitioned_by (month(sample_date), bucket(artifact_id, 64)),
   tags (
     'export',


### PR DESCRIPTION
We shouldn't pre-compute and store this. It's too large. I'm actually considering removing the `export` tag on it to prevent it from being copied to clickhouse unnecessarily. 