### PR TITLE
chore: reference oso.xyz in non-www deployments

### DIFF
--- a/ops/k8s-apps/production/consumer-trino/custom-helm-values.yaml
+++ b/ops/k8s-apps/production/consumer-trino/custom-helm-values.yaml
@@ -31,7 +31,7 @@ spec:
       enabled: true
       className: ingress-internal-cloudflare
       hosts:
-        - host: trino.opensource.observer
+        - host: trino.oso.xyz
           paths:
             - path: /
               pathType: Prefix

--- a/ops/k8s-apps/production/dagster/custom-helm-values.yaml
+++ b/ops/k8s-apps/production/dagster/custom-helm-values.yaml
@@ -25,7 +25,7 @@ spec:
     configMap:
       secretPrefix: "gcp:secretmanager:production-dagster"
     alerts:
-      baseUrl: "https://dagster.opensource.observer"
+      baseUrl: "https://dagster.oso.xyz"
     cache:
       uri: "redis://redis.production-redis.svc.cluster.local:6379?ttl=3600"
     dagster:
@@ -35,9 +35,9 @@ spec:
         enabled: true
         ingressClassName: ingress-internal-cloudflare
         dagsterWebserver:
-          host: admin-dagster.opensource.observer
+          host: admin-dagster.oso.xyz
         readOnlyDagsterWebserver:
-          host: dagster.opensource.observer
+          host: dagster.oso.xyz
       dagsterDaemon:
         runRetries:
           enabled: true


### PR DESCRIPTION
I've already handled all of the manual things on the backend (took longer than expected cause I messed some silly things up) but this is a purely cosmetic change.

Closes: #5212 