### PR TITLE
Dynamic replication assets

### DIFF
--- a/apps/frontend/supabase/migrations/20250826192155_create_dynamic_replication_config.sql
+++ b/apps/frontend/supabase/migrations/20250826192155_create_dynamic_replication_config.sql
@@ -1,0 +1,37 @@
+
+CREATE TABLE IF NOT EXISTS public.dynamic_replications (
+    id uuid DEFAULT extensions.uuid_generate_v4() PRIMARY KEY,
+    org_id uuid NOT NULL,
+    replication_name text NOT NULL,
+    replication_type text NOT NULL,
+    created_by uuid NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    deleted_at timestamp with time zone,
+    config jsonb,
+    credentials_path text,
+
+    CONSTRAINT replication_name_format CHECK ((replication_name ~ '^[a-z][a-z0-9_]*$'::text)),
+    CONSTRAINT fk_org_id FOREIGN KEY (org_id) REFERENCES public.organizations(id) ON DELETE CASCADE,
+    CONSTRAINT fk_created_by FOREIGN KEY (created_by) REFERENCES auth.users(id) ON DELETE CASCADE,
+    CONSTRAINT unique_replication_name_per_org UNIQUE (org_id, replication_name, deleted_at)
+);
+
+ALTER TABLE public.dynamic_replications ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Replications are usable by org members." ON public.dynamic_replications AS PERMISSIVE FOR ALL USING (
+    EXISTS (
+        SELECT 1
+        FROM public.users_by_organization
+        WHERE public.users_by_organization.org_id = public.dynamic_replications.org_id
+        AND public.users_by_organization.user_id = auth.uid()
+        AND public.users_by_organization.deleted_at IS NULL
+    )
+    OR EXISTS (
+        SELECT 1
+        FROM public.organizations
+        WHERE public.organizations.id = public.dynamic_replications.org_id
+        AND public.organizations.created_by = auth.uid()
+        AND public.organizations.deleted_at IS NULL
+    )
+);

--- a/apps/frontend/supabase/migrations/20250826192155_create_dynamic_replication_config.sql
+++ b/apps/frontend/supabase/migrations/20250826192155_create_dynamic_replication_config.sql
@@ -8,7 +8,7 @@ CREATE TABLE IF NOT EXISTS public.dynamic_replications (
     created_at timestamp with time zone DEFAULT now() NOT NULL,
     updated_at timestamp with time zone DEFAULT now() NOT NULL,
     deleted_at timestamp with time zone,
-    config jsonb,
+    config jsonb NOT NULL,
     credentials_path text,
 
     CONSTRAINT replication_name_format CHECK ((replication_name ~ '^[a-z][a-z0-9_]*$'::text)),
@@ -16,6 +16,8 @@ CREATE TABLE IF NOT EXISTS public.dynamic_replications (
     CONSTRAINT fk_created_by FOREIGN KEY (created_by) REFERENCES auth.users(id) ON DELETE CASCADE,
     CONSTRAINT unique_replication_name_per_org UNIQUE (org_id, replication_name, deleted_at)
 );
+
+CREATE INDEX dynamic_replications_org_type_idx ON public.dynamic_replications (org_id, replication_type) WHERE deleted_at IS NULL;
 
 ALTER TABLE public.dynamic_replications ENABLE ROW LEVEL SECURITY;
 

--- a/warehouse/oso_dagster/assets/dynamic/rest_api.py
+++ b/warehouse/oso_dagster/assets/dynamic/rest_api.py
@@ -1,3 +1,4 @@
+
 from dagster import (
     AssetExecutionContext,
     DynamicPartitionsDefinition,
@@ -14,6 +15,7 @@ from oso_dagster.factories import (
 )
 from oso_dagster.resources import PostgresResource
 from oso_dagster.utils import (
+    ReplicationType,
     get_credentials,
     get_dynamic_replication,
     get_dynamic_replications_partition_for_type,
@@ -82,7 +84,7 @@ def create_rest_api_sensor():
         """
         with postgres.get_connection() as conn:
             all_partition_keys = get_dynamic_replications_partition_for_type(
-                conn, "rest"
+                conn, ReplicationType.REST
             )
 
         sync_dynamic_partitions(

--- a/warehouse/oso_dagster/assets/dynamic/rest_api.py
+++ b/warehouse/oso_dagster/assets/dynamic/rest_api.py
@@ -1,0 +1,96 @@
+from dagster import (
+    AssetExecutionContext,
+    DynamicPartitionsDefinition,
+    SensorEvaluationContext,
+    SkipReason,
+    sensor,
+)
+from dlt.sources.rest_api import rest_api_resources
+from dlt.sources.rest_api.typing import RESTAPIConfig
+from oso_dagster.factories import (
+    AssetFactoryResponse,
+    dlt_factory,
+    early_resources_asset_factory,
+)
+from oso_dagster.resources import PostgresResource
+from oso_dagster.utils import (
+    get_credentials,
+    get_dynamic_replication,
+    get_dynamic_replications_partition_for_type,
+    parse_partition_key,
+    sync_dynamic_partitions,
+)
+from oso_dagster.utils.secrets import SecretResolver
+
+# Define a dynamic partitions definition.
+# The partitions will be the IDs of the replication configurations.
+rest_api_partitions = DynamicPartitionsDefinition(name="dynamic_rest_api")
+
+
+# Use the dlt_factory to create a partitioned asset.
+# The asset will be named 'replication' and have a key_prefix of 'dynamic_rest_api'.
+# The job created by this factory will be named 'dynamic_rest_api_replication_job'.
+@dlt_factory(
+    key_prefix="dynamic",
+    name="rest_api",
+    partitions_def=rest_api_partitions,
+    dataset_name=lambda ctx: parse_partition_key(ctx.partition_key)[0],
+    log_intermediate_results=True,
+)
+def dynamic_rest_asset(
+    context: AssetExecutionContext,
+    postgres: PostgresResource,
+    secrets: SecretResolver,
+):
+    """
+    A dynamic partitioned asset that uses dlt's rest_api source to replicate data.
+    Each partition corresponds to a row in the dynamic_replications table.
+    Credentials for the database and the REST APIs are resolved via Dagster's
+    SecretResolver resource, which is configured to use GCP Secret Manager.
+    """
+    with postgres.get_connection() as conn:
+        dynamic_replication = get_dynamic_replication(conn, context.partition_key)
+
+    rest_api_config: RESTAPIConfig = dynamic_replication.config
+
+    credentials = get_credentials(secrets, dynamic_replication.credentials_path)
+    # If credentials_path is provided, resolve it as a secret and add it to the config
+    if credentials:
+        client = rest_api_config.setdefault("client", {}) or {}
+        client["auth"] = credentials
+
+    resources = rest_api_resources(rest_api_config)
+
+    for resource in resources:
+        resource.table_name = f"{dynamic_replication.name}_{resource.name}"
+
+    # Create the dlt source
+    yield from resources
+
+
+@early_resources_asset_factory()
+def create_rest_api_sensor():
+    # A sensor to dynamically sync partitions based on the database state.
+    @sensor(minimum_interval_seconds=1 * 60 * 60)
+    def rest_api_sensor(
+        context: SensorEvaluationContext,
+        postgres: PostgresResource,
+    ):
+        """
+        A sensor that queries the dynamic_replications table to find new, updated,
+        or removed replication configurations and updates Dagster partitions accordingly.
+        """
+        with postgres.get_connection() as conn:
+            all_partition_keys = get_dynamic_replications_partition_for_type(
+                conn, "rest"
+            )
+
+        sync_dynamic_partitions(
+            context,
+            rest_api_partitions,
+            all_partition_keys,
+        )
+
+        return SkipReason("Synced dynamic REST API partitions")
+
+    return AssetFactoryResponse(assets=[], sensors=[rest_api_sensor])

--- a/warehouse/oso_dagster/definitions/dynamic.py
+++ b/warehouse/oso_dagster/definitions/dynamic.py
@@ -1,0 +1,26 @@
+import logging
+
+from oso_core.logging.decorators import time_function
+from oso_dagster.factories.common import ResourcesContext
+
+from .common import DefinitionsLoaderResponse, dagster_definitions
+
+logger = logging.getLogger(__name__)
+
+
+@dagster_definitions(name="dynamic")
+@time_function(logger, override_name="dynamic_definitions")
+def dynamic_definitions(
+    resources: ResourcesContext,
+) -> DefinitionsLoaderResponse:
+    """This is the dynamic definitions for oso_dagster."""
+    from ..factories import load_all_assets_from_packages
+
+    asset_factories = load_all_assets_from_packages(
+        ["oso_dagster.assets.dynamic"],
+        resources,
+    )
+
+    return DefinitionsLoaderResponse(
+        asset_factory_response=asset_factories,
+    )

--- a/warehouse/oso_dagster/definitions/resources.py
+++ b/warehouse/oso_dagster/definitions/resources.py
@@ -386,9 +386,9 @@ def time_ordered_storage_factory(
     )
 
 
-@resource_factory("postgres")
+@resource_factory("oso_app_db")
 @time_function(logger)
-def postgres_resource_factory(secrets: SecretResolver) -> PostgresResource:
+def oso_app_db_factory(secrets: SecretResolver) -> PostgresResource:
     """Factory function to create a Postgres DB resource."""
     return PostgresResource(
         connection_url=secrets.resolve_as_str(
@@ -430,6 +430,6 @@ def default_resource_registry():
     registry.add(io_manager_factory)
     registry.add(alert_manager_factory)
     registry.add(time_ordered_storage_factory)
-    registry.add(postgres_resource_factory)
+    registry.add(oso_app_db_factory)
 
     return registry

--- a/warehouse/oso_dagster/definitions/resources.py
+++ b/warehouse/oso_dagster/definitions/resources.py
@@ -18,6 +18,7 @@ from oso_dagster.resources import (
     DuckDBResource,
     K8sApiResource,
     K8sResource,
+    PostgresResource,
     PrefixedSQLMeshTranslator,
     SQLMeshExporter,
     Trino2BigQuerySQLMeshExporter,
@@ -42,7 +43,7 @@ from oso_dagster.utils.alerts import (
     CanvasDiscordWebhookAlertManager,
     LogAlertManager,
 )
-from oso_dagster.utils.secrets import SecretResolver
+from oso_dagster.utils.secrets import SecretReference, SecretResolver
 from sqlmesh.core.config.connection import DuckDBConnectionConfig, TrinoConnectionConfig
 
 from ..config import DagsterConfig
@@ -385,6 +386,17 @@ def time_ordered_storage_factory(
     )
 
 
+@resource_factory("postgres")
+@time_function(logger)
+def postgres_resource_factory(secrets: SecretResolver) -> PostgresResource:
+    """Factory function to create a Postgres DB resource."""
+    return PostgresResource(
+        connection_url=secrets.resolve_as_str(
+            SecretReference(group_name="postgres", key="connection_url")
+        ),
+    )
+
+
 def default_resource_registry():
     """By default we can configure all resource factories as the resource
     resolution is lazy."""
@@ -418,5 +430,6 @@ def default_resource_registry():
     registry.add(io_manager_factory)
     registry.add(alert_manager_factory)
     registry.add(time_ordered_storage_factory)
+    registry.add(postgres_resource_factory)
 
     return registry

--- a/warehouse/oso_dagster/resources/__init__.py
+++ b/warehouse/oso_dagster/resources/__init__.py
@@ -7,5 +7,6 @@ from .duckdb import *
 from .io_manager import *
 from .kube import *
 from .mcs import *
+from .postgres import *
 from .sqlmesh import *
 from .trino import *

--- a/warehouse/oso_dagster/resources/postgres.py
+++ b/warehouse/oso_dagster/resources/postgres.py
@@ -1,0 +1,20 @@
+from contextlib import contextmanager
+
+import psycopg2
+from dagster import ConfigurableResource
+from pydantic import Field
+
+
+class PostgresResource(ConfigurableResource):
+    """Resource for interacting with Supabase's PostgreSQL."""
+
+    connection_url: str = Field(description="PostgreSQL connection URL.")
+
+    @contextmanager
+    def get_connection(self):
+        """Provides a PostgreSQL connection."""
+        conn = psycopg2.connect(self.connection_url)
+        try:
+            yield conn
+        finally:
+            conn.close()

--- a/warehouse/oso_dagster/utils/__init__.py
+++ b/warehouse/oso_dagster/utils/__init__.py
@@ -5,6 +5,7 @@ from .bq import *
 from .bq_dts import *
 from .common import *
 from .dlt import *
+from .dynamic import *
 from .gcs import *
 from .http import *
 from .retry import *

--- a/warehouse/oso_dagster/utils/dynamic.py
+++ b/warehouse/oso_dagster/utils/dynamic.py
@@ -1,0 +1,115 @@
+import json
+from typing import Any
+
+from dagster import DynamicPartitionsDefinition, SensorEvaluationContext
+from oso_dagster.utils.secrets import SecretReference, SecretResolver
+from psycopg2.extensions import connection
+from pydantic import BaseModel
+
+DYNAMIC_REPLICATION_DATA_QUERY = """
+SELECT dr.replication_name, dr.config, dr.credentials_path
+FROM dynamic_replications dr
+JOIN organizations o ON dr.org_id = o.id
+WHERE dr.replication_type = 'rest' AND o.org_name = %s AND dr.replication_name = %s
+"""
+
+PARTITION_KEY_FOR_TYPE_QUERY = """
+SELECT o.org_name, dr.replication_name
+FROM dynamic_replications dr
+JOIN organizations o ON dr.org_id = o.id
+WHERE dr.replication_type = %s
+"""
+
+
+class DynamicReplication(BaseModel):
+    name: str
+    config: Any
+    credentials_path: str | None
+
+
+def parse_partition_key(partition_key: str) -> tuple[str, str]:
+    org_name, resource_name = partition_key.split("__", 1)
+    if not org_name or not resource_name:
+        raise Exception(f"Invalid partition key: {partition_key}")
+    return org_name, resource_name
+
+
+def mk_partition_key(org_name: str, resource_name: str) -> str:
+    return f"{org_name}__{resource_name}"
+
+
+def get_credentials(
+    secrets: SecretResolver, credentials_path: str | None
+) -> Any | None:
+    if not credentials_path:
+        return None
+    group, name = credentials_path.split("__", 1)
+
+    auth_config = json.loads(
+        secrets.resolve_as_str(SecretReference(group_name=group, key=name))
+    )
+
+    return auth_config
+
+
+def get_dynamic_replication(
+    postgres_conn: connection, partition_key: str
+) -> DynamicReplication:
+    org_name, resource_name = parse_partition_key(partition_key)
+    cur = postgres_conn.cursor()
+    cur.execute(
+        DYNAMIC_REPLICATION_DATA_QUERY,
+        (org_name, resource_name),
+    )
+    result = cur.fetchone()
+    if not result:
+        raise Exception(f"No config found for {org_name}.{resource_name}")
+
+    return DynamicReplication(
+        name=result[0], config=result[1], credentials_path=result[2]
+    )
+
+
+def get_dynamic_replications_partition_for_type(
+    postgres_conn: connection, replication_type: str
+):
+    cur = postgres_conn.cursor()
+    cur.execute(
+        PARTITION_KEY_FOR_TYPE_QUERY,
+        (replication_type,),
+    )
+    results = cur.fetchall()
+
+    return {mk_partition_key(row[0], row[1]) for row in results}
+
+
+def sync_dynamic_partitions(
+    context: SensorEvaluationContext,
+    partition: DynamicPartitionsDefinition,
+    all_partition_keys: set[str],
+):
+    # Get the set of existing partitions
+    # Retrieve existing partitions and normalize to string keys
+    existing_raw = context.instance.get_dynamic_partitions(str(partition.name))
+    existing_partitions = set(map(str, existing_raw or []))
+
+    # Find new partitions to add
+    new_partitions = sorted(list(all_partition_keys - existing_partitions))
+    if new_partitions:
+        context.instance.add_dynamic_partitions(
+            partitions_def_name=str(partition.name),
+            partition_keys=new_partitions,
+        )
+        context.log.info(f"Added new partitions: {new_partitions}")
+
+    # Find partitions to delete
+    partitions_to_delete = sorted(list(existing_partitions - all_partition_keys))
+    for pk in partitions_to_delete:
+        try:
+            context.instance.delete_dynamic_partition(
+                partitions_def_name=str(partition.name),
+                partition_key=pk,
+            )
+            context.log.info(f"Deleted partition: {pk}")
+        except Exception as e:
+            context.log.error(f"Failed to delete partition {pk}: {e}")

--- a/warehouse/oso_dagster/utils/dynamic.py
+++ b/warehouse/oso_dagster/utils/dynamic.py
@@ -1,4 +1,5 @@
 import json
+from enum import Enum
 from typing import Any
 
 from dagster import DynamicPartitionsDefinition, SensorEvaluationContext
@@ -19,6 +20,10 @@ FROM dynamic_replications dr
 JOIN organizations o ON dr.org_id = o.id
 WHERE dr.replication_type = %s
 """
+
+
+class ReplicationType(Enum):
+    REST = "rest"
 
 
 class DynamicReplication(BaseModel):
@@ -71,7 +76,7 @@ def get_dynamic_replication(
 
 
 def get_dynamic_replications_partition_for_type(
-    postgres_conn: connection, replication_type: str
+    postgres_conn: connection, replication_type: ReplicationType
 ):
     cur = postgres_conn.cursor()
     cur.execute(


### PR DESCRIPTION
One thing that I really dislike about the current implementation is that it has a lot of integrations that are hard to track, specially when making changes, e.g: the replication data in the database needs to be in a specific format for the asset to work correctly, the sensor and the asset being coupled because the partition key is an important part of the asset.

Another thing to think about is how to expose all the available configuration inside the dlt rest api resource in the frontend. We could always have an advanced mode where the user enters JSON, but how can we make the experience good for less technical users or users that do not want to read the dlt docs?

This closes OSO-856