### PR TITLE
fix: this ensures that no `duplicate` projects exist for `qf` rounds

### DIFF
--- a/warehouse/oso_dagster/assets/giveth_qf.py
+++ b/warehouse/oso_dagster/assets/giveth_qf.py
@@ -48,7 +48,7 @@ def projects_for_round(
         max_depth=3,
     )
 
-    yield from graphql_factory(config, global_config, context, max_table_nesting=0)
+    yield from graphql_factory(config, global_config, context)
 
 
 @dlt_factory(
@@ -75,4 +75,6 @@ def qf_rounds(context: AssetExecutionContext, global_config: DagsterConfig):
         deps_rate_limit_seconds=1.0,
     )
 
-    yield graphql_factory(config, global_config, context, max_table_nesting=0)
+    yield graphql_factory(
+        config, global_config, context, max_table_nesting=0, write_disposition="replace"
+    )


### PR DESCRIPTION
Adds `write_disposition` replace to the `giveth` asset.