### PR TITLE
fix: redirect status code to preserve `POST` method for marimo API calls

### DIFF
--- a/.github/workflows/deploy-marimo-wasm.yml
+++ b/.github/workflows/deploy-marimo-wasm.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Create _redirects file for Cloudflare Pages
         run: |
-          echo "/notebook/api/* https://www.opensource.observer/api/v1/marimo/:splat 302" > marimo_dist/_redirects
+          echo "/notebook/api/* https://www.opensource.observer/api/v1/marimo/:splat 307" > marimo_dist/_redirects
 
       - name: Install wrangler
         run: pnpm add -g wrangler


### PR DESCRIPTION
Changed redirect from `302` to `307` to prevent browsers from converting POST requests to GET when following the redirect. The `marimo` AI completion endpoint requires POST, but 302 redirects cause browsers to change the method, resulting in `405` Method Not Allowed errors.

`307` preserves the original HTTP method and request body during redirects.