### PR TITLE
add: extract `osoApiKey` from body to avoid cross-origin header strip

### DIFF
--- a/apps/frontend/app/api/v1/marimo/ai/completion/route.ts
+++ b/apps/frontend/app/api/v1/marimo/ai/completion/route.ts
@@ -77,12 +77,16 @@ export async function POST(req: NextRequest) {
   const useResponses = searchParams.get("api") === "responses";
   await using tracker = trackServerEvent(user);
 
-  const userApiKey = req.headers
-    .get("authorization")
-    ?.replace(/^bearer\s+/i, "");
+  const {
+    prompt,
+    includeOtherCode,
+    language,
+    code,
+    osoApiKey: apiKey,
+  }: MarimoCompletionRequest & { osoApiKey?: string } = await req.json();
 
   const openai = new OpenAI({
-    apiKey: userApiKey,
+    apiKey,
     baseURL,
     defaultHeaders: {
       "Accept-Encoding": "identity",
@@ -90,13 +94,6 @@ export async function POST(req: NextRequest) {
   });
 
   try {
-    const {
-      prompt,
-      includeOtherCode,
-      language,
-      code,
-    }: MarimoCompletionRequest = await req.json();
-
     tracker.track(EVENTS.API_CALL, {
       type: "marimo_ai_completion",
       useResponses,


### PR DESCRIPTION
The AI completion endpoint only reads auth tokens from the Authorization header, which gets stripped by browsers during Cloudflare's 307 redirect from `marimo.opensource.observer` to `opensource.observer/api/v1/`. I modified the endpoint to check for `osoApiKey` in the request body (which survives redirects).