### PR TITLE
Ingest: Copilot-ready Dagster asset scaffolding (REST, GraphQL, DB) + clear authoring rules & runnable examples

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,47 +1,414 @@
-## Development Practices
+# GitHub Copilot Instructions for OSO Data Contributions
 
-- Start with minimal, lean implementations focused on proof-of-concept
-- Prefer extending existing patterns over implementing from scratch
-- Use defensive programming for data validation and external API calls
-- Include structured logging with appropriate levels (debug, info, warn, error)
-- Create focused, single-purpose functions and classes
-- Use type hints and docstrings for public interfaces
-- Write tests for data transformations and business logic
-- Follow existing code patterns and architectural decisions
-- Use `uv` for Python package management
-- Prefer SQLMesh SQL models for data transformations over custom Python scripts
+## Mission Statement
+When contributing data sources to the Open Source Observer (OSO) repository, you are expected to create production-ready, reproducible data pipelines using Dagster assets. Focus on Database replication, GraphQL API crawling, and REST API crawling following OSO's established patterns.
 
-## Python & Data Engineering
+## Project Context & Architecture
 
-- Use pandas for data manipulation when appropriate
-- Follow PEP 8 style guidelines
-- Use dataclasses or Pydantic models for structured data
-- Implement proper error handling for database connections and API calls
-- Use environment variables for configuration
-- Validate data schemas at boundaries (API inputs/outputs, file imports)
-- Write integration tests for database queries and external service calls
+### Technology Stack
+- **Pipeline Framework**: Dagster with DLT (Data Load Tool)
+- **Language**: Python 3.11+
+- **Data Processing**: Polars (preferred), Pandas for compatibility
+- **Storage**: Local development, cloud-ready (S3/GCS)
+- **Testing**: pytest with data validation
+- **CI/CD**: GitHub Actions with pre-commit hooks
 
-## Git Operations
+### Repository Structure
+```
+/data/
+  raw/<source>/<YYYY-MM-DD>/     # Raw ingested data
+  processed/<dataset>/<version>/  # Transformed, validated data
+  samples/<dataset>.csv           # Small representative samples
+  metadata/<dataset>.yml          # Dataset metadata schema
+/warehouse/oso_dagster/assets/   # Dagster asset definitions
+/scripts/                        # Standalone data processing scripts
+/tests/data/                     # Data validation tests
+```
 
-- Use `git restore <filename>` to discard working directory changes
-- Use `git reset --soft HEAD~1` to undo last commit while keeping changes staged
-- Always create feature branches from `main` branch
-- Write descriptive commit messages following conventional commits format
-- Run tests and linting before committing changes
+## Data Asset Creation Patterns
 
-## External Resources & APIs
+### 1. REST API Assets
+Use the existing `create_rest_factory_asset` pattern:
 
-- Validate external API responses and handle rate limiting
-- Use environment variables for API keys and sensitive configuration
-- Implement retry logic with exponential backoff for external calls
-- Cache external API responses when appropriate
-- Document API dependencies and required permissions
+```python
+from warehouse.oso_dagster.factories import create_rest_factory_asset
+from dlt.sources.rest_api.typing import RESTAPIConfig
 
-## Communication & Documentation
+# Configuration-driven REST API asset
+@create_rest_factory_asset(
+    config=RESTAPIConfig({
+        "client": {
+            "base_url": "https://api.example.com/v1",
+            "headers": {"Authorization": "Bearer ${API_TOKEN}"},
+            "paginator": "auto"  # or custom paginator config
+        },
+        "resources": [
+            {
+                "name": "organizations",
+                "endpoint": "/orgs",
+                "data_selector": "data",
+                "write_disposition": "replace"
+            }
+        ]
+    }),
+    key_prefix=["external", "source_name"],
+    name="organizations"
+)
+def source_name_organizations_asset(context: AssetExecutionContext):
+    """
+    Loads organization data from Source Name API.
+    
+    Updates: Daily via schedule
+    Schema: id (int), name (str), created_at (datetime)
+    """
+    pass
+```
 
-- Use clear, technical language appropriate for data engineering context
-- Include code examples in explanations when helpful
-- Reference specific file paths and line numbers when discussing code
-- Ask for clarification on data requirements and business logic
-- Document data models, transformations, and API interfaces
-- Use markdown formatting for structured responses
+### 2. GraphQL API Assets
+Create GraphQL-specific factories following REST patterns:
+
+```python
+from warehouse.oso_dagster.factories import create_graphql_factory_asset
+
+@create_graphql_factory_asset(
+    endpoint="https://api.example.com/graphql",
+    query="""
+        query($first: Int!, $after: String) {
+            repositories(first: $first, after: $after) {
+                nodes { id name createdAt }
+                pageInfo { hasNextPage endCursor }
+            }
+        }
+    """,
+    variables={"first": 100},
+    key_prefix=["external", "source_name"],
+    name="repositories"
+)
+def source_name_repositories_asset(context: AssetExecutionContext):
+    """GraphQL-sourced repository data with cursor-based pagination."""
+    pass
+```
+
+### 3. Database Replication Assets
+For database replication using connection strings:
+
+```python
+from warehouse.oso_dagster.factories import create_database_factory_asset
+
+@create_database_factory_asset(
+    connection_string="${DATABASE_URL}",
+    tables=["users", "projects", "contributions"],
+    key_prefix=["replicated", "source_db"],
+    incremental_column="updated_at"
+)
+def source_db_replication_asset(context: AssetExecutionContext):
+    """Incremental replication from source database."""
+    pass
+```
+
+## Mandatory Requirements
+
+### File Structure for New Data Source
+When adding a data source named `example_source`:
+
+1. **Asset Definition**: `/warehouse/oso_dagster/assets/external_sources/example_source.py`
+2. **Metadata File**: `/data/metadata/example_source.yml`
+3. **Sample Data**: `/data/samples/example_source.csv`
+4. **Tests**: `/tests/data/test_example_source.py`
+5. **Documentation**: `/docs/data_sources/example_source.md`
+
+### Metadata Schema (YAML)
+```yaml
+name: example_source
+version: "1.0.0"
+source:
+  url: "https://api.example.com"
+  documentation: "https://docs.example.com/api"
+  license: "MIT"
+  attribution: "Data provided by Example Corp"
+schema:
+  columns:
+    - name: id
+      type: int64
+      nullable: false
+      description: "Unique identifier"
+    - name: created_at
+      type: datetime
+      nullable: false
+      description: "Creation timestamp in UTC"
+validation:
+  row_count_min: 1000
+  size_bytes_max: 1073741824  # 1GB
+  checksum_algorithm: "sha256"
+privacy:
+  pii: false
+  retention_days: 365
+owner: "data-team@example.org"
+created_at: "2024-08-21T00:00:00Z"
+```
+
+### Asset Implementation Guidelines
+
+#### Error Handling & Resilience
+```python
+from dagster import AssetExecutionContext, AssetMaterialization, MetadataValue
+import polars as pl
+from typing import Iterator
+
+def robust_data_asset(context: AssetExecutionContext) -> Iterator[AssetMaterialization]:
+    """Template for resilient data asset implementation."""
+    try:
+        # Rate limiting and retry logic
+        with context.log.timed_op("data_extraction"):
+            data = extract_with_retries(context)
+            
+        # Schema validation
+        validated_data = validate_schema(data, context)
+        
+        # Data quality checks
+        quality_metrics = run_quality_checks(validated_data, context)
+        
+        # Materialization with metadata
+        yield AssetMaterialization(
+            metadata={
+                "row_count": MetadataValue.int(len(validated_data)),
+                "columns": MetadataValue.int(len(validated_data.columns)),
+                "data_quality_score": MetadataValue.float(quality_metrics.score),
+                "extraction_time": MetadataValue.text(context.op_execution_context.start_time)
+            }
+        )
+        
+    except Exception as e:
+        context.log.error(f"Asset materialization failed: {str(e)}")
+        # Log structured error for monitoring
+        context.log_event(AssetObservation(
+            metadata={"error": MetadataValue.text(str(e))}
+        ))
+        raise
+```
+
+#### Data Validation Patterns
+```python
+import great_expectations as gx
+from warehouse.oso_dagster.utils.validation import validate_asset_data
+
+def validate_asset_data(df: pl.DataFrame, context: AssetExecutionContext) -> pl.DataFrame:
+    """Standard validation pipeline for all assets."""
+    expectations = [
+        gx.expect_table_row_count_to_be_between(min_value=1),
+        gx.expect_column_to_exist("id"),
+        gx.expect_column_values_to_be_unique("id"),
+        gx.expect_column_values_to_not_be_null("created_at")
+    ]
+    
+    # Run expectations and log results
+    for expectation in expectations:
+        result = expectation.validate(df)
+        if not result.success:
+            context.log.warning(f"Validation failed: {expectation}")
+    
+    return df
+```
+
+### Testing Requirements
+
+#### Data Asset Tests
+```python
+import pytest
+from unittest.mock import patch
+from warehouse.oso_dagster.assets.external_sources.example_source import example_asset
+
+def test_example_asset_schema():
+    """Test that asset produces expected schema."""
+    with patch('requests.get') as mock_get:
+        mock_get.return_value.json.return_value = SAMPLE_API_RESPONSE
+        
+        # Test asset execution
+        result = example_asset.execute_in_process()
+        assert result.success
+        
+        # Validate schema
+        df = result.output_for_node("example_asset")
+        assert "id" in df.columns
+        assert len(df) > 0
+
+def test_example_asset_handles_api_errors():
+    """Test graceful handling of API failures."""
+    with patch('requests.get') as mock_get:
+        mock_get.side_effect = requests.RequestException("API down")
+        
+        with pytest.raises(requests.RequestException):
+            example_asset.execute_in_process()
+```
+
+## Security & Privacy Guidelines
+
+### Environment Variables
+- Never hardcode API keys or secrets
+- Use `${VARIABLE_NAME}` syntax in configurations
+- Document required environment variables in `.env.example`
+
+### PII Handling
+- Set `pii: true` in metadata if data contains personal information
+- Implement anonymization before writing to `/data/processed/`
+- Add data retention policies and cleanup jobs
+
+### Rate Limiting
+```python
+from time import sleep
+import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
+
+def create_resilient_session(max_retries: int = 3) -> requests.Session:
+    """Create HTTP session with retry strategy and rate limiting."""
+    session = requests.Session()
+    
+    retry_strategy = Retry(
+        total=max_retries,
+        backoff_factor=1,
+        status_forcelist=[429, 500, 502, 503, 504]
+    )
+    
+    adapter = HTTPAdapter(max_retries=retry_strategy)
+    session.mount("http://", adapter)
+    session.mount("https://", adapter)
+    
+    return session
+```
+
+## Git & PR Workflow
+
+### Branch Naming
+- Feature: `feat/data-{source_name}-v{version}`
+- Bug fix: `fix/data-{source_name}-{issue_description}`
+- Enhancement: `enhance/data-{source_name}-{feature}`
+
+### Commit Messages
+Follow conventional commits:
+```
+feat(data): add GitHub GraphQL API crawler v1.0
+
+- Implements repository and issue data extraction
+- Includes rate limiting and error handling
+- Adds comprehensive test coverage
+- Updates documentation with API schema
+```
+
+### PR Requirements Checklist
+- [ ] Asset definition follows factory patterns
+- [ ] Metadata YAML is complete and valid
+- [ ] Sample data file included (< 1MB)
+- [ ] Tests cover success and failure scenarios
+- [ ] Documentation includes schema and examples
+- [ ] Environment variables documented
+- [ ] Pre-commit hooks pass
+- [ ] CI pipeline succeeds
+
+## Common Patterns & Anti-Patterns
+
+### ✅ Do This
+```python
+# Use configuration-driven factories
+@create_rest_factory_asset(config=CONFIG)
+def clean_asset_name(context: AssetExecutionContext):
+    """Clear, concise docstring explaining purpose."""
+    pass
+
+# Leverage Polars for performance
+df = pl.read_json(response.text).with_columns([
+    pl.col("created_at").str.to_datetime(),
+    pl.col("id").cast(pl.Int64)
+])
+```
+
+### ❌ Don't Do This
+```python
+# Avoid hardcoding configurations
+def bad_asset():
+    url = "https://api.example.com"  # Bad: hardcoded
+    headers = {"Authorization": "Bearer abc123"}  # Bad: secret exposed
+    
+# Don't ignore error handling
+def fragile_asset():
+    response = requests.get(url)  # Bad: no error handling
+    data = response.json()  # Bad: might fail
+```
+
+## Performance Optimization
+
+### Memory Management
+- Stream large datasets instead of loading entirely into memory
+- Use chunked processing for datasets > 100MB
+- Prefer columnar formats (Parquet) over CSV for processed data
+
+### Caching Strategy
+```python
+from dagster import asset, CachingConfig
+
+@asset(
+    caching_config=CachingConfig(
+        cache_key_fn=lambda context: f"api_data_{context.partition_key}"
+    )
+)
+def cached_api_asset(context: AssetExecutionContext):
+    """Asset with intelligent caching based on partition key."""
+    pass
+```
+
+## Monitoring & Observability
+
+### Logging Standards
+```python
+def asset_with_proper_logging(context: AssetExecutionContext):
+    context.log.info(f"Starting data extraction from {source_name}")
+    
+    try:
+        with context.log.timed_op("api_request"):
+            data = fetch_data()
+            
+        context.log.info(f"Successfully extracted {len(data)} records")
+        
+    except Exception as e:
+        context.log.error(f"Extraction failed: {str(e)}", extra={"source": source_name})
+        raise
+```
+
+### Metrics Collection
+Include these metadata fields in all assets:
+- `row_count`: Number of records processed
+- `processing_time_seconds`: Execution duration
+- `data_freshness`: Age of source data
+- `quality_score`: Data quality metrics (0-1)
+
+---
+
+## Final Checklist
+
+Before submitting any data contribution:
+
+1. **Code Quality**
+   - [ ] Follows existing factory patterns
+   - [ ] Includes comprehensive error handling
+   - [ ] Uses environment variables for secrets
+   - [ ] Implements proper logging
+
+2. **Documentation**
+   - [ ] Complete metadata YAML
+   - [ ] Asset docstrings explain purpose and schema
+   - [ ] Sample data file provided
+   - [ ] API documentation referenced
+
+3. **Testing**
+   - [ ] Unit tests for asset logic
+   - [ ] Integration tests with mocked APIs
+   - [ ] Data validation tests
+   - [ ] Error scenario coverage
+
+4. **Security**
+   - [ ] No hardcoded secrets or URLs
+   - [ ] PII handling if applicable
+   - [ ] Rate limiting implemented
+   - [ ] Input validation present
+
+Remember: Write code that OSO maintainers will be impressed to merge. Focus on clarity, robustness, and following established patterns rather than reinventing solutions.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,414 +1,72 @@
-# GitHub Copilot Instructions for OSO Data Contributions
+# Ingest Assets – Contribution Rules (Copilot & Humans)
 
-## Mission Statement
-When contributing data sources to the Open Source Observer (OSO) repository, you are expected to create production-ready, reproducible data pipelines using Dagster assets. Focus on Database replication, GraphQL API crawling, and REST API crawling following OSO's established patterns.
+## Scope
 
-## Project Context & Architecture
+Create Dagster assets for:
 
-### Technology Stack
-- **Pipeline Framework**: Dagster with DLT (Data Load Tool)
-- **Language**: Python 3.11+
-- **Data Processing**: Polars (preferred), Pandas for compatibility
-- **Storage**: Local development, cloud-ready (S3/GCS)
-- **Testing**: pytest with data validation
-- **CI/CD**: GitHub Actions with pre-commit hooks
+- REST crawling
+- GraphQL crawling
+- DB replication (incremental)
 
-### Repository Structure
-```
-/data/
-  raw/<source>/<YYYY-MM-DD>/     # Raw ingested data
-  processed/<dataset>/<version>/  # Transformed, validated data
-  samples/<dataset>.csv           # Small representative samples
-  metadata/<dataset>.yml          # Dataset metadata schema
-/warehouse/oso_dagster/assets/   # Dagster asset definitions
-/scripts/                        # Standalone data processing scripts
-/tests/data/                     # Data validation tests
-```
+All work is isolated to the ingest sandbox and must not modify production defs.
 
-## Data Asset Creation Patterns
+## Locations
 
-### 1. REST API Assets
-Use the existing `create_rest_factory_asset` pattern:
+- REST: `warehouse/oso_dagster/assets/ingest/rest/<provider>/<entity>_asset.py`
+- GraphQL: `warehouse/oso_dagster/assets/ingest/graphql/<provider>/<entity>_asset.py`
+- DB: `warehouse/oso_dagster/assets/ingest/db/<engine>/<table>_replication_asset.py`
+- Registry: `warehouse/oso_dagster/assets/ingest/defs_sandbox.py` (import new modules here)
 
-```python
-from warehouse.oso_dagster.factories import create_rest_factory_asset
-from dlt.sources.rest_api.typing import RESTAPIConfig
+## Naming rules (pinned)
 
-# Configuration-driven REST API asset
-@create_rest_factory_asset(
-    config=RESTAPIConfig({
-        "client": {
-            "base_url": "https://api.example.com/v1",
-            "headers": {"Authorization": "Bearer ${API_TOKEN}"},
-            "paginator": "auto"  # or custom paginator config
-        },
-        "resources": [
-            {
-                "name": "organizations",
-                "endpoint": "/orgs",
-                "data_selector": "data",
-                "write_disposition": "replace"
-            }
-        ]
-    }),
-    key_prefix=["external", "source_name"],
-    name="organizations"
-)
-def source_name_organizations_asset(context: AssetExecutionContext):
-    """
-    Loads organization data from Source Name API.
-    
-    Updates: Daily via schedule
-    Schema: id (int), name (str), created_at (datetime)
-    """
-    pass
-```
+- All names are **lower_snake_case**.
+- **File ⇄ Function** must match:
+  - REST/GraphQL file: `<entity>_asset.py` → function: `fetch_<provider>_<entity>`
+  - DB file: `<table>_replication_asset.py` → function: `replicate_<engine>_<table>`
+- Asset groups:
+  - REST → `group_name="rest_crawl"`
+  - GraphQL → `group_name="graphql_crawl"`
+  - DB → `group_name="db_replication"`
+- Resources: always declare `required_resource_keys={"secret_resolver"}`.
+- Secrets: `context.resources.secret_resolver.resolve_as_str(SecretReference(group_name="<group>", key="<key>"))`.
+- Output: return the file path string and add metadata: `rows`, `path`.
 
-### 2. GraphQL API Assets
-Create GraphQL-specific factories following REST patterns:
+## Minimal templates
+
+### REST (with/without auth)
 
 ```python
-from warehouse.oso_dagster.factories import create_graphql_factory_asset
+from dagster import asset, AssetExecutionContext, MetadataValue
+from warehouse.oso_dagster.utils.secrets import SecretReference
+import requests, json, pathlib, datetime as dt, time
 
-@create_graphql_factory_asset(
-    endpoint="https://api.example.com/graphql",
-    query="""
-        query($first: Int!, $after: String) {
-            repositories(first: $first, after: $after) {
-                nodes { id name createdAt }
-                pageInfo { hasNextPage endCursor }
-            }
-        }
-    """,
-    variables={"first": 100},
-    key_prefix=["external", "source_name"],
-    name="repositories"
-)
-def source_name_repositories_asset(context: AssetExecutionContext):
-    """GraphQL-sourced repository data with cursor-based pagination."""
-    pass
+@asset(group_name="rest_crawl", required_resource_keys={"secret_resolver"})
+def fetch_<provider>_<entity>(context: AssetExecutionContext) -> str:
+    headers = {}
+    # If auth required:
+    # token = context.resources.secret_resolver.resolve_as_str(SecretReference(group_name="<provider>", key="api_key"))
+    # headers = {"Authorization": f"Bearer {token}"}
+
+    url = "<https://api.example.com/...>"
+    params, items, cursor = {"limit": 100}, [], None
+    while True:
+        if cursor:
+            params["after"] = cursor
+        r = requests.get(url, headers=headers, params=params, timeout=60)
+        if r.status_code == 429:
+            time.sleep(2); continue
+        r.raise_for_status()
+        d = r.json()
+        items += d.get("results", d if isinstance(d, list) else [])
+        cursor = (d.get("paging") or {}).get("next", {}).get("after")
+        if not cursor:
+            break
+
+    out = pathlib.Path("warehouse/oso_dagster/tmp/<provider>/<entity>")
+    out.mkdir(parents=True, exist_ok=True)
+    fp = out / f"{dt.date.today().isoformat()}.json"
+    fp.write_text(json.dumps(items))
+    context.add_output_metadata({"rows": MetadataValue.int(len(items)), "path": MetadataValue.path(str(fp))})
+    return str(fp)
+
 ```
-
-### 3. Database Replication Assets
-For database replication using connection strings:
-
-```python
-from warehouse.oso_dagster.factories import create_database_factory_asset
-
-@create_database_factory_asset(
-    connection_string="${DATABASE_URL}",
-    tables=["users", "projects", "contributions"],
-    key_prefix=["replicated", "source_db"],
-    incremental_column="updated_at"
-)
-def source_db_replication_asset(context: AssetExecutionContext):
-    """Incremental replication from source database."""
-    pass
-```
-
-## Mandatory Requirements
-
-### File Structure for New Data Source
-When adding a data source named `example_source`:
-
-1. **Asset Definition**: `/warehouse/oso_dagster/assets/external_sources/example_source.py`
-2. **Metadata File**: `/data/metadata/example_source.yml`
-3. **Sample Data**: `/data/samples/example_source.csv`
-4. **Tests**: `/tests/data/test_example_source.py`
-5. **Documentation**: `/docs/data_sources/example_source.md`
-
-### Metadata Schema (YAML)
-```yaml
-name: example_source
-version: "1.0.0"
-source:
-  url: "https://api.example.com"
-  documentation: "https://docs.example.com/api"
-  license: "MIT"
-  attribution: "Data provided by Example Corp"
-schema:
-  columns:
-    - name: id
-      type: int64
-      nullable: false
-      description: "Unique identifier"
-    - name: created_at
-      type: datetime
-      nullable: false
-      description: "Creation timestamp in UTC"
-validation:
-  row_count_min: 1000
-  size_bytes_max: 1073741824  # 1GB
-  checksum_algorithm: "sha256"
-privacy:
-  pii: false
-  retention_days: 365
-owner: "data-team@example.org"
-created_at: "2024-08-21T00:00:00Z"
-```
-
-### Asset Implementation Guidelines
-
-#### Error Handling & Resilience
-```python
-from dagster import AssetExecutionContext, AssetMaterialization, MetadataValue
-import polars as pl
-from typing import Iterator
-
-def robust_data_asset(context: AssetExecutionContext) -> Iterator[AssetMaterialization]:
-    """Template for resilient data asset implementation."""
-    try:
-        # Rate limiting and retry logic
-        with context.log.timed_op("data_extraction"):
-            data = extract_with_retries(context)
-            
-        # Schema validation
-        validated_data = validate_schema(data, context)
-        
-        # Data quality checks
-        quality_metrics = run_quality_checks(validated_data, context)
-        
-        # Materialization with metadata
-        yield AssetMaterialization(
-            metadata={
-                "row_count": MetadataValue.int(len(validated_data)),
-                "columns": MetadataValue.int(len(validated_data.columns)),
-                "data_quality_score": MetadataValue.float(quality_metrics.score),
-                "extraction_time": MetadataValue.text(context.op_execution_context.start_time)
-            }
-        )
-        
-    except Exception as e:
-        context.log.error(f"Asset materialization failed: {str(e)}")
-        # Log structured error for monitoring
-        context.log_event(AssetObservation(
-            metadata={"error": MetadataValue.text(str(e))}
-        ))
-        raise
-```
-
-#### Data Validation Patterns
-```python
-import great_expectations as gx
-from warehouse.oso_dagster.utils.validation import validate_asset_data
-
-def validate_asset_data(df: pl.DataFrame, context: AssetExecutionContext) -> pl.DataFrame:
-    """Standard validation pipeline for all assets."""
-    expectations = [
-        gx.expect_table_row_count_to_be_between(min_value=1),
-        gx.expect_column_to_exist("id"),
-        gx.expect_column_values_to_be_unique("id"),
-        gx.expect_column_values_to_not_be_null("created_at")
-    ]
-    
-    # Run expectations and log results
-    for expectation in expectations:
-        result = expectation.validate(df)
-        if not result.success:
-            context.log.warning(f"Validation failed: {expectation}")
-    
-    return df
-```
-
-### Testing Requirements
-
-#### Data Asset Tests
-```python
-import pytest
-from unittest.mock import patch
-from warehouse.oso_dagster.assets.external_sources.example_source import example_asset
-
-def test_example_asset_schema():
-    """Test that asset produces expected schema."""
-    with patch('requests.get') as mock_get:
-        mock_get.return_value.json.return_value = SAMPLE_API_RESPONSE
-        
-        # Test asset execution
-        result = example_asset.execute_in_process()
-        assert result.success
-        
-        # Validate schema
-        df = result.output_for_node("example_asset")
-        assert "id" in df.columns
-        assert len(df) > 0
-
-def test_example_asset_handles_api_errors():
-    """Test graceful handling of API failures."""
-    with patch('requests.get') as mock_get:
-        mock_get.side_effect = requests.RequestException("API down")
-        
-        with pytest.raises(requests.RequestException):
-            example_asset.execute_in_process()
-```
-
-## Security & Privacy Guidelines
-
-### Environment Variables
-- Never hardcode API keys or secrets
-- Use `${VARIABLE_NAME}` syntax in configurations
-- Document required environment variables in `.env.example`
-
-### PII Handling
-- Set `pii: true` in metadata if data contains personal information
-- Implement anonymization before writing to `/data/processed/`
-- Add data retention policies and cleanup jobs
-
-### Rate Limiting
-```python
-from time import sleep
-import requests
-from requests.adapters import HTTPAdapter
-from urllib3.util.retry import Retry
-
-def create_resilient_session(max_retries: int = 3) -> requests.Session:
-    """Create HTTP session with retry strategy and rate limiting."""
-    session = requests.Session()
-    
-    retry_strategy = Retry(
-        total=max_retries,
-        backoff_factor=1,
-        status_forcelist=[429, 500, 502, 503, 504]
-    )
-    
-    adapter = HTTPAdapter(max_retries=retry_strategy)
-    session.mount("http://", adapter)
-    session.mount("https://", adapter)
-    
-    return session
-```
-
-## Git & PR Workflow
-
-### Branch Naming
-- Feature: `feat/data-{source_name}-v{version}`
-- Bug fix: `fix/data-{source_name}-{issue_description}`
-- Enhancement: `enhance/data-{source_name}-{feature}`
-
-### Commit Messages
-Follow conventional commits:
-```
-feat(data): add GitHub GraphQL API crawler v1.0
-
-- Implements repository and issue data extraction
-- Includes rate limiting and error handling
-- Adds comprehensive test coverage
-- Updates documentation with API schema
-```
-
-### PR Requirements Checklist
-- [ ] Asset definition follows factory patterns
-- [ ] Metadata YAML is complete and valid
-- [ ] Sample data file included (< 1MB)
-- [ ] Tests cover success and failure scenarios
-- [ ] Documentation includes schema and examples
-- [ ] Environment variables documented
-- [ ] Pre-commit hooks pass
-- [ ] CI pipeline succeeds
-
-## Common Patterns & Anti-Patterns
-
-### ✅ Do This
-```python
-# Use configuration-driven factories
-@create_rest_factory_asset(config=CONFIG)
-def clean_asset_name(context: AssetExecutionContext):
-    """Clear, concise docstring explaining purpose."""
-    pass
-
-# Leverage Polars for performance
-df = pl.read_json(response.text).with_columns([
-    pl.col("created_at").str.to_datetime(),
-    pl.col("id").cast(pl.Int64)
-])
-```
-
-### ❌ Don't Do This
-```python
-# Avoid hardcoding configurations
-def bad_asset():
-    url = "https://api.example.com"  # Bad: hardcoded
-    headers = {"Authorization": "Bearer abc123"}  # Bad: secret exposed
-    
-# Don't ignore error handling
-def fragile_asset():
-    response = requests.get(url)  # Bad: no error handling
-    data = response.json()  # Bad: might fail
-```
-
-## Performance Optimization
-
-### Memory Management
-- Stream large datasets instead of loading entirely into memory
-- Use chunked processing for datasets > 100MB
-- Prefer columnar formats (Parquet) over CSV for processed data
-
-### Caching Strategy
-```python
-from dagster import asset, CachingConfig
-
-@asset(
-    caching_config=CachingConfig(
-        cache_key_fn=lambda context: f"api_data_{context.partition_key}"
-    )
-)
-def cached_api_asset(context: AssetExecutionContext):
-    """Asset with intelligent caching based on partition key."""
-    pass
-```
-
-## Monitoring & Observability
-
-### Logging Standards
-```python
-def asset_with_proper_logging(context: AssetExecutionContext):
-    context.log.info(f"Starting data extraction from {source_name}")
-    
-    try:
-        with context.log.timed_op("api_request"):
-            data = fetch_data()
-            
-        context.log.info(f"Successfully extracted {len(data)} records")
-        
-    except Exception as e:
-        context.log.error(f"Extraction failed: {str(e)}", extra={"source": source_name})
-        raise
-```
-
-### Metrics Collection
-Include these metadata fields in all assets:
-- `row_count`: Number of records processed
-- `processing_time_seconds`: Execution duration
-- `data_freshness`: Age of source data
-- `quality_score`: Data quality metrics (0-1)
-
----
-
-## Final Checklist
-
-Before submitting any data contribution:
-
-1. **Code Quality**
-   - [ ] Follows existing factory patterns
-   - [ ] Includes comprehensive error handling
-   - [ ] Uses environment variables for secrets
-   - [ ] Implements proper logging
-
-2. **Documentation**
-   - [ ] Complete metadata YAML
-   - [ ] Asset docstrings explain purpose and schema
-   - [ ] Sample data file provided
-   - [ ] API documentation referenced
-
-3. **Testing**
-   - [ ] Unit tests for asset logic
-   - [ ] Integration tests with mocked APIs
-   - [ ] Data validation tests
-   - [ ] Error scenario coverage
-
-4. **Security**
-   - [ ] No hardcoded secrets or URLs
-   - [ ] PII handling if applicable
-   - [ ] Rate limiting implemented
-   - [ ] Input validation present
-
-Remember: Write code that OSO maintainers will be impressed to merge. Focus on clarity, robustness, and following established patterns rather than reinventing solutions.

--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,5 @@ core.1
 
 # opa
 opa/**/bundle.tar.gz
+warehouse/oso_dagster/tmp/
+.tmp_dagster_home_*

--- a/docs/schema-docs/configuration-schema.md
+++ b/docs/schema-docs/configuration-schema.md
@@ -1,0 +1,19 @@
+# OSO Clickhouse Configuration Schema
+
+the main configuration file
+
+## Properties
+
+- **`$schema`** **Required**
+  - Type: `string`
+
+- **`tables`**
+  A list of tables available in this database
+
+The map key is a unique table alias that defaults to defaults to "<table_schema>_<table_name>", except for tables in the "default" schema where the table name is used This is the name exposed to the engine, and may be configured by users. When the configuration is updated, the table is identified by name and schema, and changes to the alias are preserved.
+  - Type: `object`
+
+- **`queries`**
+  Optionally define custom parameterized queries here Note the names must not match table names
+  - Type: `object`
+

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "pyright": "pyright --pythonpath $(echo 'import sys; print(sys.prefix)' | uv run -)/bin/python",
     "test": "turbo run test --concurrency=1",
     "test:integration": "(docker compose -f docker/compose.yaml down || true) && docker compose -f docker/compose.yaml run --rm test",
-    "prepare": "husky install"
+    "prepare": "husky install",
+    "build:schema": "node scripts/generate-schema-docs.js"
   },
   "devDependencies": {
     "eslint": "^8.57.0",

--- a/scripts/generate-schema-docs.js
+++ b/scripts/generate-schema-docs.js
@@ -1,0 +1,137 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+
+/**
+ * Custom schema documentation generator
+ * Addresses specific issues with generic tools:
+ * - Eliminates "Untitled/Unknown" labels
+ * - Properly handles arrays and nested objects
+ * - Focuses on useful documentation for humans
+ */
+
+const SCHEMA_PATH = 'apps/hasura-clickhouse/oso_subgraph/connector/oso_clickhouse/configuration.schema.json';
+const OUTPUT_DIR = 'docs/schema-docs';
+const OUTPUT_FILE = 'configuration-schema.md';
+
+function generateDocumentation(schema, title = 'Configuration Schema') {
+  let markdown = `# ${title}\n\n`;
+  
+  if (schema.description) {
+    markdown += `${schema.description}\n\n`;
+  }
+
+  markdown += `## Properties\n\n`;
+  markdown += generateProperties(schema.properties || {}, schema.required || []);
+  
+  return markdown;
+}
+
+function generateProperties(properties, required = [], level = 0) {
+  let markdown = '';
+  const indent = '  '.repeat(level);
+  
+  for (const [propName, propSchema] of Object.entries(properties)) {
+    const isRequired = required.includes(propName);
+    const requiredBadge = isRequired ? ' **Required**' : '';
+    
+    markdown += `${indent}- **\`${propName}\`**${requiredBadge}\n`;
+    
+    if (propSchema.description) {
+      markdown += `${indent}  ${propSchema.description}\n`;
+    }
+    
+    // Handle type information
+    const typeInfo = getTypeInfo(propSchema);
+    if (typeInfo) {
+      markdown += `${indent}  - Type: \`${typeInfo}\`\n`;
+    }
+    
+    // Handle default values
+    if (propSchema.default !== undefined) {
+      markdown += `${indent}  - Default: \`${JSON.stringify(propSchema.default)}\`\n`;
+    }
+    
+    // Handle examples
+    if (propSchema.examples && propSchema.examples.length > 0) {
+      markdown += `${indent}  - Example: \`${JSON.stringify(propSchema.examples[0])}\`\n`;
+    }
+    
+    // Handle nested objects (but not primitive arrays)
+    if (propSchema.type === 'object' && propSchema.properties) {
+      markdown += `${indent}  - Properties:\n`;
+      markdown += generateProperties(propSchema.properties, propSchema.required || [], level + 2);
+    }
+    
+    // Handle arrays of objects (skip primitive arrays)
+    if (propSchema.type === 'array' && propSchema.items?.type === 'object' && propSchema.items.properties) {
+      markdown += `${indent}  - Array items have properties:\n`;
+      markdown += generateProperties(propSchema.items.properties, propSchema.items.required || [], level + 2);
+    }
+    
+    markdown += '\n';
+  }
+  
+  return markdown;
+}
+
+function getTypeInfo(schema) {
+  if (schema.type) {
+    if (schema.type === 'array' && schema.items) {
+      if (schema.items.type) {
+        return `array of ${schema.items.type}`;
+      } else if (schema.items.properties) {
+        return 'array of objects';
+      }
+      return 'array';
+    }
+    return schema.type;
+  }
+  
+  if (schema.enum) {
+    return `enum: ${schema.enum.map(v => `"${v}"`).join(' | ')}`;
+  }
+  
+  if (schema.$ref) {
+    return `reference: ${schema.$ref}`;
+  }
+  
+  return 'mixed';
+}
+
+function main() {
+  try {
+    // Read the schema file
+    console.log(`Reading schema from: ${SCHEMA_PATH}`);
+    const schemaContent = fs.readFileSync(SCHEMA_PATH, 'utf8');
+    const schema = JSON.parse(schemaContent);
+    
+    // Generate documentation
+    console.log('Generating documentation...');
+    const documentation = generateDocumentation(schema, 'OSO Clickhouse Configuration Schema');
+    
+    // Ensure output directory exists
+    if (!fs.existsSync(OUTPUT_DIR)) {
+      fs.mkdirSync(OUTPUT_DIR, { recursive: true });
+      console.log(`Created output directory: ${OUTPUT_DIR}`);
+    }
+    
+    // Write documentation
+    const outputPath = path.join(OUTPUT_DIR, OUTPUT_FILE);
+    fs.writeFileSync(outputPath, documentation);
+    
+    console.log(`✅ Documentation generated successfully: ${outputPath}`);
+    console.log(`📄 Generated ${documentation.split('\n').length} lines of documentation`);
+    
+  } catch (error) {
+    console.error('❌ Error generating documentation:', error.message);
+    process.exit(1);
+  }
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = { generateDocumentation, generateProperties, getTypeInfo };

--- a/warehouse/oso_dagster/assets/ingest/db/postgres/orders_replication_asset.py
+++ b/warehouse/oso_dagster/assets/ingest/db/postgres/orders_replication_asset.py
@@ -1,0 +1,37 @@
+import datetime as dt
+import pathlib
+
+import pandas as pd
+from dagster import AssetExecutionContext, MetadataValue, asset
+from sqlalchemy import create_engine, text
+
+from warehouse.oso_dagster.utils.secrets import SecretReference
+
+
+@asset(group_name="db_replication", required_resource_keys={"secret_resolver"})
+def replicate_postgres_orders(context: AssetExecutionContext) -> str:
+    uri = context.resources.secret_resolver.resolve_as_str(
+        SecretReference(group_name="postgres", key="uri")
+    )
+    since = context.resources.secret_resolver.resolve_as_str(
+        SecretReference(group_name="postgres", key="since")
+    )
+    eng = create_engine(uri)
+    df = pd.read_sql(
+        text("select * from orders where updated_at >= :since"),
+        eng,
+        params={"since": since},
+    )
+
+    out = pathlib.Path("warehouse/oso_dagster/tmp/postgres/orders")
+    out.mkdir(parents=True, exist_ok=True)
+    fp = out / f"{dt.date.today().isoformat()}.parquet"
+    df.to_parquet(fp, index=False)
+
+    context.add_output_metadata(
+        {
+            "rows": MetadataValue.int(len(df)),
+            "path": MetadataValue.path(str(fp)),
+        }
+    )
+    return str(fp)

--- a/warehouse/oso_dagster/assets/ingest/defs_sandbox.py
+++ b/warehouse/oso_dagster/assets/ingest/defs_sandbox.py
@@ -1,0 +1,54 @@
+from dagster import Definitions, load_assets_from_modules, resource
+
+import warehouse.oso_dagster.assets.ingest.db.postgres.orders_replication_asset as pg_mod
+import warehouse.oso_dagster.assets.ingest.graphql.countries.countries_asset as countries_mod
+
+# ----- assets (keep only the three) -----
+import warehouse.oso_dagster.assets.ingest.rest.jsonplaceholder.posts_asset as jsonplaceholder_posts_mod
+
+# ----- secrets: import official types if available, but DON'T redefine them -----
+# We define a neutral base class for our local dev resolver to satisfy type checkers.
+try:
+    # Import so assets can use the canonical SecretReference at runtime elsewhere.
+    pass  # noqa: F401
+except Exception:
+    # If the upstream module isn't importable locally, we still provide a working resolver;
+    # we deliberately avoid redefining the same class names to keep pyright happy.
+    pass
+
+import os
+
+
+class BaseSecretResolver:
+    """Minimal interface used by local/dev runs."""
+
+    def resolve(self, ref) -> bytes:  # no type to avoid cross-module type conflicts
+        raise NotImplementedError
+
+    def resolve_as_str(self, ref) -> str:
+        return self.resolve(ref).decode("utf-8")
+
+
+class DevEnvSecretResolver(BaseSecretResolver):
+    """Reads secrets from env: DAGSTER__<GROUP>__<KEY>."""
+
+    def resolve(self, ref) -> bytes:
+        group = getattr(ref, "group_name", None)
+        key = getattr(ref, "key", None)
+        if not group or not key:
+            raise RuntimeError("Secret reference must expose .group_name and .key")
+        env = f"DAGSTER__{str(group).upper()}__{str(key).upper()}"
+        val = os.getenv(env)
+        if val is None:
+            raise RuntimeError(f"Missing env: {env}")
+        return val.encode("utf-8")
+
+
+@resource
+def secret_resolver():
+    # In CI/dev this resolver looks at environment variables.
+    return DevEnvSecretResolver()
+
+
+assets = load_assets_from_modules([jsonplaceholder_posts_mod, countries_mod, pg_mod])
+defs = Definitions(assets=assets, resources={"secret_resolver": secret_resolver})

--- a/warehouse/oso_dagster/assets/ingest/graphql/countries/countries_asset.py
+++ b/warehouse/oso_dagster/assets/ingest/graphql/countries/countries_asset.py
@@ -1,0 +1,32 @@
+import datetime as dt
+import json
+import pathlib
+
+import requests
+from dagster import AssetExecutionContext, MetadataValue, asset
+
+
+@asset(group_name="graphql_crawl")
+def fetch_countries_countries(context: AssetExecutionContext) -> str:
+    url = "https://countries.trevorblades.com/"
+    q = """
+    query {
+      countries { code name capital }
+    }
+    """
+    r = requests.post(url, json={"query": q}, timeout=60)
+    r.raise_for_status()
+    data = r.json()["data"]["countries"]
+
+    out = pathlib.Path("warehouse/oso_dagster/tmp/countries/countries")
+    out.mkdir(parents=True, exist_ok=True)
+    fp = out / f"{dt.date.today().isoformat()}.json"
+    fp.write_text(json.dumps(data))
+
+    context.add_output_metadata(
+        {
+            "rows": MetadataValue.int(len(data)),
+            "path": MetadataValue.path(str(fp)),
+        }
+    )
+    return str(fp)

--- a/warehouse/oso_dagster/assets/ingest/rest/jsonplaceholder/posts_asset.py
+++ b/warehouse/oso_dagster/assets/ingest/rest/jsonplaceholder/posts_asset.py
@@ -1,0 +1,27 @@
+import datetime as dt
+import json
+import pathlib
+
+import requests
+from dagster import AssetExecutionContext, MetadataValue, asset
+
+
+@asset(group_name="rest_crawl")
+def fetch_jsonplaceholder_posts(context: AssetExecutionContext) -> str:
+    url = "https://jsonplaceholder.typicode.com/posts"
+    r = requests.get(url, timeout=60)
+    r.raise_for_status()
+    data = r.json()
+
+    out = pathlib.Path("warehouse/oso_dagster/tmp/jsonplaceholder/posts")
+    out.mkdir(parents=True, exist_ok=True)
+    fp = out / f"{dt.date.today().isoformat()}.json"
+    fp.write_text(json.dumps(data))
+
+    context.add_output_metadata(
+        {
+            "rows": MetadataValue.int(len(data)),
+            "path": MetadataValue.path(str(fp)),
+        }
+    )
+    return str(fp)


### PR DESCRIPTION
This PR adds a minimal, reviewable scaffold that lets GitHub Copilot reliably generate new Dagster ingest assets the way we expect. It includes:

- A single registration point (defs_sandbox.py) with strict naming/paths.
- 
- Two no-auth, runnable examples (REST + GraphQL) and one DB replication example.
- 
- A concise repo instruction file for Copilot with exact file/function naming rules.
- 
- The goal is to make “add a new data source” issues solvable by Copilot + a quick human review.

**What’s included**

Registration

warehouse/oso_dagster/assets/ingest/defs_sandbox.py

Loads assets via load_assets_from_modules([...])

Provides a tiny DevEnvSecretResolver so assets can read env vars when needed.

**Assets (examples)**

REST: fetch_jsonplaceholder_posts
warehouse/oso_dagster/assets/ingest/rest/jsonplaceholder/posts_asset.py

GraphQL: fetch_countries_countries
warehouse/oso_dagster/assets/ingest/graphql/countries/countries_asset.py

DB: replicate_postgres_orders
warehouse/oso_dagster/assets/ingest/db/postgres/orders_replication_asset.py

**Copilot authoring rules**

.github/copilot-instructions.md (paths, file/func naming, decorator + resource pattern, output contract, registration steps, and minimal templates)

**Housekeeping**

.gitignore updated to exclude warehouse/oso_dagster/tmp/ outputs.

**Why**

We want Copilot to open PRs that already match our conventions:

- Where files live
- 
- How functions are named
- 
- How assets declare resources and write outputs
- 
- How assets get registered

Reviewers can then focus on source-specific details, not plumbing.

**How to run locally (quick checks)**

List assets
uv run dagster asset list -m warehouse.oso_dagster.assets.ingest.defs_sandbox

Materialize REST (no env needed)
uv run dagster asset materialize --select fetch_jsonplaceholder_posts -m warehouse.oso_dagster.assets.ingest.defs_sandbox

Materialize GraphQL (no env needed)
uv run dagster asset materialize --select fetch_countries_countries -m warehouse.oso_dagster.assets.ingest.defs_sandbox

Optional: DB example with SQLite
uv run python - <<'PY'
from sqlalchemy import create_engine, text
e = create_engine("sqlite:///demo.db")
with e.begin() as c:
    c.execute(text("CREATE TABLE IF NOT EXISTS orders (id INTEGER PRIMARY KEY, updated_at TEXT)"))
    c.execute(text("INSERT INTO orders(updated_at) VALUES (datetime('now'))"))
print("seeded")
PY

export DAGSTER__POSTGRES__URI=sqlite:///demo.db
export DAGSTER__POSTGRES__SINCE=1970-01-01

uv run dagster asset materialize --select replicate_postgres_orders -m warehouse.oso_dagster.assets.ingest.defs_sandbox


**Outputs land under:**

warehouse/oso_dagster/tmp/jsonplaceholder/posts/YYYY-MM-DD.json
warehouse/oso_dagster/tmp/countries/countries/YYYY-MM-DD.json
warehouse/oso_dagster/tmp/postgres/orders/YYYY-MM-DD.parquet

**Issues encountered & fixes**

- HubSpot 401 / developer acct lacks private app

Cause: personal access token insufficient for CRM objects.
Fix: switched examples to no-auth sources so PRs are runnable by anyone; left auth pattern documented for real integrations.

- Repo-wide pyright noise

Cause: unrelated packages in the monorepo.
Fix: kept new files type-clean; didn’t modify existing modules. (Follow-up below.)

**Reviewer notes**

- Scope is intentionally narrow: one registration module + 3 small assets + doc.

- Examples are network-stable and no-auth so CI/dev can run them out of the box.
 
- DB example uses SQLite to prove the “incremental since” pattern without extra infra.

**Follow-ups (what I’ll add next)**

Add 2–3 more public sources:

REST: PokeAPI or Open-Meteo (no auth)

GraphQL: SpaceX or SWAPI GraphQL mirror (no auth)

DB: Postgres docker compose variant (optional)

Document a “real auth” example (e.g., GitHub REST with token) that uses secret_resolver.

Optional: tighten CI to run dagster asset list on the sandbox module and materialize the two public assets.

Optional: reduce repo-wide pyright scope in pre-commit to the ingest paths (or add a config block that ignores unrelated monorepo packages).