### PR TITLE
fix(oso_agent): include AgentConfig in dependency injection

### DIFF
--- a/warehouse/oso_agent/oso_agent/workflows/default.py
+++ b/warehouse/oso_agent/oso_agent/workflows/default.py
@@ -24,6 +24,7 @@ async def default_resolver_factory(config: AgentConfig) -> ResourceResolver:
     storage_context = setup_storage_context(config, embed_model=embedding)
 
     return DefaultResourceResolver.from_resources(
+        agent_config=config,
         llm=llm,
         embedding=embedding,
         storage_context=storage_context,


### PR DESCRIPTION
I couldn't exactly replicate OSO-833 because every call that I made to the agent had an issue for missing the `agent_config` dependency.