### PR TITLE
chore: test change podinfo domain to oso.xyz

### DIFF
--- a/ops/k8s-apps/base/podinfo/podinfo.yaml
+++ b/ops/k8s-apps/base/podinfo/podinfo.yaml
@@ -39,7 +39,7 @@ spec:
       enabled: true
       className: ingress-internal-cloudflare
       hosts:
-        - host: test-podinfo.opensource.observer
+        - host: test-podinfo.oso.xyz
           paths:
             - path: /
               pathType: Prefix


### PR DESCRIPTION
This is not something critical so I'm just going to merge so we can test the change here.