### PR TITLE
feat(sqlmesh): add new artifacts_by_project models so we can derive metrics

### DIFF
--- a/warehouse/oso_sqlmesh/models/intermediate/entities/projects/int_artifacts_by_project_all_sources.sql
+++ b/warehouse/oso_sqlmesh/models/intermediate/entities/projects/int_artifacts_by_project_all_sources.sql
@@ -61,6 +61,41 @@ WITH unioned AS (
     artifact_name,
     artifact_url
   FROM oso.int_artifacts_by_project_in_op_atlas_downstream
+  UNION ALL
+  SELECT
+    project_id,
+    artifact_id,
+    artifact_source_id,
+    artifact_source,
+    'REPOSITORY' AS artifact_type,
+    artifact_namespace,
+    artifact_name,
+    artifact_url
+  FROM oso.int_artifacts_by_project_in_crypto_ecosystems
+  UNION ALL
+  SELECT
+    project_id,
+    artifact_id,
+    artifact_source_id,
+    artifact_source,
+    'DEFILLAMA_PROTOCOL' AS artifact_type,
+    artifact_namespace,
+    artifact_name,
+    artifact_url
+  FROM oso.int_artifacts_by_project_in_defillama
+  UNION ALL
+  SELECT
+    oli.project_id,
+    oli.artifact_id,
+    oli.artifact_source_id,
+    oli.artifact_source,
+    artifacts.artifact_type,
+    oli.artifact_namespace,
+    oli.artifact_name,
+    oli.artifact_url
+  FROM oso.int_artifacts_by_project_in_openlabelsinitiative AS oli
+  LEFT JOIN oso.int_artifacts AS artifacts
+    ON artifacts.artifact_id = oli.artifact_id
 )
 SELECT DISTINCT
   unioned.project_id,

--- a/warehouse/oso_sqlmesh/models/intermediate/entities/projects/int_projects.sql
+++ b/warehouse/oso_sqlmesh/models/intermediate/entities/projects/int_projects.sql
@@ -16,7 +16,7 @@ WITH ossd_projects AS (
     project_source,
     project_namespace,
     project_name,
-    display_name,
+    COALESCE(display_name, project_name) AS display_name,
     description
   FROM oso.stg_ossd__current_projects
 ), op_atlas_projects AS (
@@ -28,6 +28,35 @@ WITH ossd_projects AS (
     display_name,
     description
   FROM oso.stg_op_atlas_project
+), crypto_ecosystem_projects AS (
+  SELECT DISTINCT
+    project_id,
+    project_source,
+    project_namespace,
+    project_name,
+    project_display_name AS display_name,
+    NULL::VARCHAR AS description
+  FROM oso.int_artifacts_by_project_in_crypto_ecosystems
+), defillama_projects AS (
+  SELECT DISTINCT
+    project_id,
+    project_source,
+    project_namespace,
+    project_name,
+    project_display_name AS display_name,
+    NULL::VARCHAR AS description
+  FROM oso.int_artifacts_by_project_in_defillama
+), openlabels_projects AS (
+  SELECT DISTINCT
+    oli.project_id,
+    oli.project_source,
+    oli.project_namespace,
+    oli.project_name,
+    COALESCE(ossd_projects.display_name, oli.project_name) AS display_name,
+    NULL::VARCHAR AS description
+  FROM oso.int_artifacts_by_project_in_openlabelsinitiative AS oli
+  LEFT JOIN ossd_projects
+    ON oli.project_name = ossd_projects.project_name
 )
 SELECT
   *
@@ -36,3 +65,15 @@ UNION ALL
 SELECT
   *
 FROM op_atlas_projects
+UNION ALL
+SELECT
+  *
+FROM crypto_ecosystem_projects
+UNION ALL
+SELECT
+  *
+FROM defillama_projects
+UNION ALL
+SELECT
+  *
+FROM openlabels_projects


### PR DESCRIPTION
This PR adds three new project data sources (crypto ecosystems, DeFiLlama, and OpenLabels Initiative) to the `int_artifacts_by_project` and `int_project` models, enabling metric derivation for a a much larger set of projects. 

Note: each of these project sources only has one type of artifact associated with it (eg, DefiLlama is only DefiLlama protocol slugs).

Tagging @ravenac95 for review because we probably need some macros to assist with this kind of work in the future, and would love his thoughts on how best to approach this. See also: https://github.com/opensource-observer/oso/issues/4797