### PR TITLE
feat: setup `email` invite flow

### DIFF
--- a/apps/frontend/.env.local.example
+++ b/apps/frontend/.env.local.example
@@ -63,3 +63,4 @@ OSO_JWT_SECRET=
 ### Mailjet (required for invites)
 MJ_API_KEY=
 MJ_SECRET_KEY=
+MJ_FROM_EMAIL=

--- a/apps/frontend/.env.local.example
+++ b/apps/frontend/.env.local.example
@@ -60,3 +60,6 @@ NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=
 STRIPE_WEBHOOK_SECRET=
 ### OSO (required)
 OSO_JWT_SECRET=
+### Mailjet (required for invites)
+MJ_API_KEY=
+MJ_SECRET_KEY=

--- a/apps/frontend/app/api/v1/invitations/create/route.ts
+++ b/apps/frontend/app/api/v1/invitations/create/route.ts
@@ -1,0 +1,194 @@
+import { createServerClient } from "@/lib/supabase/server";
+import { NextRequest, NextResponse } from "next/server";
+import { sendInvitationEmail } from "@/lib/services/email";
+import { logger } from "@/lib/logger";
+import { z } from "zod";
+import { v4 as uuid4 } from "uuid";
+
+const CreateInvitationSchema = z.object({
+  email: z.string().email("Invalid email address"),
+  orgName: z.string().min(1, "Organization name is required"),
+});
+
+export async function POST(request: NextRequest) {
+  try {
+    const supabase = await createServerClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
+    if (!user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const { email, orgName } = CreateInvitationSchema.parse(
+      await request.json(),
+    );
+    const normalizedEmail = email.toLowerCase().trim();
+
+    const { data: userProfile } = await supabase
+      .from("user_profiles")
+      .select("*")
+      .eq("id", user.id)
+      .single();
+
+    if (!userProfile) {
+      return NextResponse.json(
+        { error: "User profile not found" },
+        {
+          status: 404,
+        },
+      );
+    }
+
+    const { data: org, error: orgError } = await supabase
+      .from("organizations")
+      .select("*")
+      .eq("org_name", orgName)
+      .single();
+
+    if (orgError || !org) {
+      return NextResponse.json(
+        { error: "Organization not found" },
+        {
+          status: 404,
+        },
+      );
+    }
+
+    const { data: membership } = await supabase
+      .from("users_by_organization")
+      .select("*")
+      .eq("user_id", user.id)
+      .eq("org_id", org.id)
+      .is("deleted_at", null)
+      .single();
+
+    if (!membership) {
+      return NextResponse.json(
+        {
+          error: "Not authorized for this organization",
+        },
+        { status: 403 },
+      );
+    }
+
+    if (user.email?.toLowerCase() === normalizedEmail) {
+      return NextResponse.json(
+        {
+          error: "You cannot invite yourself to an organization",
+        },
+        { status: 400 },
+      );
+    }
+
+    const { data: existingUser } = await supabase
+      .from("user_profiles")
+      .select("id")
+      .ilike("email", normalizedEmail)
+      .single();
+
+    if (existingUser) {
+      const { data: existingMembership } = await supabase
+        .from("users_by_organization")
+        .select("*")
+        .eq("user_id", existingUser.id)
+        .eq("org_id", org.id)
+        .is("deleted_at", null)
+        .single();
+
+      if (existingMembership) {
+        return NextResponse.json(
+          {
+            error: "This user is already a member of the organization",
+          },
+          { status: 400 },
+        );
+      }
+    }
+
+    const { data: existingInvitation } = await supabase
+      .from("invitations")
+      .select("id, status, expires_at")
+      .eq("org_id", org.id)
+      .ilike("email", normalizedEmail)
+      .eq("status", "pending")
+      .is("deleted_at", null)
+      .single();
+
+    if (existingInvitation) {
+      if (new Date(existingInvitation.expires_at) > new Date()) {
+        return NextResponse.json(
+          {
+            error: "An active invitation already exists for this email",
+          },
+          { status: 400 },
+        );
+      }
+
+      await supabase
+        .from("invitations")
+        .update({ status: "expired", updated_at: new Date().toISOString() })
+        .eq("id", existingInvitation.id);
+    }
+
+    const invitationId = uuid4();
+
+    try {
+      await sendInvitationEmail({
+        to: normalizedEmail,
+        orgName: org.org_name,
+        inviteToken: invitationId,
+        inviterName: userProfile.full_name || userProfile.email || "Someone",
+      });
+    } catch (emailError) {
+      logger.error("Failed to send invitation email:", emailError);
+      return NextResponse.json(
+        {
+          error: "Failed to send invitation email",
+        },
+        { status: 500 },
+      );
+    }
+
+    const { data: invitation, error } = await supabase
+      .from("invitations")
+      .insert({
+        id: invitationId,
+        email: normalizedEmail,
+        org_name: org.org_name,
+        org_id: org.id,
+        invited_by: userProfile.id,
+        status: "pending",
+      })
+      .select()
+      .single();
+
+    if (error) {
+      logger.error("Database error:", error);
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+
+    return NextResponse.json({
+      invitation,
+      message: `Invitation sent to ${normalizedEmail}`,
+    });
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return NextResponse.json(
+        {
+          error: "Validation error",
+          details: error.errors,
+        },
+        { status: 400 },
+      );
+    }
+    logger.error("API error:", error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      {
+        status: 500,
+      },
+    );
+  }
+}

--- a/apps/frontend/components/dataprovider/oso-global-context.tsx
+++ b/apps/frontend/components/dataprovider/oso-global-context.tsx
@@ -71,6 +71,11 @@ const OsoGlobalActionNames: ExtractMethodNames<OsoAppClient>[] = [
   "buyCredits",
   "getCreditPackages",
   "getMyPurchaseHistory",
+  "createInvitation",
+  "listInvitationsForOrg",
+  "acceptInvitation",
+  "deleteInvitation",
+  "getInviteById",
 ];
 const OsoGlobalActions: Partial<ExtractMethods<OsoAppClient>> = _.fromPairs(
   OsoGlobalActionNames.map((name) => [

--- a/apps/frontend/lib/config.ts
+++ b/apps/frontend/lib/config.ts
@@ -106,3 +106,5 @@ export const MAILJET_API_KEY =
   process.env.MJ_API_KEY ?? "MISSING MAILJET_API_KEY";
 export const MAILJET_API_SECRET =
   process.env.MJ_SECRET_KEY ?? "MISSING MAILJET_API_SECRET";
+export const MAILJET_FROM_EMAIL =
+  process.env.MJ_FROM_EMAIL ?? "MISSING MAILJET_FROM_EMAIL";

--- a/apps/frontend/lib/config.ts
+++ b/apps/frontend/lib/config.ts
@@ -101,3 +101,8 @@ export const OSO_ENTITIES = [
   "project.project_id",
   "metrics.metric_id",
 ];
+
+export const MAILJET_API_KEY =
+  process.env.MJ_API_KEY ?? "MISSING MAILJET_API_KEY";
+export const MAILJET_API_SECRET =
+  process.env.MJ_SECRET_KEY ?? "MISSING MAILJET_API_SECRET";

--- a/apps/frontend/lib/services/email.ts
+++ b/apps/frontend/lib/services/email.ts
@@ -4,7 +4,7 @@ import {
   MAILJET_API_KEY,
   MAILJET_API_SECRET,
   MAILJET_FROM_EMAIL,
-} from "@/apps/frontend/lib/config";
+} from "@/lib/config";
 
 const client = mailjet.apiConnect(MAILJET_API_KEY, MAILJET_API_SECRET);
 

--- a/apps/frontend/lib/services/email.ts
+++ b/apps/frontend/lib/services/email.ts
@@ -1,0 +1,117 @@
+import mailjet from "node-mailjet";
+import {
+  DOMAIN,
+  MAILJET_API_KEY,
+  MAILJET_API_SECRET,
+} from "@/apps/frontend/lib/config";
+
+const client = mailjet.apiConnect(MAILJET_API_KEY, MAILJET_API_SECRET);
+
+export interface InvitationEmailData {
+  to: string;
+  orgName: string;
+  inviteToken: string;
+  inviterName?: string;
+}
+
+export async function sendInvitationEmail({
+  to,
+  orgName,
+  inviteToken,
+  inviterName,
+}: InvitationEmailData): Promise<void> {
+  const PROTOCOL = DOMAIN.includes("localhost") ? "http" : "https";
+  const inviteUrl = `${PROTOCOL}://${DOMAIN}/invite/${inviteToken}`;
+
+  const subject = `${
+    inviterName || "Someone"
+  } invited you to join ${orgName} on OSO`;
+
+  const htmlBody = `
+    <!DOCTYPE html>
+    <html>
+    <head>
+      <meta charset="utf-8">
+      <meta name="viewport" content="width=device-width, initial-scale=1.0">
+      <title>You're invited to ${orgName}</title>
+    </head>
+    <body style="margin: 0; padding: 0; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; line-height: 1.6; color: #000000; background-color: #ffffff;">
+      <table width="100%" cellpadding="0" cellspacing="0" style="background-color: #ffffff; padding: 60px 20px;">
+        <tr>
+          <td align="center">
+            <table width="500" cellpadding="0" cellspacing="0" style="background-color: #ffffff;">
+
+              <!-- Header -->
+              <tr>
+                <td style="padding: 0 0 40px 0; text-align: center; border-bottom: 1px solid #000000;">
+                  <h1 style="color: #000000; margin: 0; font-size: 24px; font-weight: 400; letter-spacing: 2px;">
+                    OSO
+                  </h1>
+                </td>
+              </tr>
+
+              <!-- Main Content -->
+              <tr>
+                <td style="padding: 40px 0;">
+                  <p style="font-size: 16px; margin: 0 0 30px; color: #000000; text-align: center;">
+                    You have been invited to join <strong>${orgName}</strong>
+                  </p>
+
+                  <p style="font-size: 14px; margin: 0 0 40px; color: #666666; line-height: 1.6; text-align: center;">
+                    ${inviterName || "Someone"} has invited you to collaborate on open source analytics and insights.
+                  </p>
+
+                  <!-- CTA Button -->
+                  <div style="text-align: center; margin: 40px 0;">
+                    <a href="${inviteUrl}"
+                       style="display: inline-block; background: #000000 !important; color: #ffffff !important; text-decoration: none; padding: 12px 24px; font-weight: 400; font-size: 14px; letter-spacing: 1px; text-transform: uppercase;">
+                      Accept Invitation
+                    </a>
+                  </div>
+
+                  <p style="font-size: 12px; color: #999999; margin: 40px 0 0; line-height: 1.5; text-align: center;">
+                    Or visit: ${inviteUrl}
+                  </p>
+                </td>
+              </tr>
+
+              <!-- Footer -->
+              <tr>
+                <td style="padding: 30px 0 0; text-align: center; border-top: 1px solid #eeeeee;">
+                  <p style="margin: 0 0 10px; font-size: 12px; color: #999999;">
+                    This invitation expires in 7 days
+                  </p>
+                  <p style="margin: 0; font-size: 11px; color: #cccccc; letter-spacing: 1px;">
+                    OSO — OPEN SOURCE OBSERVER
+                  </p>
+                </td>
+              </tr>
+            </table>
+          </td>
+        </tr>
+      </table>
+    </body>
+    </html>
+  `;
+
+  const request = client.post("send", { version: "v3.1" }).request({
+    Messages: [
+      {
+        From: {
+          Email: `no-reply@opensource.observer`,
+          Name: "OSO - Open Source Observer",
+        },
+        To: [
+          {
+            Email: to,
+            Name: to,
+          },
+        ],
+        Subject: subject,
+        HtmlPart: htmlBody,
+      },
+    ],
+  });
+
+  console.log(JSON.stringify((await request).body, null, 2));
+}

--- a/apps/frontend/lib/services/email.ts
+++ b/apps/frontend/lib/services/email.ts
@@ -3,6 +3,7 @@ import {
   DOMAIN,
   MAILJET_API_KEY,
   MAILJET_API_SECRET,
+  MAILJET_FROM_EMAIL,
 } from "@/apps/frontend/lib/config";
 
 const client = mailjet.apiConnect(MAILJET_API_KEY, MAILJET_API_SECRET);
@@ -98,7 +99,7 @@ export async function sendInvitationEmail({
     Messages: [
       {
         From: {
-          Email: `no-reply@opensource.observer`,
+          Email: MAILJET_FROM_EMAIL,
           Name: "OSO - Open Source Observer",
         },
         To: [

--- a/apps/frontend/lib/types/schema-types.ts
+++ b/apps/frontend/lib/types/schema-types.ts
@@ -98,6 +98,16 @@ export type DynamicTableContextsUpdate = z.infer<
 export type DynamicTableContextsRelationships = z.infer<
   typeof generated.dynamicTableContextsRelationshipsSchema
 >;
+export type InvitationsRow = z.infer<typeof generated.invitationsRowSchema>;
+export type InvitationsInsert = z.infer<
+  typeof generated.invitationsInsertSchema
+>;
+export type InvitationsUpdate = z.infer<
+  typeof generated.invitationsUpdateSchema
+>;
+export type InvitationsRelationships = z.infer<
+  typeof generated.invitationsRelationshipsSchema
+>;
 export type NotebooksRow = z.infer<typeof generated.notebooksRowSchema>;
 export type NotebooksInsert = z.infer<typeof generated.notebooksInsertSchema>;
 export type NotebooksUpdate = z.infer<typeof generated.notebooksUpdateSchema>;
@@ -190,6 +200,12 @@ export type UsersByOrganizationUpdate = z.infer<
 export type UsersByOrganizationRelationships = z.infer<
   typeof generated.usersByOrganizationRelationshipsSchema
 >;
+export type AcceptInvitationArgs = z.infer<
+  typeof generated.acceptInvitationArgsSchema
+>;
+export type AcceptInvitationReturns = z.infer<
+  typeof generated.acceptInvitationReturnsSchema
+>;
 export type AddCreditsArgs = z.infer<typeof generated.addCreditsArgsSchema>;
 export type AddCreditsReturns = z.infer<
   typeof generated.addCreditsReturnsSchema
@@ -199,6 +215,12 @@ export type AddOrganizationCreditsArgs = z.infer<
 >;
 export type AddOrganizationCreditsReturns = z.infer<
   typeof generated.addOrganizationCreditsReturnsSchema
+>;
+export type CleanupOrphanedInvitationsArgs = z.infer<
+  typeof generated.cleanupOrphanedInvitationsArgsSchema
+>;
+export type CleanupOrphanedInvitationsReturns = z.infer<
+  typeof generated.cleanupOrphanedInvitationsReturnsSchema
 >;
 export type DeductCreditsArgs = z.infer<
   typeof generated.deductCreditsArgsSchema
@@ -211,6 +233,12 @@ export type DeductOrganizationCreditsArgs = z.infer<
 >;
 export type DeductOrganizationCreditsReturns = z.infer<
   typeof generated.deductOrganizationCreditsReturnsSchema
+>;
+export type ExpireOldInvitationsArgs = z.infer<
+  typeof generated.expireOldInvitationsArgsSchema
+>;
+export type ExpireOldInvitationsReturns = z.infer<
+  typeof generated.expireOldInvitationsReturnsSchema
 >;
 export type GetOrganizationCreditsArgs = z.infer<
   typeof generated.getOrganizationCreditsArgsSchema

--- a/apps/frontend/lib/types/schema.ts
+++ b/apps/frontend/lib/types/schema.ts
@@ -429,6 +429,75 @@ export const dynamicTableContextsRelationshipsSchema = z.tuple([
   }),
 ]);
 
+export const invitationsRowSchema = z.object({
+  accepted_at: z.string().nullable(),
+  accepted_by: z.string().nullable(),
+  created_at: z.string(),
+  deleted_at: z.string().nullable(),
+  email: z.string(),
+  expires_at: z.string(),
+  id: z.string(),
+  invited_by: z.string(),
+  org_id: z.string(),
+  org_name: z.string(),
+  status: z.string(),
+  updated_at: z.string(),
+});
+
+export const invitationsInsertSchema = z.object({
+  accepted_at: z.string().optional().nullable(),
+  accepted_by: z.string().optional().nullable(),
+  created_at: z.string().optional(),
+  deleted_at: z.string().optional().nullable(),
+  email: z.string(),
+  expires_at: z.string().optional(),
+  id: z.string().optional(),
+  invited_by: z.string(),
+  org_id: z.string(),
+  org_name: z.string(),
+  status: z.string().optional(),
+  updated_at: z.string().optional(),
+});
+
+export const invitationsUpdateSchema = z.object({
+  accepted_at: z.string().optional().nullable(),
+  accepted_by: z.string().optional().nullable(),
+  created_at: z.string().optional(),
+  deleted_at: z.string().optional().nullable(),
+  email: z.string().optional(),
+  expires_at: z.string().optional(),
+  id: z.string().optional(),
+  invited_by: z.string().optional(),
+  org_id: z.string().optional(),
+  org_name: z.string().optional(),
+  status: z.string().optional(),
+  updated_at: z.string().optional(),
+});
+
+export const invitationsRelationshipsSchema = z.tuple([
+  z.object({
+    foreignKeyName: z.literal("invitations_accepted_by_fkey"),
+    columns: z.tuple([z.literal("accepted_by")]),
+    isOneToOne: z.literal(false),
+    referencedRelation: z.literal("user_profiles"),
+    referencedColumns: z.tuple([z.literal("id")]),
+  }),
+  z.object({
+    foreignKeyName: z.literal("invitations_invited_by_fkey"),
+    columns: z.tuple([z.literal("invited_by")]),
+    isOneToOne: z.literal(false),
+    referencedRelation: z.literal("user_profiles"),
+    referencedColumns: z.tuple([z.literal("id")]),
+  }),
+  z.object({
+    foreignKeyName: z.literal("invitations_org_id_fkey"),
+    columns: z.tuple([z.literal("org_id")]),
+    isOneToOne: z.literal(false),
+    referencedRelation: z.literal("organizations"),
+    referencedColumns: z.tuple([z.literal("id")]),
+  }),
+]);
+
 export const notebooksRowSchema = z.object({
   created_at: z.string(),
   created_by: z.string(),
@@ -792,6 +861,13 @@ export const usersByOrganizationRelationshipsSchema = z.tuple([
   }),
 ]);
 
+export const acceptInvitationArgsSchema = z.object({
+  p_invitation_id: z.string(),
+  p_user_id: z.string(),
+});
+
+export const acceptInvitationReturnsSchema = z.boolean();
+
 export const addCreditsArgsSchema = z.object({
   p_amount: z.number(),
   p_metadata: jsonSchema.optional(),
@@ -810,6 +886,10 @@ export const addOrganizationCreditsArgsSchema = z.object({
 });
 
 export const addOrganizationCreditsReturnsSchema = z.boolean();
+
+export const cleanupOrphanedInvitationsArgsSchema = z.object({});
+
+export const cleanupOrphanedInvitationsReturnsSchema = z.undefined();
 
 export const deductCreditsArgsSchema = z.object({
   p_amount: z.number(),
@@ -831,6 +911,10 @@ export const deductOrganizationCreditsArgsSchema = z.object({
 });
 
 export const deductOrganizationCreditsReturnsSchema = z.boolean();
+
+export const expireOldInvitationsArgsSchema = z.object({});
+
+export const expireOldInvitationsReturnsSchema = z.undefined();
 
 export const getOrganizationCreditsArgsSchema = z.object({
   p_org_id: z.string(),

--- a/apps/frontend/lib/types/supabase.ts
+++ b/apps/frontend/lib/types/supabase.ts
@@ -396,6 +396,73 @@ export type Database = {
           },
         ];
       };
+      invitations: {
+        Row: {
+          accepted_at: string | null;
+          accepted_by: string | null;
+          created_at: string;
+          deleted_at: string | null;
+          email: string;
+          expires_at: string;
+          id: string;
+          invited_by: string;
+          org_id: string;
+          org_name: string;
+          status: string;
+          updated_at: string;
+        };
+        Insert: {
+          accepted_at?: string | null;
+          accepted_by?: string | null;
+          created_at?: string;
+          deleted_at?: string | null;
+          email: string;
+          expires_at?: string;
+          id?: string;
+          invited_by: string;
+          org_id: string;
+          org_name: string;
+          status?: string;
+          updated_at?: string;
+        };
+        Update: {
+          accepted_at?: string | null;
+          accepted_by?: string | null;
+          created_at?: string;
+          deleted_at?: string | null;
+          email?: string;
+          expires_at?: string;
+          id?: string;
+          invited_by?: string;
+          org_id?: string;
+          org_name?: string;
+          status?: string;
+          updated_at?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "invitations_accepted_by_fkey";
+            columns: ["accepted_by"];
+            isOneToOne: false;
+            referencedRelation: "user_profiles";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "invitations_invited_by_fkey";
+            columns: ["invited_by"];
+            isOneToOne: false;
+            referencedRelation: "user_profiles";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "invitations_org_id_fkey";
+            columns: ["org_id"];
+            isOneToOne: false;
+            referencedRelation: "organizations";
+            referencedColumns: ["id"];
+          },
+        ];
+      };
       notebooks: {
         Row: {
           created_at: string;
@@ -752,6 +819,10 @@ export type Database = {
       [_ in never]: never;
     };
     Functions: {
+      accept_invitation: {
+        Args: { p_invitation_id: string; p_user_id: string };
+        Returns: boolean;
+      };
       add_credits: {
         Args: {
           p_amount: number;
@@ -770,6 +841,10 @@ export type Database = {
           p_user_id: string;
         };
         Returns: boolean;
+      };
+      cleanup_orphaned_invitations: {
+        Args: Record<PropertyKey, never>;
+        Returns: undefined;
       };
       deduct_credits: {
         Args: {
@@ -791,6 +866,10 @@ export type Database = {
           p_user_id: string;
         };
         Returns: boolean;
+      };
+      expire_old_invitations: {
+        Args: Record<PropertyKey, never>;
+        Returns: undefined;
       };
       get_organization_credits: {
         Args: { p_org_id: string };

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -79,6 +79,7 @@
     "lz-string": "^1.5.0",
     "next": "^14.2.32",
     "next-themes": "^0.4.6",
+    "node-mailjet": "^6.0.9",
     "node-sql-parser": "^5.3.11",
     "openai": "^5.19.1",
     "posthog-js": "^1.260.1",

--- a/apps/frontend/supabase/migrations/20250919000000_create_invitations_table.sql
+++ b/apps/frontend/supabase/migrations/20250919000000_create_invitations_table.sql
@@ -1,0 +1,224 @@
+CREATE TABLE IF NOT EXISTS "public"."invitations" (
+  "id" uuid DEFAULT extensions.uuid_generate_v4() NOT NULL,
+  "email" text NOT NULL,
+  "org_name" text NOT NULL,
+  "org_id" uuid NOT NULL,
+  "invited_by" uuid NOT NULL,
+  "status" text NOT NULL DEFAULT 'pending',
+  "expires_at" timestamp with time zone NOT NULL DEFAULT (now() + interval '7 days'),
+  "accepted_at" timestamp with time zone,
+  "accepted_by" uuid,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "deleted_at" timestamp with time zone,
+  PRIMARY KEY ("id"),
+  FOREIGN KEY ("org_id") REFERENCES "public"."organizations"("id") ON DELETE CASCADE,
+  FOREIGN KEY ("invited_by") REFERENCES "public"."user_profiles"("id") ON DELETE CASCADE,
+  FOREIGN KEY ("accepted_by") REFERENCES "public"."user_profiles"("id") ON DELETE SET NULL,
+  CONSTRAINT "valid_status" CHECK (status IN ('pending', 'accepted', 'expired', 'revoked')),
+  CONSTRAINT "email_format" CHECK (email ~* '^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}$')
+);
+
+CREATE INDEX "idx_invitations_org_id" ON "public"."invitations" ("org_id");
+CREATE INDEX "idx_invitations_email" ON "public"."invitations" ("email");
+CREATE INDEX "idx_invitations_status" ON "public"."invitations" ("status");
+CREATE INDEX "idx_invitations_expires_at" ON "public"."invitations" ("expires_at");
+
+CREATE UNIQUE INDEX "idx_unique_pending_invitations"
+ON "public"."invitations" (LOWER(email), org_id)
+WHERE status = 'pending' AND deleted_at IS NULL;
+
+ALTER TABLE "public"."invitations" ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can view org invitations" ON "public"."invitations"
+FOR SELECT USING (
+  EXISTS (
+    SELECT 1 FROM "public"."users_by_organization" ubo
+    WHERE ubo.org_id = invitations.org_id
+    AND ubo.user_id = auth.uid()
+    AND ubo.deleted_at IS NULL
+  )
+);
+
+CREATE POLICY "Users can view invitations sent to them" ON "public"."invitations"
+FOR SELECT USING (
+  LOWER(email) = LOWER((SELECT email FROM "public"."user_profiles" WHERE id = auth.uid()))
+);
+
+CREATE POLICY "Users can create org invitations" ON "public"."invitations"
+FOR INSERT WITH CHECK (
+  EXISTS (
+    SELECT 1 FROM "public"."user_profiles" up
+    WHERE up.id = invited_by AND up.id = auth.uid()
+  ) AND
+  EXISTS (
+    SELECT 1 FROM "public"."users_by_organization" ubo
+    WHERE ubo.org_id = invitations.org_id
+    AND ubo.user_id = auth.uid()
+    AND ubo.deleted_at IS NULL
+  )
+);
+
+CREATE POLICY "Users can update own invitations" ON "public"."invitations"
+FOR UPDATE USING (
+  EXISTS (
+    SELECT 1 FROM "public"."user_profiles" up
+    WHERE up.id = invited_by AND up.id = auth.uid()
+  )
+);
+
+CREATE OR REPLACE FUNCTION "public"."validate_invitation_status_transition"()
+RETURNS trigger AS $$
+BEGIN
+  IF TG_OP = 'INSERT' THEN
+    IF NEW.status != 'pending' THEN
+      RAISE EXCEPTION 'New invitations must have status "pending"';
+    END IF;
+    RETURN NEW;
+  END IF;
+
+  IF TG_OP = 'UPDATE' AND OLD.status != NEW.status THEN
+    CASE OLD.status
+      WHEN 'pending' THEN
+        IF NEW.status NOT IN ('accepted', 'expired', 'revoked') THEN
+          RAISE EXCEPTION 'Invalid status transition from "%" to "%"', OLD.status, NEW.status;
+        END IF;
+      WHEN 'accepted' THEN
+        RAISE EXCEPTION 'Cannot change status from "accepted" to "%"', NEW.status;
+      WHEN 'expired' THEN
+        RAISE EXCEPTION 'Cannot change status from "expired" to "%"', NEW.status;
+      WHEN 'revoked' THEN
+        RAISE EXCEPTION 'Cannot change status from "revoked" to "%"', NEW.status;
+      ELSE
+        RAISE EXCEPTION 'Unknown status "%"', OLD.status;
+    END CASE;
+  END IF;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER "invitation_status_validation_trigger"
+  BEFORE INSERT OR UPDATE ON "public"."invitations"
+  FOR EACH ROW EXECUTE FUNCTION "public"."validate_invitation_status_transition"();
+
+CREATE OR REPLACE FUNCTION "public"."expire_old_invitations"()
+RETURNS void AS $$
+BEGIN
+  UPDATE public.invitations
+  SET status = 'expired', updated_at = now()
+  WHERE status = 'pending'
+  AND expires_at < now();
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+CREATE OR REPLACE FUNCTION "public"."cleanup_orphaned_invitations"()
+RETURNS void AS $$
+BEGIN
+  UPDATE public.invitations
+  SET status = 'revoked',
+      updated_at = now(),
+      deleted_at = now()
+  WHERE status = 'pending'
+  AND (
+    NOT EXISTS (
+      SELECT 1 FROM public.users_by_organization ubo
+      WHERE ubo.user_id = invitations.invited_by
+      AND ubo.org_id = invitations.org_id
+      AND ubo.deleted_at IS NULL
+    )
+    OR
+    NOT EXISTS (
+      SELECT 1 FROM public.user_profiles up
+      WHERE up.id = invitations.invited_by
+    )
+  );
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+CREATE OR REPLACE FUNCTION "public"."accept_invitation"(p_invitation_id uuid, p_user_id uuid)
+RETURNS boolean AS $$
+DECLARE
+  invitation_record record;
+  user_email text;
+BEGIN
+  PERFORM expire_old_invitations();
+  PERFORM cleanup_orphaned_invitations();
+
+  SELECT email INTO user_email
+  FROM "public"."user_profiles"
+  WHERE id = p_user_id;
+
+  IF user_email IS NULL THEN
+    RAISE EXCEPTION 'User profile not found for user ID: %', p_user_id;
+  END IF;
+
+  SELECT * INTO invitation_record
+  FROM public.invitations
+  WHERE id = p_invitation_id;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Invalid invitation ID';
+  END IF;
+
+  IF invitation_record.status != 'pending' THEN
+    RAISE EXCEPTION 'Invitation has already been % or is no longer valid', invitation_record.status;
+  END IF;
+
+  IF invitation_record.expires_at <= now() THEN
+    RAISE EXCEPTION 'Invitation has expired';
+  END IF;
+
+  IF LOWER(invitation_record.email) != LOWER(user_email) THEN
+    RAISE EXCEPTION 'Invitation email does not match user email';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM public.users_by_organization
+    WHERE user_id = p_user_id
+    AND org_id = invitation_record.org_id
+    AND deleted_at IS NULL
+  ) THEN
+    UPDATE public.invitations
+    SET status = 'accepted',
+        accepted_at = now(),
+        accepted_by = p_user_id,
+        updated_at = now()
+    WHERE id = invitation_record.id;
+
+    RETURN true;
+  END IF;
+
+  INSERT INTO public.users_by_organization (user_id, org_id, user_role)
+  VALUES (p_user_id, invitation_record.org_id, 'member');
+
+  UPDATE public.invitations
+  SET status = 'accepted',
+      accepted_at = now(),
+      accepted_by = p_user_id,
+      updated_at = now()
+  WHERE id = invitation_record.id;
+
+  RETURN true;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+GRANT ALL ON TABLE "public"."invitations" TO "anon";
+GRANT ALL ON TABLE "public"."invitations" TO "authenticated";
+GRANT ALL ON TABLE "public"."invitations" TO "service_role";
+
+GRANT ALL ON FUNCTION "public"."expire_old_invitations"() TO "anon";
+GRANT ALL ON FUNCTION "public"."expire_old_invitations"() TO "authenticated";
+GRANT ALL ON FUNCTION "public"."expire_old_invitations"() TO "service_role";
+
+GRANT ALL ON FUNCTION "public"."cleanup_orphaned_invitations"() TO "anon";
+GRANT ALL ON FUNCTION "public"."cleanup_orphaned_invitations"() TO "authenticated";
+GRANT ALL ON FUNCTION "public"."cleanup_orphaned_invitations"() TO "service_role";
+
+GRANT ALL ON FUNCTION "public"."validate_invitation_status_transition"() TO "anon";
+GRANT ALL ON FUNCTION "public"."validate_invitation_status_transition"() TO "authenticated";
+GRANT ALL ON FUNCTION "public"."validate_invitation_status_transition"() TO "service_role";
+
+GRANT ALL ON FUNCTION "public"."accept_invitation"(uuid, uuid) TO "anon";
+GRANT ALL ON FUNCTION "public"."accept_invitation"(uuid, uuid) TO "authenticated";
+GRANT ALL ON FUNCTION "public"."accept_invitation"(uuid, uuid) TO "service_role";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -255,6 +255,9 @@ importers:
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      node-mailjet:
+        specifier: ^6.0.9
+        version: 6.0.9
       node-sql-parser:
         specifier: ^5.3.11
         version: 5.3.11
@@ -10273,6 +10276,10 @@ packages:
   node-int64@0.4.0:
     resolution: {integrity: sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==}
 
+  node-mailjet@6.0.9:
+    resolution: {integrity: sha512-WGovS3g+2R/02IkD9/EWNvItRVhei7ltmh40JN53cozna41Ug/T3oKOAehBnV0B6Egx1H6L565HbeffUE7DYWg==}
+    engines: {node: '>= 12.0.0', npm: '>= 6.9.0'}
+
   node-releases@2.0.19:
     resolution: {integrity: sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==}
 
@@ -13006,6 +13013,9 @@ packages:
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  url-join@4.0.1:
+    resolution: {integrity: sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==}
 
   url-loader@4.1.1:
     resolution: {integrity: sha512-3BTV812+AVHHOJQO8O5MkWgZ5aosP7GnROJwvzLS9hWDj00lZ6Z0wNak423Lp9PBZN05N+Jk/N5Si8jRAlGyWA==}
@@ -20993,7 +21003,7 @@ snapshots:
 
   axios@1.11.0:
     dependencies:
-      follow-redirects: 1.15.9(debug@4.4.1)
+      follow-redirects: 1.15.9
       form-data: 4.0.4
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
@@ -23577,6 +23587,8 @@ snapshots:
   flatted@3.3.3: {}
 
   fn.name@1.1.0: {}
+
+  follow-redirects@1.15.9: {}
 
   follow-redirects@1.15.9(debug@4.4.1):
     optionalDependencies:
@@ -26517,6 +26529,14 @@ snapshots:
       he: 1.2.0
 
   node-int64@0.4.0: {}
+
+  node-mailjet@6.0.9:
+    dependencies:
+      axios: 1.11.0
+      json-bigint: 1.0.0
+      url-join: 4.0.1
+    transitivePeerDependencies:
+      - debug
 
   node-releases@2.0.19: {}
 
@@ -29622,6 +29642,8 @@ snapshots:
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
+
+  url-join@4.0.1: {}
 
   url-loader@4.1.1(file-loader@6.2.0(webpack@5.101.1))(webpack@5.101.1):
     dependencies:


### PR DESCRIPTION
This PR is related to #5058 and allows users to join an organization via an invite link.

> [!WARNING]
> Currently, users must be already logged in on their account to accept the invite. We want to allow users to accept invitations even when they don't have an account, WIP.

~~New env vars that need to be added to vercel:~~ Added!

```sh
MJ_API_KEY=
MJ_SECRET_KEY=
MJ_FROM_EMAIL=no-reply@opensource.observer
```