### PR TITLE
hotfix: fix wasm build to allow new domains

### DIFF
--- a/.github/workflows/deploy-marimo-wasm.yml
+++ b/.github/workflows/deploy-marimo-wasm.yml
@@ -4,6 +4,7 @@ permissions:
   contents: read
 env:
   CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+  VITE_ALLOWED_DOMAINS: oso.xyz,opensource.observer,www.oso.xyz,www.opensource.observer,marimo.oso.xyz,marimo.opensource.observer
 
 # Trigger the workflow when:
 on:


### PR DESCRIPTION
The wasm build does not have the correct allow list for domains