### PR TITLE
feat: create dynamic `pricing` plans

### DIFF
--- a/apps/frontend/lib/types/schema-types.ts
+++ b/apps/frontend/lib/types/schema-types.ts
@@ -138,6 +138,13 @@ export type OrganizationsUpdate = z.infer<
 export type OrganizationsRelationships = z.infer<
   typeof generated.organizationsRelationshipsSchema
 >;
+export type PricingPlanRow = z.infer<typeof generated.pricingPlanRowSchema>;
+export type PricingPlanInsert = z.infer<
+  typeof generated.pricingPlanInsertSchema
+>;
+export type PricingPlanUpdate = z.infer<
+  typeof generated.pricingPlanUpdateSchema
+>;
 export type PurchaseIntentsRow = z.infer<
   typeof generated.purchaseIntentsRowSchema
 >;

--- a/apps/frontend/lib/types/schema.ts
+++ b/apps/frontend/lib/types/schema.ts
@@ -562,6 +562,7 @@ export const organizationsRowSchema = z.object({
   deleted_at: z.string().nullable(),
   id: z.string(),
   org_name: z.string(),
+  plan_id: z.string().nullable(),
   updated_at: z.string(),
 });
 
@@ -571,6 +572,7 @@ export const organizationsInsertSchema = z.object({
   deleted_at: z.string().optional().nullable(),
   id: z.string().optional(),
   org_name: z.string(),
+  plan_id: z.string().optional().nullable(),
   updated_at: z.string().optional(),
 });
 
@@ -580,6 +582,7 @@ export const organizationsUpdateSchema = z.object({
   deleted_at: z.string().optional().nullable(),
   id: z.string().optional(),
   org_name: z.string().optional(),
+  plan_id: z.string().optional().nullable(),
   updated_at: z.string().optional(),
 });
 
@@ -591,7 +594,38 @@ export const organizationsRelationshipsSchema = z.tuple([
     referencedRelation: z.literal("user_profiles"),
     referencedColumns: z.tuple([z.literal("id")]),
   }),
+  z.object({
+    foreignKeyName: z.literal("organizations_plan_id_fkey"),
+    columns: z.tuple([z.literal("plan_id")]),
+    isOneToOne: z.literal(false),
+    referencedRelation: z.literal("pricing_plan"),
+    referencedColumns: z.tuple([z.literal("plan_id")]),
+  }),
 ]);
+
+export const pricingPlanRowSchema = z.object({
+  created_at: z.string(),
+  plan_id: z.string(),
+  plan_name: z.string(),
+  price_per_credit: z.number(),
+  updated_at: z.string(),
+});
+
+export const pricingPlanInsertSchema = z.object({
+  created_at: z.string().optional(),
+  plan_id: z.string().optional(),
+  plan_name: z.string(),
+  price_per_credit: z.number(),
+  updated_at: z.string().optional(),
+});
+
+export const pricingPlanUpdateSchema = z.object({
+  created_at: z.string().optional(),
+  plan_id: z.string().optional(),
+  plan_name: z.string().optional(),
+  price_per_credit: z.number().optional(),
+  updated_at: z.string().optional(),
+});
 
 export const purchaseIntentsRowSchema = z.object({
   completed_at: z.string().nullable(),

--- a/apps/frontend/lib/types/supabase.ts
+++ b/apps/frontend/lib/types/supabase.ts
@@ -524,6 +524,7 @@ export type Database = {
           deleted_at: string | null;
           id: string;
           org_name: string;
+          plan_id: string | null;
           updated_at: string;
         };
         Insert: {
@@ -532,6 +533,7 @@ export type Database = {
           deleted_at?: string | null;
           id?: string;
           org_name: string;
+          plan_id?: string | null;
           updated_at?: string;
         };
         Update: {
@@ -540,6 +542,7 @@ export type Database = {
           deleted_at?: string | null;
           id?: string;
           org_name?: string;
+          plan_id?: string | null;
           updated_at?: string;
         };
         Relationships: [
@@ -550,7 +553,38 @@ export type Database = {
             referencedRelation: "user_profiles";
             referencedColumns: ["id"];
           },
+          {
+            foreignKeyName: "organizations_plan_id_fkey";
+            columns: ["plan_id"];
+            isOneToOne: false;
+            referencedRelation: "pricing_plan";
+            referencedColumns: ["plan_id"];
+          },
         ];
+      };
+      pricing_plan: {
+        Row: {
+          created_at: string;
+          plan_id: string;
+          plan_name: string;
+          price_per_credit: number;
+          updated_at: string;
+        };
+        Insert: {
+          created_at?: string;
+          plan_id?: string;
+          plan_name: string;
+          price_per_credit: number;
+          updated_at?: string;
+        };
+        Update: {
+          created_at?: string;
+          plan_id?: string;
+          plan_name?: string;
+          price_per_credit?: number;
+          updated_at?: string;
+        };
+        Relationships: [];
       };
       purchase_intents: {
         Row: {

--- a/apps/frontend/supabase/migrations/20250918230503_create_pricing_plans.sql
+++ b/apps/frontend/supabase/migrations/20250918230503_create_pricing_plans.sql
@@ -1,0 +1,52 @@
+CREATE TABLE IF NOT EXISTS public.pricing_plan (
+    plan_id uuid DEFAULT extensions.uuid_generate_v4() NOT NULL,
+    plan_name text NOT NULL,
+    price_per_credit integer NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    CONSTRAINT pricing_plan_pkey PRIMARY KEY (plan_id),
+    CONSTRAINT pricing_plan_plan_name_key UNIQUE (plan_name),
+    CONSTRAINT positive_price_per_credit CHECK ((price_per_credit > 0))
+);
+
+COMMENT ON TABLE public.pricing_plan IS 'Defines pricing plans and their cost per credit';
+COMMENT ON COLUMN public.pricing_plan.plan_id IS 'Unique identifier for the pricing plan';
+COMMENT ON COLUMN public.pricing_plan.plan_name IS 'Name of the pricing plan';
+COMMENT ON COLUMN public.pricing_plan.price_per_credit IS 'Cost per credit for this plan';
+
+INSERT INTO public.pricing_plan (plan_name, price_per_credit) VALUES
+('FREE', 1),
+('ENTERPRISE', 1);
+
+DO $$
+DECLARE
+    free_plan_id UUID;
+BEGIN
+    SELECT plan_id INTO free_plan_id FROM pricing_plan WHERE plan_name = 'FREE';
+
+    ALTER TABLE public.organizations
+    ADD COLUMN IF NOT EXISTS plan_id uuid;
+
+    ALTER TABLE public.organizations
+    ADD CONSTRAINT organizations_plan_id_fkey
+    FOREIGN KEY (plan_id) REFERENCES public.pricing_plan(plan_id) ON DELETE RESTRICT ON UPDATE CASCADE;
+
+    UPDATE public.organizations
+    SET plan_id = free_plan_id
+    WHERE plan_id IS NULL AND deleted_at IS NULL;
+
+    EXECUTE format('ALTER TABLE public.organizations ALTER COLUMN plan_id SET DEFAULT %L', free_plan_id);
+END $$;
+
+CREATE INDEX IF NOT EXISTS idx_organizations_plan_id ON public.organizations USING btree (plan_id);
+
+COMMENT ON COLUMN public.organizations.plan_id IS 'References the pricing plan this organization is subscribed to';
+
+ALTER TABLE public.pricing_plan ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Pricing plans are viewable by everyone" ON public.pricing_plan
+    FOR SELECT USING (true);
+
+GRANT ALL ON TABLE public.pricing_plan TO anon;
+GRANT ALL ON TABLE public.pricing_plan TO authenticated;
+GRANT ALL ON TABLE public.pricing_plan TO service_role;


### PR DESCRIPTION
> [!NOTE]
> Migration is already done and live on prod, subsequent PRs need the schema changes on this PR to land or CI will fail

This PR closes #5089 by creating a new table `pricing_plan` with different plans (free, enterprise). It also wires the credit service to use these plans to deduct credits, etc.