### PR TITLE
feat(sqlmesh): collections for defillama and OLI-defined project categories

### DIFF
--- a/warehouse/metrics_tools/seed/schemas/openlabelsinitiative/labels_decoded.py
+++ b/warehouse/metrics_tools/seed/schemas/openlabelsinitiative/labels_decoded.py
@@ -6,15 +6,27 @@ class LabelsDecoded(BaseModel):
     """Stores decoded labels from the Open Labels Initiative"""
 
     id: str | None = Column("VARCHAR", description="Unique identifier for the label")
-    chain_id: str | None = Column("VARCHAR", description="Chain identifier in eip155 format")
+    chain_id: str | None = Column(
+        "VARCHAR", description="Chain identifier in eip155 format"
+    )
     address: str | None = Column("VARCHAR", description="The address being labeled")
     tag_id: str | None = Column("VARCHAR", description="The type of label")
     tag_value: str | None = Column("VARCHAR", description="The value of the label")
-    attester: str | None = Column("VARCHAR", description="Address of the entity that attested the label")
-    time_created: int | None = Column("INTEGER", description="Unix timestamp when the label was created")
-    revocation_time: int | None = Column("INTEGER", description="Unix timestamp when the label was revoked")
-    revoked: bool | None = Column("BOOLEAN", description="Whether the label has been revoked")
-    is_offchain: bool | None = Column("BOOLEAN", description="Whether the label is stored offchain")
+    attester: str | None = Column(
+        "VARCHAR", description="Address of the entity that attested the label"
+    )
+    time_created: int | None = Column(
+        "INTEGER", description="Unix timestamp when the label was created"
+    )
+    revocation_time: int | None = Column(
+        "INTEGER", description="Unix timestamp when the label was revoked"
+    )
+    revoked: bool | None = Column(
+        "BOOLEAN", description="Whether the label has been revoked"
+    )
+    is_offchain: bool | None = Column(
+        "BOOLEAN", description="Whether the label is stored offchain"
+    )
 
 
 seed = SeedConfig(
@@ -119,7 +131,7 @@ seed = SeedConfig(
             chain_id="eip155:1",
             address="0x6B175474E89094C44Da98b954EedeAC495271d0F",
             tag_id="erc_type",
-            tag_value="erc20",
+            tag_value='["erc20"]',
             attester="0xA725646c05e6Bb813d98C5aBB4E72DF4bcF00B56",
             time_created=1744237337,
             revocation_time=0,
@@ -150,6 +162,18 @@ seed = SeedConfig(
             time_created=1744237337,
             revocation_time=1744237338,
             revoked=True,
+            is_offchain=True,
+        ),
+        LabelsDecoded(
+            id="0xd16d9ca932c3263c17df8a2b7618fde52b66e8194287a06de0cf205dc49e6bcf",
+            chain_id="eip155:1",
+            address="0x6b175474e89094c44da98b954eedeac495271d0f",
+            tag_id="usage_category",
+            tag_value="stablecoin",
+            attester="0xa725646c05e6bb813d98c5abb4e72df4bcf00b56",
+            time_created=1744237337,
+            revocation_time=0,
+            revoked=False,
             is_offchain=True,
         ),
     ],

--- a/warehouse/oso_sqlmesh/models/intermediate/entities/artifacts/blockchain/addresses/int_addresses__openlabelsinitiative.sql
+++ b/warehouse/oso_sqlmesh/models/intermediate/entities/artifacts/blockchain/addresses/int_addresses__openlabelsinitiative.sql
@@ -30,7 +30,7 @@ WITH pivoted AS (
         WHEN tag_id = 'is_paymaster' THEN ['PAYMASTER']
         WHEN tag_id = 'is_safe_contract' THEN ['SAFE']
         WHEN tag_id = 'deployer_address' THEN ['DEPLOYER']
-        WHEN tag_id = 'erc_type' THEN [UPPER(tag_value)]
+        WHEN tag_id = 'erc_type' AND tag_value = '["erc20"]' THEN ['TOKEN']
         ELSE []
       END
     )) AS address_types

--- a/warehouse/oso_sqlmesh/models/intermediate/entities/collections/int_collections.sql
+++ b/warehouse/oso_sqlmesh/models/intermediate/entities/collections/int_collections.sql
@@ -8,19 +8,37 @@ MODEL (
 );
 
 SELECT
-  collections.collection_id,
-  collections.collection_source,
-  collections.collection_namespace,
-  collections.collection_name,
-  collections.display_name,
-  collections.description
-FROM oso.stg_ossd__current_collections AS collections
+  collection_id,
+  collection_source,
+  collection_namespace,
+  collection_name,
+  display_name,
+  description
+FROM oso.stg_ossd__current_collections
 UNION ALL
 SELECT DISTINCT
-  atlas_collections.collection_id,
-  atlas_collections.collection_source,
-  atlas_collections.collection_namespace,
-  atlas_collections.collection_name,
-  atlas_collections.collection_display_name AS display_name,
+  collection_id,
+  collection_source,
+  collection_namespace,
+  collection_name,
+  collection_display_name AS display_name,
   '' AS description
-FROM oso.int_projects_by_collection_in_op_atlas AS atlas_collections
+FROM oso.int_projects_by_collection_in_op_atlas
+UNION ALL
+SELECT DISTINCT
+  collection_id,
+  collection_source,
+  collection_namespace,
+  collection_name,
+  collection_display_name AS display_name,
+  '' AS description
+FROM oso.int_projects_by_collection_in_defillama
+UNION ALL
+SELECT DISTINCT
+  collection_id,
+  collection_source,
+  collection_namespace,
+  collection_name,
+  collection_display_name AS display_name,
+  '' AS description
+FROM oso.int_projects_by_collection_in_openlabelsinitiative

--- a/warehouse/oso_sqlmesh/models/intermediate/entities/collections/int_projects_by_collection.sql
+++ b/warehouse/oso_sqlmesh/models/intermediate/entities/collections/int_projects_by_collection.sql
@@ -5,6 +5,7 @@ MODEL (
   tags (
     'entity_category=collection'
   ),
+  partitioned_by ("project_source", "collection_source"),
   audits (
     has_at_least_n_rows(threshold := 0)
   )
@@ -31,3 +32,25 @@ SELECT
   project_namespace,
   project_name
 FROM oso.int_projects_by_collection_in_op_atlas
+UNION ALL
+SELECT
+  collection_id,
+  collection_source,
+  collection_namespace,
+  collection_name,
+  project_id,
+  project_source,
+  project_namespace,
+  project_name
+FROM oso.int_projects_by_collection_in_defillama
+UNION ALL
+SELECT
+  collection_id,
+  collection_source,
+  collection_namespace,
+  collection_name,
+  project_id,
+  project_source,
+  project_namespace,
+  project_name
+FROM oso.int_projects_by_collection_in_openlabelsinitiative


### PR DESCRIPTION
This is the final step in having metrics for categories of projects, eg, TVL of all lending protocols and gas generated by all trading bots.