### PR TITLE
chore: temporarily add test-podinfo to production

### DIFF
--- a/ops/k8s-apps/production/kustomization.yaml
+++ b/ops/k8s-apps/production/kustomization.yaml
@@ -14,3 +14,4 @@ resources:
   - ./mcp
   - ./agent
   - ./open-policy-agent
+  - ./podinfo

--- a/ops/k8s-apps/production/podinfo/kustomization.yaml
+++ b/ops/k8s-apps/production/podinfo/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base/podinfo
+namespace: production-podinfo


### PR DESCRIPTION
whoops hrm it seems the domains aren't automatically managed and I didn't actually have the podinfo deployed. merging again to test