### PR TITLE
fix: notebook permissions `rls` policies and `misc`

### DIFF
--- a/apps/frontend/lib/types/schema.ts
+++ b/apps/frontend/lib/types/schema.ts
@@ -496,7 +496,6 @@ export const invitationsRelationshipsSchema = z.tuple([
 ]);
 
 export const notebooksRowSchema = z.object({
-  accessed_at: z.string().nullable(),
   created_at: z.string(),
   created_by: z.string(),
   data: z.string().nullable(),
@@ -509,7 +508,6 @@ export const notebooksRowSchema = z.object({
 });
 
 export const notebooksInsertSchema = z.object({
-  accessed_at: z.string().optional().nullable(),
   created_at: z.string().optional(),
   created_by: z.string(),
   data: z.string().optional().nullable(),
@@ -522,7 +520,6 @@ export const notebooksInsertSchema = z.object({
 });
 
 export const notebooksUpdateSchema = z.object({
-  accessed_at: z.string().optional().nullable(),
   created_at: z.string().optional(),
   created_by: z.string().optional(),
   data: z.string().optional().nullable(),
@@ -629,7 +626,6 @@ export const organizationCreditsRelationshipsSchema = z.tuple([
 ]);
 
 export const organizationsRowSchema = z.object({
-  accessed_at: z.string().nullable(),
   created_at: z.string(),
   created_by: z.string(),
   deleted_at: z.string().nullable(),
@@ -640,7 +636,6 @@ export const organizationsRowSchema = z.object({
 });
 
 export const organizationsInsertSchema = z.object({
-  accessed_at: z.string().optional().nullable(),
   created_at: z.string().optional(),
   created_by: z.string(),
   deleted_at: z.string().optional().nullable(),
@@ -651,7 +646,6 @@ export const organizationsInsertSchema = z.object({
 });
 
 export const organizationsUpdateSchema = z.object({
-  accessed_at: z.string().optional().nullable(),
   created_at: z.string().optional(),
   created_by: z.string().optional(),
   deleted_at: z.string().optional().nullable(),
@@ -683,6 +677,7 @@ export const pricingPlanRowSchema = z.object({
   plan_id: z.string(),
   plan_name: z.string(),
   price_per_credit: z.number(),
+  priority: z.number(),
   updated_at: z.string(),
 });
 
@@ -691,6 +686,7 @@ export const pricingPlanInsertSchema = z.object({
   plan_id: z.string().optional(),
   plan_name: z.string(),
   price_per_credit: z.number(),
+  priority: z.number().optional(),
   updated_at: z.string().optional(),
 });
 
@@ -699,6 +695,7 @@ export const pricingPlanUpdateSchema = z.object({
   plan_id: z.string().optional(),
   plan_name: z.string().optional(),
   price_per_credit: z.number().optional(),
+  priority: z.number().optional(),
   updated_at: z.string().optional(),
 });
 

--- a/apps/frontend/lib/types/supabase.ts
+++ b/apps/frontend/lib/types/supabase.ts
@@ -462,7 +462,6 @@ export type Database = {
       };
       notebooks: {
         Row: {
-          accessed_at: string | null;
           created_at: string;
           created_by: string;
           data: string | null;
@@ -474,7 +473,6 @@ export type Database = {
           updated_at: string;
         };
         Insert: {
-          accessed_at?: string | null;
           created_at?: string;
           created_by: string;
           data?: string | null;
@@ -486,7 +484,6 @@ export type Database = {
           updated_at?: string;
         };
         Update: {
-          accessed_at?: string | null;
           created_at?: string;
           created_by?: string;
           data?: string | null;
@@ -589,7 +586,6 @@ export type Database = {
       };
       organizations: {
         Row: {
-          accessed_at: string | null;
           created_at: string;
           created_by: string;
           deleted_at: string | null;
@@ -599,7 +595,6 @@ export type Database = {
           updated_at: string;
         };
         Insert: {
-          accessed_at?: string | null;
           created_at?: string;
           created_by: string;
           deleted_at?: string | null;
@@ -609,7 +604,6 @@ export type Database = {
           updated_at?: string;
         };
         Update: {
-          accessed_at?: string | null;
           created_at?: string;
           created_by?: string;
           deleted_at?: string | null;
@@ -641,6 +635,7 @@ export type Database = {
           plan_id: string;
           plan_name: string;
           price_per_credit: number;
+          priority: number;
           updated_at: string;
         };
         Insert: {
@@ -648,6 +643,7 @@ export type Database = {
           plan_id?: string;
           plan_name: string;
           price_per_credit: number;
+          priority?: number;
           updated_at?: string;
         };
         Update: {
@@ -655,6 +651,7 @@ export type Database = {
           plan_id?: string;
           plan_name?: string;
           price_per_credit?: number;
+          priority?: number;
           updated_at?: string;
         };
         Relationships: [];

--- a/apps/frontend/supabase/migrations/20251003175104_fix_notebooks_rls.sql
+++ b/apps/frontend/supabase/migrations/20251003175104_fix_notebooks_rls.sql
@@ -1,0 +1,76 @@
+DROP POLICY IF EXISTS "Org members and permitted users can access notebooks" ON notebooks;
+
+CREATE POLICY "Org members and permitted users can view notebooks"
+ON notebooks
+FOR SELECT
+USING (
+  (auth.uid() IS NOT NULL AND EXISTS (
+    SELECT 1 FROM users_by_organization u
+    WHERE u.user_id = auth.uid()
+    AND u.org_id = notebooks.org_id
+    AND u.deleted_at IS NULL
+  ))
+  OR
+  (check_resource_permission('notebook', id)->>'hasAccess')::boolean
+);
+
+CREATE POLICY "Org members can create notebooks"
+ON notebooks
+FOR INSERT
+WITH CHECK (
+  auth.uid() IS NOT NULL AND EXISTS (
+    SELECT 1 FROM users_by_organization u
+    WHERE u.user_id = auth.uid()
+    AND u.org_id = notebooks.org_id
+    AND u.deleted_at IS NULL
+  )
+);
+
+CREATE POLICY "Org members and write-permitted users can update notebooks"
+ON notebooks
+FOR UPDATE
+USING (
+  (auth.uid() IS NOT NULL AND EXISTS (
+    SELECT 1 FROM users_by_organization u
+    WHERE u.user_id = auth.uid()
+    AND u.org_id = notebooks.org_id
+    AND u.deleted_at IS NULL
+  ))
+  OR
+  (
+    (check_resource_permission('notebook', id)->>'hasAccess')::boolean
+    AND
+    (check_resource_permission('notebook', id)->>'permissionLevel') IN ('write', 'admin', 'owner')
+  )
+);
+
+CREATE POLICY "Org members and write-permitted users can delete notebooks"
+ON notebooks
+FOR DELETE
+USING (
+  (auth.uid() IS NOT NULL AND EXISTS (
+    SELECT 1 FROM users_by_organization u
+    WHERE u.user_id = auth.uid()
+    AND u.org_id = notebooks.org_id
+    AND u.deleted_at IS NULL
+  ))
+  OR
+  (
+    (check_resource_permission('notebook', id)->>'hasAccess')::boolean
+    AND
+    (check_resource_permission('notebook', id)->>'permissionLevel') IN ('write', 'admin', 'owner')
+  )
+);
+
+DROP INDEX IF EXISTS idx_notebooks_accessed_at;
+DROP INDEX IF EXISTS idx_organizations_accessed_at;
+
+ALTER TABLE notebooks DROP COLUMN IF EXISTS accessed_at;
+ALTER TABLE organizations DROP COLUMN IF EXISTS accessed_at;
+
+ALTER TABLE pricing_plan ADD COLUMN IF NOT EXISTS priority INTEGER NOT NULL DEFAULT 100;
+
+COMMENT ON COLUMN pricing_plan.priority IS 'Priority for routing traffic by importance (lower = higher priority)';
+
+UPDATE pricing_plan SET priority = 1 WHERE plan_name = 'ENTERPRISE';
+UPDATE pricing_plan SET priority = 100 WHERE plan_name = 'FREE';


### PR DESCRIPTION
> [!NOTE]
> Migration is not yet on prod, pending review

This PR:
- Fixes notebook RLS policies by splitting the generic "Org members and permitted users can access notebooks" policy into granular policies and checking the returned `role` to instead of only `hasAccess` (part of #5248)
- Removes unused `accessed_at` columns and indexes from notebooks and organizations tables (closes #5151)
- Adds priority column to `pricing_plan` table for traffic routing by importance (1 for ENTERPRISE, 100 for FREE tier) (closes #5150)
