### PR TITLE
fix(dagster): remove fake asset from core job list

### DIFF
--- a/warehouse/oso_dagster/assets/default/fake.py
+++ b/warehouse/oso_dagster/assets/default/fake.py
@@ -5,7 +5,7 @@ from oso_dagster.factories import AssetFactoryResponse, early_resources_asset_fa
 
 @early_resources_asset_factory()
 def fake_early_resources_asset(global_config: DagsterConfig) -> AssetFactoryResponse:
-    @asset(compute_kind="fake")
+    @asset(compute_kind="fake", tags={"opensource.observer/experimental": "true"})
     def fake_failing_asset() -> None:
         raise Exception("This fake asset only ever fails")
 


### PR DESCRIPTION
This asset was being executed on the materialize_core_assets_job. This removes it from the list.