### PR TITLE
chore: setup marimo build to use oso.xyz

### DIFF
--- a/.github/workflows/deploy-marimo-wasm.yml
+++ b/.github/workflows/deploy-marimo-wasm.yml
@@ -49,11 +49,11 @@ jobs:
         run: pixi run make fe
 
       - name: Build the dist directory for marimo
-        run: pixi run bash scripts/build_marimo_static_dist.sh marimo_dist marimo.opensource.observer
+        run: pixi run bash scripts/build_marimo_static_dist.sh marimo_dist marimo.oso.xyz
 
       - name: Create _redirects file for Cloudflare Pages
         run: |
-          echo "/notebook/api/* https://www.opensource.observer/api/v1/marimo/:splat 307" > marimo_dist/_redirects
+          echo "/notebook/api/* https://www.oso.xyz/api/v1/marimo/:splat 307" > marimo_dist/_redirects
 
       - name: Create _headers file for Cloudflare Pages for CORS
         run: |


### PR DESCRIPTION
NOTE: We need to simultaneously update plasmic to use `marimo.oso.xyz` for the notebook host. If we do not, the generative AI features will be broken until we do (due to the 307 redirect). Unfortunately, this is a limitation of cloudflare that we cannot overcome without our own deployment. 