### PR TITLE
chore: expose oso_agent on tailscale

### DIFF
--- a/ops/k8s-apps/production/agent/custom-helm-values.yaml
+++ b/ops/k8s-apps/production/agent/custom-helm-values.yaml
@@ -11,6 +11,9 @@ spec:
             newTag: deploy-20250819202048-05be8da # {"$imagepolicy": "flux-system:oso:tag"}
   values:
     app:
+      service:
+        annotations:
+          tailscale.com/expose: "true"
       ingress:
         enabled: true
         className: ingress-internal-cloudflare


### PR DESCRIPTION
Doing this so we don't need to run the `oso_agent` to test the frontend services (this might not always be desired as well)

