### PR TITLE
feat: dynamically render `og` images for `notebooks`

### DIFF
--- a/apps/frontend/app/[...catchall]/page.tsx
+++ b/apps/frontend/app/[...catchall]/page.tsx
@@ -2,6 +2,8 @@ import { PlasmicComponent } from "@plasmicapp/loader-nextjs";
 import { notFound } from "next/navigation";
 import { PLASMIC } from "@/plasmic-init";
 import { PlasmicClientRootProvider } from "@/plasmic-init-client";
+import type { Metadata, ResolvingMetadata } from "next";
+import { generateNotebookMetadata } from "@/lib/utils/og-metadata";
 
 // Use revalidate if you want incremental static regeneration
 // export const dynamic = "force-static";
@@ -46,6 +48,55 @@ async function fetchPlasmicComponentData(catchall: string[] | undefined) {
   }
 
   return { prefetchedData };
+}
+
+type MetadataProps = {
+  params: Promise<{ catchall?: string[] }>;
+};
+
+export async function generateMetadata(
+  { params }: MetadataProps,
+  parent: ResolvingMetadata,
+): Promise<Metadata> {
+  const { catchall } = await params;
+
+  const plasmicComponentData = await fetchPlasmicComponentData(catchall);
+  if (!plasmicComponentData) {
+    notFound();
+  }
+
+  const { prefetchedData } = plasmicComponentData;
+  if (prefetchedData.entryCompMetas.length === 0) {
+    notFound();
+  }
+
+  const [{ pageMetadata }] = prefetchedData.entryCompMetas;
+
+  if (catchall?.length === 2) {
+    const [orgName, notebookName] = catchall;
+    const notebookMetadata = await generateNotebookMetadata(
+      orgName,
+      notebookName,
+      parent,
+    );
+    if (notebookMetadata) return notebookMetadata;
+  }
+
+  return {
+    title: pageMetadata?.title,
+    description: pageMetadata?.description,
+    openGraph: {
+      title: pageMetadata?.title ?? undefined,
+      description: pageMetadata?.description ?? undefined,
+      images: pageMetadata?.openGraphImageUrl
+        ? [
+            {
+              url: pageMetadata?.openGraphImageUrl,
+            },
+          ]
+        : [],
+    },
+  } satisfies Metadata;
 }
 
 export async function generateStaticParams() {

--- a/apps/frontend/app/api/v1/og/route.tsx
+++ b/apps/frontend/app/api/v1/og/route.tsx
@@ -1,0 +1,136 @@
+import { logger } from "@/lib/logger";
+import { ImageResponse } from "@vercel/og";
+import Image from "next/image";
+import { NextRequest } from "next/server";
+
+export const runtime = "edge";
+
+async function loadGoogleFont(font: string, text: string) {
+  const url = `https://fonts.googleapis.com/css2?family=${font}:wght@400;700&text=${encodeURIComponent(
+    text,
+  )}`;
+  const css = await (await fetch(url)).text();
+  const resource = css.match(
+    /src: url\((.+)\) format\('(opentype|truetype)'\)/,
+  );
+
+  if (resource) {
+    const response = await fetch(resource[1]);
+    if (response.status == 200) {
+      return await response.arrayBuffer();
+    }
+  }
+
+  throw new Error("failed to load font data");
+}
+
+export async function GET(request: NextRequest) {
+  try {
+    const { searchParams } = new URL(request.url);
+
+    const orgName = searchParams.get("org") ?? "opensource-observer";
+    const notebookName = searchParams.get("notebook") ?? "notebook";
+    const description =
+      searchParams.get("description") ??
+      "Interactive data analysis and visualization";
+    const authorAvatar =
+      searchParams.get("avatar") ??
+      "https://avatars.githubusercontent.com/u/74559859?v=4";
+    const likes = searchParams.get("likes") ?? "1";
+    const forks = searchParams.get("forks") ?? "0";
+
+    const logoUrl =
+      "https://avatars.githubusercontent.com/u/145079657?s=200&v=4";
+
+    const pawsText = `${likes} Paw${likes === "1" ? "" : "s"}`;
+    const forksText = `${forks} Fork${forks === "1" ? "" : "s"}`;
+
+    const allText = `${orgName}/${notebookName}${description}1 Contributor${pawsText}${forksText}`;
+
+    return new ImageResponse(
+      (
+        <div tw="h-full w-full flex bg-white font-sans relative">
+          <div tw="flex w-full pt-20 pb-10 px-12 justify-between items-start">
+            <div tw="flex flex-col max-w-2xl">
+              <div tw="flex flex-wrap text-6xl text-gray-900 mb-6 leading-tight">
+                <span tw="font-normal">{orgName}/</span>
+                <span tw="font-bold">{notebookName}</span>
+              </div>
+
+              <div tw="text-3xl text-gray-600 mb-12 leading-normal flex">
+                {description}
+              </div>
+            </div>
+
+            <div tw="flex items-center justify-center pt-10">
+              <Image
+                src={authorAvatar}
+                width="240"
+                height="240"
+                tw="rounded-3xl"
+                alt="Author avatar"
+              />
+            </div>
+          </div>
+
+          <div tw="absolute bottom-20 left-12 flex gap-8 items-center">
+            <div tw="flex items-center gap-2 text-2xl text-gray-600">
+              <svg width="24" height="24" viewBox="0 0 16 16" fill="#6b7280">
+                <path d="M1 14s-1 0-1-1 1-4 6-4 6 3 6 4-1 1-1 1H1zm5-6a3 3 0 1 0 0-6 3 3 0 0 0 0 6z"></path>
+              </svg>
+              <span tw="font-bold">1 Contributor</span>
+            </div>
+
+            <div tw="flex items-center gap-2 text-2xl text-gray-600">
+              <svg
+                stroke="currentColor"
+                fill="currentColor"
+                stroke-width="0"
+                viewBox="0 0 512 512"
+                height="24px"
+                width="24px"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path d="M256 224c-79.41 0-192 122.76-192 200.25 0 34.9 26.81 55.75 71.74 55.75 48.84 0 81.09-25.08 120.26-25.08 39.51 0 71.85 25.08 120.26 25.08 44.93 0 71.74-20.85 71.74-55.75C448 346.76 335.41 224 256 224zm-147.28-12.61c-10.4-34.65-42.44-57.09-71.56-50.13-29.12 6.96-44.29 40.69-33.89 75.34 10.4 34.65 42.44 57.09 71.56 50.13 29.12-6.96 44.29-40.69 33.89-75.34zm84.72-20.78c30.94-8.14 46.42-49.94 34.58-93.36s-46.52-72.01-77.46-63.87-46.42 49.94-34.58 93.36c11.84 43.42 46.53 72.02 77.46 63.87zm281.39-29.34c-29.12-6.96-61.15 15.48-71.56 50.13-10.4 34.65 4.77 68.38 33.89 75.34 29.12 6.96 61.15-15.48 71.56-50.13 10.4-34.65-4.77-68.38-33.89-75.34zm-156.27 29.34c30.94 8.14 65.62-20.45 77.46-63.87 11.84-43.42-3.64-85.21-34.58-93.36s-65.62 20.45-77.46 63.87c-11.84 43.42 3.64 85.22 34.58 93.36z"></path>
+              </svg>
+              <span tw="font-bold">{pawsText}</span>
+            </div>
+
+            <div tw="flex items-center gap-2 text-2xl text-gray-600">
+              <svg width="24" height="24" viewBox="0 0 16 16" fill="#6b7280">
+                <path d="M5 5.372v.878c0 .414.336.75.75.75h4.5a.75.75 0 0 0 .75-.75v-.878a2.25 2.25 0 1 1 1.5 0v.878a2.25 2.25 0 0 1-2.25 2.25h-1.5v2.128a2.251 2.251 0 1 1-1.5 0V8.5h-1.5A2.25 2.25 0 0 1 3.5 6.25v-.878a2.25 2.25 0 1 1 1.5 0ZM5 3.25a.75.75 0 1 0-1.5 0 .75.75 0 0 0 1.5 0Zm6.75.75a.75.75 0 1 0 0-1.5.75.75 0 0 0 0 1.5Zm-3 8.75a.75.75 0 1 0-1.5 0 .75.75 0 0 0 1.5 0Z"></path>
+              </svg>
+              <span tw="font-bold">{forksText}</span>
+            </div>
+          </div>
+
+          <div tw="absolute bottom-6 right-6 flex">
+            <Image
+              src={logoUrl}
+              width="96"
+              height="96"
+              tw="rounded-xl"
+              alt="OSO Logo"
+            />
+          </div>
+        </div>
+      ),
+      {
+        width: 1200,
+        height: 630,
+        fonts: [
+          {
+            name: "Inter",
+            data: await loadGoogleFont("Inter", allText),
+            style: "normal",
+          },
+        ],
+      },
+    );
+  } catch (e) {
+    logger.error("Failed to generate OG image:", e);
+    return new Response(`Failed to generate the image`, {
+      status: 500,
+    });
+  }
+}

--- a/apps/frontend/app/api/v1/og/route.tsx
+++ b/apps/frontend/app/api/v1/og/route.tsx
@@ -35,7 +35,7 @@ export async function GET(request: NextRequest) {
       "Interactive data analysis and visualization";
     const authorAvatar =
       searchParams.get("avatar") ??
-      "https://avatars.githubusercontent.com/u/74559859?v=4";
+      "https://avatars.githubusercontent.com/u/145079657?s=200&v=4";
     const likes = searchParams.get("likes") ?? "1";
     const forks = searchParams.get("forks") ?? "0";
 

--- a/apps/frontend/lib/types/og-image.ts
+++ b/apps/frontend/lib/types/og-image.ts
@@ -1,0 +1,10 @@
+import { z } from "zod";
+
+export const ogImageInfoSchema = z.object({
+  orgName: z.string(),
+  notebookName: z.string(),
+  authorAvatar: z.string().nullable(),
+  description: z.string().nullable(),
+});
+
+export type OGImageInfo = z.infer<typeof ogImageInfoSchema>;

--- a/apps/frontend/lib/types/schema-types.ts
+++ b/apps/frontend/lib/types/schema-types.ts
@@ -276,6 +276,12 @@ export type ExpireOldInvitationsArgs = z.infer<
 export type ExpireOldInvitationsReturns = z.infer<
   typeof generated.expireOldInvitationsReturnsSchema
 >;
+export type GetOgImageInfoArgs = z.infer<
+  typeof generated.getOgImageInfoArgsSchema
+>;
+export type GetOgImageInfoReturns = z.infer<
+  typeof generated.getOgImageInfoReturnsSchema
+>;
 export type GetOrganizationCreditsArgs = z.infer<
   typeof generated.getOrganizationCreditsArgsSchema
 >;
@@ -305,4 +311,10 @@ export type PreviewDeductOrganizationCreditsArgs = z.infer<
 >;
 export type PreviewDeductOrganizationCreditsReturns = z.infer<
   typeof generated.previewDeductOrganizationCreditsReturnsSchema
+>;
+export type ValidateOwnershipLimitsArgs = z.infer<
+  typeof generated.validateOwnershipLimitsArgsSchema
+>;
+export type ValidateOwnershipLimitsReturns = z.infer<
+  typeof generated.validateOwnershipLimitsReturnsSchema
 >;

--- a/apps/frontend/lib/types/schema.ts
+++ b/apps/frontend/lib/types/schema.ts
@@ -501,6 +501,7 @@ export const notebooksRowSchema = z.object({
   created_by: z.string(),
   data: z.string().nullable(),
   deleted_at: z.string().nullable(),
+  description: z.string().nullable(),
   id: z.string(),
   notebook_name: z.string(),
   org_id: z.string(),
@@ -513,6 +514,7 @@ export const notebooksInsertSchema = z.object({
   created_by: z.string(),
   data: z.string().optional().nullable(),
   deleted_at: z.string().optional().nullable(),
+  description: z.string().optional().nullable(),
   id: z.string().optional(),
   notebook_name: z.string(),
   org_id: z.string(),
@@ -525,6 +527,7 @@ export const notebooksUpdateSchema = z.object({
   created_by: z.string().optional(),
   data: z.string().optional().nullable(),
   deleted_at: z.string().optional().nullable(),
+  description: z.string().optional().nullable(),
   id: z.string().optional(),
   notebook_name: z.string().optional(),
   org_id: z.string().optional(),
@@ -1017,6 +1020,13 @@ export const expireOldInvitationsArgsSchema = z.object({});
 
 export const expireOldInvitationsReturnsSchema = z.undefined();
 
+export const getOgImageInfoArgsSchema = z.object({
+  p_notebook_name: z.string(),
+  p_org_name: z.string(),
+});
+
+export const getOgImageInfoReturnsSchema = jsonSchema;
+
 export const getOrganizationCreditsArgsSchema = z.object({
   p_org_id: z.string(),
 });
@@ -1055,3 +1065,12 @@ export const previewDeductOrganizationCreditsArgsSchema = z.object({
 });
 
 export const previewDeductOrganizationCreditsReturnsSchema = z.boolean();
+
+export const validateOwnershipLimitsArgsSchema = z.object({
+  p_current_record_id: z.string().optional(),
+  p_new_role: z.string(),
+  p_old_role: z.string().optional(),
+  p_user_id: z.string(),
+});
+
+export const validateOwnershipLimitsReturnsSchema = z.boolean();

--- a/apps/frontend/lib/types/supabase.ts
+++ b/apps/frontend/lib/types/supabase.ts
@@ -467,6 +467,7 @@ export type Database = {
           created_by: string;
           data: string | null;
           deleted_at: string | null;
+          description: string | null;
           id: string;
           notebook_name: string;
           org_id: string;
@@ -478,6 +479,7 @@ export type Database = {
           created_by: string;
           data?: string | null;
           deleted_at?: string | null;
+          description?: string | null;
           id?: string;
           notebook_name: string;
           org_id: string;
@@ -489,6 +491,7 @@ export type Database = {
           created_by?: string;
           data?: string | null;
           deleted_at?: string | null;
+          description?: string | null;
           id?: string;
           notebook_name?: string;
           org_id?: string;
@@ -961,6 +964,10 @@ export type Database = {
         Args: Record<PropertyKey, never>;
         Returns: undefined;
       };
+      get_og_image_info: {
+        Args: { p_notebook_name: string; p_org_name: string };
+        Returns: Json;
+      };
       get_organization_credits: {
         Args: { p_org_id: string };
         Returns: number;
@@ -990,6 +997,15 @@ export type Database = {
           p_metadata?: Json;
           p_org_id: string;
           p_transaction_type: string;
+          p_user_id: string;
+        };
+        Returns: boolean;
+      };
+      validate_ownership_limits: {
+        Args: {
+          p_current_record_id?: string;
+          p_new_role: string;
+          p_old_role?: string;
           p_user_id: string;
         };
         Returns: boolean;

--- a/apps/frontend/lib/utils/og-metadata.ts
+++ b/apps/frontend/lib/utils/og-metadata.ts
@@ -1,0 +1,63 @@
+import type { Metadata, ResolvingMetadata } from "next";
+import { createServerClient } from "@/lib/supabase/server";
+import { ogImageInfoSchema } from "@/lib/types/og-image";
+import { DOMAIN } from "@/lib/config";
+import { logger } from "@/lib/logger";
+
+export async function generateNotebookMetadata(
+  orgName: string,
+  notebookName: string,
+  parent: ResolvingMetadata,
+): Promise<Metadata | null> {
+  try {
+    const supabase = await createServerClient();
+
+    const { data, error } = await supabase.rpc("get_og_image_info", {
+      p_org_name: orgName,
+      p_notebook_name: notebookName,
+    });
+
+    if (error) return null;
+
+    const validation = ogImageInfoSchema.safeParse(data);
+    if (!validation.success) return null;
+
+    const paramFields = [
+      ["org", orgName],
+      ["notebook", notebookName],
+      ["avatar", validation.data.authorAvatar],
+      ["description", validation.data.description],
+    ].filter(([, v]) => v !== null) as [string, string][];
+
+    const PROTOCOL = DOMAIN.includes("localhost") ? "http:" : "https:";
+    const ogImageUrl = new URL("/api/v1/og", `${PROTOCOL}//${DOMAIN}`);
+
+    for (const [key, value] of paramFields) {
+      ogImageUrl.searchParams.set(key, value);
+    }
+
+    const previousImages = (await parent).openGraph?.images || [];
+    const title = `${orgName}/${notebookName}`;
+    const description = "Interactive data analysis and visualization";
+
+    return {
+      title,
+      description,
+      openGraph: {
+        title,
+        description,
+        type: "website",
+        images: [ogImageUrl.toString(), ...previousImages],
+      },
+      twitter: {
+        card: "summary_large_image",
+        title,
+        description,
+        images: [ogImageUrl.toString()],
+      },
+    };
+  } catch (error) {
+    logger.error("Error generating notebook metadata:", error);
+    return null;
+  }
+}

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -67,6 +67,7 @@
     "@supabase/supabase-js": "^2.55.0",
     "@tanstack/react-table": "^8.21.3",
     "@tremor/react": "^3.18.7",
+    "@vercel/og": "^0.8.5",
     "add": "^2.0.6",
     "ai": "^5.0.15",
     "algoliasearch": "^5.35.0",

--- a/apps/frontend/robots.ts
+++ b/apps/frontend/robots.ts
@@ -1,0 +1,10 @@
+import type { MetadataRoute } from "next";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: "*",
+      allow: "/api/v1/og/*",
+    },
+  };
+}

--- a/apps/frontend/supabase/migrations/20250925143413_users_rls_policy.sql
+++ b/apps/frontend/supabase/migrations/20250925143413_users_rls_policy.sql
@@ -1,0 +1,81 @@
+DROP POLICY IF EXISTS "Public profiles are viewable by everyone." ON "public"."user_profiles";
+
+CREATE POLICY "Users can view their own profiles" ON "public"."user_profiles"
+  FOR SELECT USING (auth.uid() = id);
+
+CREATE OR REPLACE FUNCTION get_og_image_info(p_org_name text, p_notebook_name text)
+RETURNS json AS $$
+DECLARE
+  org_record record;
+  notebook_record record;
+  author_avatar_url text;
+  is_public boolean := false;
+BEGIN
+  SELECT id, org_name INTO org_record
+  FROM organizations
+  WHERE org_name = p_org_name AND deleted_at IS NULL;
+
+  IF NOT FOUND THEN
+    RETURN json_build_object(
+      'orgName', p_org_name,
+      'notebookName', p_notebook_name,
+      'authorAvatar', null,
+      'description', null
+    );
+  END IF;
+
+  SELECT id, notebook_name, created_by, description INTO notebook_record
+  FROM notebooks
+  WHERE notebook_name = p_notebook_name
+    AND org_id = org_record.id
+    AND deleted_at IS NULL;
+
+  IF NOT FOUND THEN
+    RETURN json_build_object(
+      'orgName', p_org_name,
+      'notebookName', p_notebook_name,
+      'authorAvatar', null,
+      'description', null
+    );
+  END IF;
+
+  SELECT EXISTS(
+    SELECT 1 FROM resource_permissions
+    WHERE notebook_id = notebook_record.id
+      AND user_id IS NULL
+      AND revoked_at IS NULL
+  ) INTO is_public;
+
+  IF is_public THEN
+    SELECT avatar_url INTO author_avatar_url
+    FROM user_profiles
+    WHERE id = notebook_record.created_by;
+
+    RETURN json_build_object(
+      'orgName', p_org_name,
+      'notebookName', p_notebook_name,
+      'authorAvatar', author_avatar_url,
+      'description', notebook_record.description
+    );
+  ELSE
+    RETURN json_build_object(
+      'orgName', p_org_name,
+      'notebookName', p_notebook_name,
+      'authorAvatar', null,
+      'description', null
+    );
+  END IF;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+GRANT EXECUTE ON FUNCTION get_og_image_info(text, text) TO anon;
+GRANT EXECUTE ON FUNCTION get_og_image_info(text, text) TO authenticated;
+
+ALTER TABLE notebooks DROP CONSTRAINT IF EXISTS notebooks_name_org_id_unique;
+DROP INDEX IF EXISTS notebooks_name_org_id_unique;
+
+CREATE UNIQUE INDEX notebooks_name_org_id_active_unique
+ON notebooks (notebook_name, org_id)
+WHERE deleted_at IS NULL;
+
+ALTER TABLE notebooks ADD COLUMN IF NOT EXISTS description text;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -219,6 +219,9 @@ importers:
       '@tremor/react':
         specifier: ^3.18.7
         version: 3.18.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@vercel/og':
+        specifier: ^0.8.5
+        version: 0.8.5
       add:
         specifier: ^2.0.6
         version: 2.0.6
@@ -4598,6 +4601,10 @@ packages:
   '@repeaterjs/repeater@3.0.6':
     resolution: {integrity: sha512-Javneu5lsuhwNCryN+pXH93VPQ8g0dBX7wItHFgYiwQmzE1sVdg5tWHiOgHywzL2W21XQopa7IwIEnNbmeUJYA==}
 
+  '@resvg/resvg-wasm@2.4.0':
+    resolution: {integrity: sha512-C7c51Nn4yTxXFKvgh2txJFNweaVcfUPQxwEUFw4aWsCmfiBDJsTSwviIF8EcwjQ6k8bPyMWCl1vw4BdxE569Cg==}
+    engines: {node: '>= 10'}
+
   '@rollup/pluginutils@5.2.0':
     resolution: {integrity: sha512-qWJ2ZTbmumwiLFomfzTyt5Kng4hwPi9rwCYN4SHb6eaRU1KNO4ccxINHr/VhH4GgPlt1XfSTLX2LBTme8ne4Zw==}
     engines: {node: '>=14.0.0'}
@@ -4755,6 +4762,11 @@ packages:
   '@sentry/utils@5.30.0':
     resolution: {integrity: sha512-zaYmoH0NWWtvnJjC9/CBseXMtKHm/tm40sz3YfJRxeQjyzRqNQPgivpd9R/oDJCYj999mzdW382p/qi2ypjLww==}
     engines: {node: '>=6'}
+
+  '@shuding/opentype.js@1.4.0-beta.0':
+    resolution: {integrity: sha512-3NgmNyH3l/Hv6EvsWJbsvpcpUba6R8IREQ83nH83cyakCw7uM1arZKNfHwv1Wz6jgqrF/j4x5ELvR6PnK9nTcA==}
+    engines: {node: '>= 8.0.0'}
+    hasBin: true
 
   '@sideway/address@4.1.5':
     resolution: {integrity: sha512-IqO/DUQHUkPeixNQ8n0JA6102hT9CmaljNTPmQ1u8MEhBo/R4Q8eKLN/vGZxuebwOroDB4cbpjheD4+/sKFK4Q==}
@@ -5982,6 +5994,10 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@vercel/og@0.8.5':
+    resolution: {integrity: sha512-fHqnxfBYcwkamlEgcIzaZqL8IHT09hR7FZL7UdMTdGJyoaBzM/dY6ulO5Swi4ig30FrBJI9I2C+GLV9sb9vexA==}
+    engines: {node: '>=16'}
+
   '@vitest/browser@3.2.4':
     resolution: {integrity: sha512-tJxiPrWmzH8a+w9nLKlQMzAKX/7VjFs50MWgcAj7p9XQ7AQ9/35fByFYptgPELyLw+0aixTnC4pUWV+APcZ/kw==}
     peerDependencies:
@@ -6532,6 +6548,10 @@ packages:
   base-x@4.0.0:
     resolution: {integrity: sha512-FuwxlW4H5kh37X/oW59pwTzzTKRzfrrQwhmyspRM7swOEZcHtDZSCt45U6oKgtuFE+WYPblePMVIPR4RZrh/hw==}
 
+  base64-js@0.0.8:
+    resolution: {integrity: sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw==}
+    engines: {node: '>= 0.4'}
+
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
@@ -6738,6 +6758,9 @@ packages:
   camelcase@7.0.1:
     resolution: {integrity: sha512-xlx1yCK2Oc1APsPXDL2LdlNP6+uu8OCDdhOBSVT279M/S+y75O30C2VuD8T2ogdePBBl7PfPF4504tnLgX3zfw==}
     engines: {node: '>=14.16'}
+
+  camelize@1.0.1:
+    resolution: {integrity: sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==}
 
   caniuse-api@3.0.0:
     resolution: {integrity: sha512-bsTwuIg/BZZK/vreVTYYbSWoe2F+71P7K5QGEX+pT250DZbfU1MQ5prOKpPR+LL6uWKK3KMwMCAS74QB3Um1uw==}
@@ -7230,17 +7253,31 @@ packages:
     resolution: {integrity: sha512-x8dy3RnvYdlUcPOjkEHqozhiwzKNSq7GcPuXFbnyMOCHxX8V3OgIg/pYuabl2sbUPfIJaeAQB7PMOK8DFIdoRA==}
     engines: {node: '>=12'}
 
+  css-background-parser@0.1.0:
+    resolution: {integrity: sha512-2EZLisiZQ+7m4wwur/qiYJRniHX4K5Tc9w93MT3AS0WS1u5kaZ4FKXlOTBhOjc+CgEgPiGY+fX1yWD8UwpEqUA==}
+
   css-blank-pseudo@7.0.1:
     resolution: {integrity: sha512-jf+twWGDf6LDoXDUode+nc7ZlrqfaNphrBIBrcmeP3D8yw1uPaix1gCC8LUQUGQ6CycuK2opkbFFWFuq/a94ag==}
     engines: {node: '>=18'}
     peerDependencies:
       postcss: ^8.4
 
+  css-box-shadow@1.0.0-3:
+    resolution: {integrity: sha512-9jaqR6e7Ohds+aWwmhe6wILJ99xYQbfmK9QQB9CcMjDbTxPZjwEmUQpU91OG05Xgm8BahT5fW+svbsQGjS/zPg==}
+
+  css-color-keywords@1.0.0:
+    resolution: {integrity: sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==}
+    engines: {node: '>=4'}
+
   css-declaration-sorter@7.2.0:
     resolution: {integrity: sha512-h70rUM+3PNFuaBDTLe8wF/cdWu+dOZmb7pJt8Z2sedYbAcQVQV/tEchueg3GWxwqS0cxtbxmaHEdkNACqcvsow==}
     engines: {node: ^14 || ^16 || >=18}
     peerDependencies:
       postcss: ^8.0.9
+
+  css-gradient-parser@0.0.16:
+    resolution: {integrity: sha512-3O5QdqgFRUbXvK1x5INf1YkBz1UKSWqrd63vWsum8MNHDBYD5urm3QtxZbKU259OrEXNM26lP/MPY3d1IGkBgA==}
+    engines: {node: '>=16'}
 
   css-has-pseudo@7.0.2:
     resolution: {integrity: sha512-nzol/h+E0bId46Kn2dQH5VElaknX2Sr0hFuB/1EomdC7j+OISt2ZzK7EHX9DZDY53WbIVAR7FYKSO2XnSf07MQ==}
@@ -7299,6 +7336,9 @@ packages:
 
   css-select@5.2.2:
     resolution: {integrity: sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==}
+
+  css-to-react-native@3.2.0:
+    resolution: {integrity: sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==}
 
   css-tree@1.1.3:
     resolution: {integrity: sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==}
@@ -7903,6 +7943,10 @@ packages:
     resolution: {integrity: sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==}
     engines: {node: '>=12'}
 
+  emoji-regex-xs@2.0.1:
+    resolution: {integrity: sha512-1QFuh8l7LqUcKe24LsPUNzjrzJQ7pgRwp1QMcZ5MX6mFplk2zQ08NVCM84++1cveaUUYtcCYHmeFEuNg16sU4g==}
+    engines: {node: '>=10.0.0'}
+
   emoji-regex@10.4.0:
     resolution: {integrity: sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==}
 
@@ -8447,6 +8491,9 @@ packages:
   fflate@0.4.8:
     resolution: {integrity: sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA==}
 
+  fflate@0.7.4:
+    resolution: {integrity: sha512-5u2V/CDW15QM1XbbgS+0DfPxVB+jUKhWEKuuFuHncbk3tEEqzmoXL+2KyOFuKGqOnmdIy0/davWF1CkuwtibCw==}
+
   figures@3.2.0:
     resolution: {integrity: sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==}
     engines: {node: '>=8'}
@@ -8934,6 +8981,10 @@ packages:
 
   header-case@2.0.4:
     resolution: {integrity: sha512-H/vuk5TEEVZwrR0lp2zed9OCo1uAILMlx0JEMgC26rzyJJ3N1v6XkwHHXJQdR2doSjcGPM6OKPYoJgf0plJ11Q==}
+
+  hex-rgb@4.3.0:
+    resolution: {integrity: sha512-Ox1pJVrDCyGHMG9CFg1tmrRUMRPRsAWYc/PinY0XzJU4K7y7vjNoLKIQ7BR5UJMCxNN8EM1MNDmHWA/B3aZUuw==}
+    engines: {node: '>=6'}
 
   history@4.10.1:
     resolution: {integrity: sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==}
@@ -9959,6 +10010,9 @@ packages:
   lilconfig@3.1.3:
     resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
     engines: {node: '>=14'}
+
+  linebreak@1.1.0:
+    resolution: {integrity: sha512-MHp03UImeVhB7XZtjd0E4n6+3xr5Dq/9xI/5FptGk5FrbDR3zagPa2DS6U8ks/3HjbKWG9Q1M2ufOzxV2qLYSQ==}
 
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
@@ -10996,6 +11050,9 @@ packages:
   package-manager-detector@1.3.0:
     resolution: {integrity: sha512-ZsEbbZORsyHuO00lY1kV3/t72yp6Ysay6Pd17ZAlNGuGwmWDLCJxFpRs0IzfXfj1o4icJOkUEioexFHzyPurSQ==}
 
+  pako@0.2.9:
+    resolution: {integrity: sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==}
+
   pako@2.1.0:
     resolution: {integrity: sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==}
 
@@ -11005,6 +11062,9 @@ packages:
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
+
+  parse-css-color@0.2.1:
+    resolution: {integrity: sha512-bwS/GGIFV3b6KS4uwpzCFj4w297Yl3uqnSgIPsoQkx7GMLROXfMnWvxfNkL0oh8HVhZA4hvJoEoEIqonfJ3BWg==}
 
   parse-entities@4.0.2:
     resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
@@ -12263,6 +12323,10 @@ packages:
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
+  satori@0.16.0:
+    resolution: {integrity: sha512-ZvHN3ygzZ8FuxjSNB+mKBiF/NIoqHzlBGbD0MJiT+MvSsFOvotnWOhdTjxKzhHRT2wPC1QbhLzx2q/Y83VhfYQ==}
+    engines: {node: '>=16'}
+
   sax@1.4.1:
     resolution: {integrity: sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==}
 
@@ -12695,6 +12759,9 @@ packages:
     resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
     engines: {node: '>=18'}
 
+  string.prototype.codepointat@0.2.1:
+    resolution: {integrity: sha512-2cBVCj6I4IOvEnjgO/hWqXjqBGsY+zwPmHl12Srk9IXSZ56Jwwmy+66XO5Iut/oQVR7t5ihYdLB0GMa4alEUcg==}
+
   string.prototype.includes@2.0.0:
     resolution: {integrity: sha512-E34CkBgyeqNDcrbU76cDjL5JLcVrtSdYq0MEh/B10r17pRP4ciHLwTgnuLV8Ay6cgEMLkcBkFCKyFZ43YldYzg==}
 
@@ -12990,6 +13057,9 @@ packages:
 
   tiny-case@1.0.3:
     resolution: {integrity: sha512-Eet/eeMhkO6TX8mnUteS9zgPbUMQa4I6Kkp5ORiBD5476/m+PIRiumP5tmh5ioJpH7k51Kehawy2UDfsnxxY8Q==}
+
+  tiny-inflate@1.0.3:
+    resolution: {integrity: sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==}
 
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
@@ -13380,6 +13450,9 @@ packages:
   unicode-property-aliases-ecmascript@2.1.0:
     resolution: {integrity: sha512-6t3foTQI9qne+OZoVQB/8x8rk2k1eVy1gRXhV3oFQ5T6R1dqQ1xtin3XqSlx3+ATBkliTaR/hHyJBm+LVPNM8w==}
     engines: {node: '>=4'}
+
+  unicode-trie@2.0.0:
+    resolution: {integrity: sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==}
 
   unicorn-magic@0.1.0:
     resolution: {integrity: sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==}
@@ -14084,6 +14157,9 @@ packages:
   yocto-queue@1.1.1:
     resolution: {integrity: sha512-b4JR1PFR10y1mKjhHY9LaGo6tmrgjit7hxVIeAmyMw3jegXR4dhYqLaQF5zMXZxY7tLpMyJeLjr1C4rLmkVe8g==}
     engines: {node: '>=12.20'}
+
+  yoga-layout@3.2.1:
+    resolution: {integrity: sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==}
 
   yup@1.7.0:
     resolution: {integrity: sha512-VJce62dBd+JQvoc+fCVq+KZfPHr+hXaxCcVgotfwWvlR0Ja3ffYKaJBT8rptPOSKOGJDCUnW2C2JWpud7aRP6Q==}
@@ -20133,6 +20209,8 @@ snapshots:
 
   '@repeaterjs/repeater@3.0.6': {}
 
+  '@resvg/resvg-wasm@2.4.0': {}
+
   '@rollup/pluginutils@5.2.0(rollup@4.46.2)':
     dependencies:
       '@types/estree': 1.0.8
@@ -20277,6 +20355,11 @@ snapshots:
     dependencies:
       '@sentry/types': 5.30.0
       tslib: 1.14.1
+
+  '@shuding/opentype.js@1.4.0-beta.0':
+    dependencies:
+      fflate: 0.7.4
+      string.prototype.codepointat: 0.2.1
 
   '@sideway/address@4.1.5':
     dependencies:
@@ -21755,6 +21838,11 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
 
+  '@vercel/og@0.8.5':
+    dependencies:
+      '@resvg/resvg-wasm': 2.4.0
+      satori: 0.16.0
+
   '@vitest/browser@3.2.4(bufferutil@4.0.9)(playwright@1.54.2)(vite@7.1.1(@types/node@24.2.1)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(yaml@2.8.1))(vitest@3.2.4)':
     dependencies:
       '@testing-library/dom': 10.4.1
@@ -22423,6 +22511,8 @@ snapshots:
 
   base-x@4.0.0: {}
 
+  base64-js@0.0.8: {}
+
   base64-js@1.5.1: {}
 
   batch@0.6.1: {}
@@ -22710,6 +22800,8 @@ snapshots:
   camelcase@6.3.0: {}
 
   camelcase@7.0.1: {}
+
+  camelize@1.0.1: {}
 
   caniuse-api@3.0.0:
     dependencies:
@@ -23225,14 +23317,22 @@ snapshots:
     dependencies:
       type-fest: 1.4.0
 
+  css-background-parser@0.1.0: {}
+
   css-blank-pseudo@7.0.1(postcss@8.5.6):
     dependencies:
       postcss: 8.5.6
       postcss-selector-parser: 7.1.0
 
+  css-box-shadow@1.0.0-3: {}
+
+  css-color-keywords@1.0.0: {}
+
   css-declaration-sorter@7.2.0(postcss@8.5.6):
     dependencies:
       postcss: 8.5.6
+
+  css-gradient-parser@0.0.16: {}
 
   css-has-pseudo@7.0.2(postcss@8.5.6):
     dependencies:
@@ -23289,6 +23389,12 @@ snapshots:
       domhandler: 5.0.3
       domutils: 3.2.2
       nth-check: 2.1.1
+
+  css-to-react-native@3.2.0:
+    dependencies:
+      camelize: 1.0.1
+      css-color-keywords: 1.0.0
+      postcss-value-parser: 4.2.0
 
   css-tree@1.1.3:
     dependencies:
@@ -23934,6 +24040,8 @@ snapshots:
       minimalistic-crypto-utils: 1.0.1
 
   emittery@0.13.1: {}
+
+  emoji-regex-xs@2.0.1: {}
 
   emoji-regex@10.4.0: {}
 
@@ -24805,6 +24913,8 @@ snapshots:
 
   fflate@0.4.8: {}
 
+  fflate@0.7.4: {}
+
   figures@3.2.0:
     dependencies:
       escape-string-regexp: 1.0.5
@@ -25487,6 +25597,8 @@ snapshots:
     dependencies:
       capital-case: 1.0.4
       tslib: 2.8.1
+
+  hex-rgb@4.3.0: {}
 
   history@4.10.1:
     dependencies:
@@ -26742,6 +26854,11 @@ snapshots:
       lightningcss-win32-x64-msvc: 1.30.1
 
   lilconfig@3.1.3: {}
+
+  linebreak@1.1.0:
+    dependencies:
+      base64-js: 0.0.8
+      unicode-trie: 2.0.0
 
   lines-and-columns@1.2.4: {}
 
@@ -28164,6 +28281,8 @@ snapshots:
 
   package-manager-detector@1.3.0: {}
 
+  pako@0.2.9: {}
+
   pako@2.1.0: {}
 
   param-case@3.0.4:
@@ -28174,6 +28293,11 @@ snapshots:
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
+
+  parse-css-color@0.2.1:
+    dependencies:
+      color-name: 1.1.4
+      hex-rgb: 4.3.0
 
   parse-entities@4.0.2:
     dependencies:
@@ -29607,6 +29731,20 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
+  satori@0.16.0:
+    dependencies:
+      '@shuding/opentype.js': 1.4.0-beta.0
+      css-background-parser: 0.1.0
+      css-box-shadow: 1.0.0-3
+      css-gradient-parser: 0.0.16
+      css-to-react-native: 3.2.0
+      emoji-regex-xs: 2.0.1
+      escape-html: 1.0.3
+      linebreak: 1.1.0
+      parse-css-color: 0.2.1
+      postcss-value-parser: 4.2.0
+      yoga-layout: 3.2.1
+
   sax@1.4.1: {}
 
   saxes@6.0.0:
@@ -30142,6 +30280,8 @@ snapshots:
       get-east-asian-width: 1.3.0
       strip-ansi: 7.1.0
 
+  string.prototype.codepointat@0.2.1: {}
+
   string.prototype.includes@2.0.0:
     dependencies:
       define-properties: 1.2.1
@@ -30470,6 +30610,8 @@ snapshots:
   thunky@1.1.0: {}
 
   tiny-case@1.0.3: {}
+
+  tiny-inflate@1.0.3: {}
 
   tiny-invariant@1.3.3: {}
 
@@ -30836,6 +30978,11 @@ snapshots:
   unicode-match-property-value-ecmascript@2.2.0: {}
 
   unicode-property-aliases-ecmascript@2.1.0: {}
+
+  unicode-trie@2.0.0:
+    dependencies:
+      pako: 0.2.9
+      tiny-inflate: 1.0.3
 
   unicorn-magic@0.1.0: {}
 
@@ -31653,6 +31800,8 @@ snapshots:
   yocto-queue@0.1.0: {}
 
   yocto-queue@1.1.1: {}
+
+  yoga-layout@3.2.1: {}
 
   yup@1.7.0:
     dependencies:


### PR DESCRIPTION
This PR:
- dynamically renders `og` images on `/$org/$notebook` (closes #5162)
- makes `user_profiles` private (part of #4526)
- adds `description` column to `notebooks` (closes #5163)
